### PR TITLE
#350 NoMethodError: undefined method `[]` for nil

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,7 +65,7 @@ GEM
       net-http
     faraday-retry (2.2.1)
       faraday (~> 2.0)
-    fbe (0.0.69)
+    fbe (0.0.70)
       backtrace (> 0)
       decoor (> 0)
       factbase (> 0)

--- a/judges/github-events/github-events.rb
+++ b/judges/github-events/github-events.rb
@@ -94,7 +94,7 @@ Fbe.iterate do
         issue_comments.count { |comment| comment[:user][:id] != pr[:user][:id] },
       comments_appreciated: count_appreciated_comments(pr, issue_comments, code_comments),
       comments_resolved: Fbe.github_graph.resolved_conversations(
-        pr[:base][:repo][:owner][:login], pr[:base][:repo][:name], pr[:number]
+        pr[:base][:repo][:full_name].split('/').first, pr[:base][:repo][:name], pr[:number]
       ).count
     }
   end


### PR DESCRIPTION
A field `pr[:base][:repo][:owner]` is not stable, sometimes I don't see it, for example an event with id `42193949105` (https://api.github.com/repos/zerocracy/judges-action/events)
I suggest using `full_name`, splitting it by `/` and using the first value.

Removed `owner` from the test data: https://github.com/zerocracy/fbe/pull/102

fixes #350