### PR TITLE
#218 delete lost issues when we can't find them

### DIFF
--- a/judges/label-was-attached/label-was-attached.rb
+++ b/judges/label-was-attached/label-was-attached.rb
@@ -34,7 +34,9 @@ Fbe.iterate do
   repeats 20
   over do |repository, issue|
     Fbe.octo.issue_timeline(repository, issue).each do |te|
-      Fbe.fb.query("(eq issue #{issue})").delete! if te[:status] == '404'
+      if te[:status] == '404'
+        Fbe.fb.query("(and (eq where 'github') (eq repository #{repository}) (eq issue #{issue}))").delete!
+      end
       next unless te[:event] == 'labeled'
       badge = te[:label][:name]
       next unless %w[bug enhancement question].include?(badge)

--- a/judges/label-was-attached/label-was-attached.rb
+++ b/judges/label-was-attached/label-was-attached.rb
@@ -34,6 +34,7 @@ Fbe.iterate do
   repeats 20
   over do |repository, issue|
     Fbe.octo.issue_timeline(repository, issue).each do |te|
+      Fbe.fb.query("(eq issue #{issue})").delete! if te[:status] == '404'
       next unless te[:event] == 'labeled'
       badge = te[:label][:name]
       next unless %w[bug enhancement question].include?(badge)

--- a/test/judges/test-label-was-attached.rb
+++ b/test/judges/test-label-was-attached.rb
@@ -63,4 +63,98 @@ class TestLabelWasAttached < Minitest::Test
     assert_equal(42, f.who)
     assert_equal('bug', f.label)
   end
+
+  def test_removes_lost_issue
+    WebMock.disable_net_connect!
+    stub_request(:get, 'https://api.github.com/repos/foo/foo').to_return(
+      body: { id: 44, full_name: 'foo/foo' }.to_json, headers: {
+        'content-type': 'application/json'
+      }
+    )
+    stub_request(:get, 'https://api.github.com/repositories/44').to_return(
+      body: { id: 44, full_name: 'foo/foo' }.to_json, headers: {
+        'content-type': 'application/json'
+      }
+    )
+    stub_request(:get, 'https://api.github.com/repositories/44/issues/44/timeline?per_page=100').to_return(
+      body: [
+        {
+          message: 'Not Found',
+          documentation_url: 'https://docs.github.com/rest/issues/timeline#list-timeline-events-for-an-issue',
+          status: '404'
+        }
+      ].to_json,
+      headers: {
+        'content-type': 'application/json'
+      }
+    )
+    fb = Factbase.new
+    op = fb.insert
+    op.what = 'issue-was-opened'
+    op.repository = 44
+    op.issue = 44
+    load_it('label-was-attached', fb)
+    f = fb.query('(eq what "issue-was-opened")').each.to_a
+    assert_equal(0, f.count)
+    f = fb.query('(eq issue 44)').each.to_a
+    assert_equal(0, f.count)
+  end
+
+  def test_does_not_remove_labeled_issue
+    WebMock.disable_net_connect!
+    stub_request(:get, 'https://api.github.com/repos/foo/foo').to_return(
+      body: { id: 44, full_name: 'foo/foo' }.to_json, headers: {
+        'content-type': 'application/json'
+      }
+    )
+    stub_request(:get, 'https://api.github.com/repositories/44').to_return(
+      body: { id: 44, full_name: 'foo/foo' }.to_json, headers: {
+        'content-type': 'application/json'
+      }
+    )
+    stub_request(:get, 'https://api.github.com/repositories/44/issues/44/timeline?per_page=100').to_return(
+      body: [
+        {
+          message: 'Not Found',
+          documentation_url: 'https://docs.github.com/rest/issues/timeline#list-timeline-events-for-an-issue',
+          status: '404'
+        }
+      ].to_json,
+      headers: {
+        'content-type': 'application/json'
+      }
+    )
+    stub_request(:get, 'https://api.github.com/repositories/44/issues/45/timeline?per_page=100').to_return(
+      body: [
+        {
+          event: 'labeled',
+          label: { name: 'bug' },
+          actor: { id: 45 },
+          created_at: Time.now
+        }
+      ].to_json,
+      headers: {
+        'content-type': 'application/json'
+      }
+    )
+    fb = Factbase.new
+    op = fb.insert
+    op.what = 'issue-was-opened'
+    op.repository = 44
+    op.issue = 44
+
+    op = fb.insert
+    op.what = 'issue-was-opened'
+    op.repository = 44
+    op.issue = 45
+
+    load_it('label-was-attached', fb)
+    f = fb.query('(eq what "issue-was-opened")').each.to_a
+    assert_equal(1, f.count)
+    assert_equal(45, f.first.issue)
+    assert_equal('issue-was-opened', f.first.what)
+    assert_nil(f[1])
+    f = fb.query('(eq issue 44)').each.to_a
+    assert_equal(0, f.count)
+  end
 end

--- a/test/judges/test-label-was-attached.rb
+++ b/test/judges/test-label-was-attached.rb
@@ -142,12 +142,10 @@ class TestLabelWasAttached < Minitest::Test
     op.what = 'issue-was-opened'
     op.repository = 44
     op.issue = 44
-
     op = fb.insert
     op.what = 'issue-was-opened'
     op.repository = 44
     op.issue = 45
-
     load_it('label-was-attached', fb)
     f = fb.query('(eq what "issue-was-opened")').each.to_a
     assert_equal(1, f.count)

--- a/test/judges/test-label-was-attached.rb
+++ b/test/judges/test-label-was-attached.rb
@@ -93,6 +93,7 @@ class TestLabelWasAttached < Minitest::Test
     op.what = 'issue-was-opened'
     op.repository = 44
     op.issue = 44
+    op.where = 'github'
     load_it('label-was-attached', fb)
     f = fb.query('(eq what "issue-was-opened")').each.to_a
     assert_equal(0, f.count)
@@ -142,10 +143,12 @@ class TestLabelWasAttached < Minitest::Test
     op.what = 'issue-was-opened'
     op.repository = 44
     op.issue = 44
+    op.where = 'github'
     op = fb.insert
     op.what = 'issue-was-opened'
     op.repository = 44
     op.issue = 45
+    op.where = 'github'
     load_it('label-was-attached', fb)
     f = fb.query('(eq what "issue-was-opened")').each.to_a
     assert_equal(1, f.count)
@@ -154,5 +157,74 @@ class TestLabelWasAttached < Minitest::Test
     assert_nil(f[1])
     f = fb.query('(eq issue 44)').each.to_a
     assert_equal(0, f.count)
+  end
+
+  def test_does_not_remove_issue_from_other_repository
+    WebMock.disable_net_connect!
+    stub_request(:get, 'https://api.github.com/repos/foo/foo').to_return(
+      body: { id: 50, full_name: 'foo/foo' }.to_json, headers: {
+        'content-type': 'application/json'
+      }
+    )
+    stub_request(:get, 'https://api.github.com/repositories/50').to_return(
+      body: { id: 50, full_name: 'foo/foo' }.to_json, headers: {
+        'content-type': 'application/json'
+      }
+    )
+    stub_request(:get, 'https://api.github.com/repos/bar/bar').to_return(
+      body: { id: 55, full_name: 'bar/bar' }.to_json, headers: {
+        'content-type': 'application/json'
+      }
+    )
+    stub_request(:get, 'https://api.github.com/repositories/55').to_return(
+      body: { id: 55, full_name: 'bar/bar' }.to_json, headers: {
+        'content-type': 'application/json'
+      }
+    )
+    stub_request(:get, 'https://api.github.com/repositories/50/issues/46/timeline?per_page=100').to_return(
+      body: [
+        {
+          message: 'Not Found',
+          documentation_url: 'https://docs.github.com/rest/issues/timeline#list-timeline-events-for-an-issue',
+          status: '404'
+        }
+      ].to_json,
+      headers: {
+        'content-type': 'application/json'
+      }
+    )
+    stub_request(:get, 'https://api.github.com/repositories/55/issues/46/timeline?per_page=100').to_return(
+      body: [
+        {
+          event: 'labeled',
+          label: { name: 'bug' },
+          actor: { id: 46 },
+          created_at: Time.now
+        }
+      ].to_json,
+      headers: {
+        'content-type': 'application/json'
+      }
+    )
+    fb = Factbase.new
+    op = fb.insert
+    op.what = 'issue-was-opened'
+    op.repository = 50
+    op.issue = 46
+    op.where = 'github'
+    op = fb.insert
+    op.what = 'issue-was-opened'
+    op.repository = 55
+    op.issue = 46
+    op.where = 'github'
+    load_it('label-was-attached', fb)
+    f = fb.query('(and (eq what "issue-was-opened") (eq repository 50))').each.to_a
+    assert_equal(0, f.count)
+    f = fb.query('(and (eq issue 46) (eq repository 50))').each.to_a
+    assert_equal(0, f.count)
+    f = fb.query('(and (eq issue 46) (eq repository 55))').each.to_a
+    assert_equal(1, f.count)
+    assert_equal(46, f.first.issue)
+    assert_equal(55, f.first.repository)
   end
 end


### PR DESCRIPTION
## Changes

* Added removing the issue when the GitHub API returns a 404 status
* Added tests

Fixes #218