### PR TITLE
#544: add eliminate-ghosts judge that delete `who` property when GitHub user is gone

### DIFF
--- a/judges/eliminate-ghosts/eliminate-ghosts.rb
+++ b/judges/eliminate-ghosts/eliminate-ghosts.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Zerocracy
+# SPDX-License-Identifier: MIT
+
+require 'fbe/octo'
+require 'fbe/conclude'
+require 'fbe/delete'
+
+Fbe.conclude do
+  quota_aware
+  on '(and (eq where "github") (exists who))'
+  consider do |f|
+    Fbe.octo.user(f.who)
+  rescue Octokit::NotFound
+    $loog.info("GitHub user ##{f.who} is not found")
+    Fbe.delete(f, 'who')
+  end
+end

--- a/judges/eliminate-ghosts/scan-users.yml
+++ b/judges/eliminate-ghosts/scan-users.yml
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Zerocracy
+# SPDX-License-Identifier: MIT
+---
+options:
+  testing: true
+input:
+  -
+    _id: 1
+    who: 526_301
+    where: github
+  -
+    _id: 2
+    where: github
+    who: 404_001
+  -
+    _id: 3
+    where: gitlab
+    who: 404_001
+  -
+    _id: 4
+    where: github
+    who: 526_302
+  -
+    _id: 5
+    where: github
+  -
+    _id: 6
+    where: github
+    who: 404_002
+expected:
+  - /fb[count(f)=6]
+  - /fb/f[_id=1 and where='github' and who=526301]
+  - /fb/f[_id/v[1]=7 and _id/v[2]=2 and where='github' and not(who)]
+  - /fb/f[_id=3 and where='gitlab' and who=404001]
+  - /fb/f[_id=4 and where='github' and who=526302]
+  - /fb/f[_id=5 and where='github' and not(who)]
+  - /fb/f[_id/v[1]=8 and _id/v[2]=6 and where='github' and not(who)]

--- a/test/judges/test-eliminate-ghosts.rb
+++ b/test/judges/test-eliminate-ghosts.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Zerocracy
+# SPDX-License-Identifier: MIT
+
+require 'factbase'
+require_relative '../test__helper'
+
+# Test.
+# Author:: Yegor Bugayenko (yegor256@gmail.com)
+# Copyright:: Copyright (c) 2025 Yegor Bugayenko
+# License:: MIT
+class TestEliminateGhosts < Jp::Test
+  def test_delete_who_if_user_not_found
+    WebMock.disable_net_connect!
+    stub_github('https://api.github.com/rate_limit', body: {})
+    stub_github(
+      'https://api.github.com/user/526301',
+      body: { login: 'yegor256', id: 526_301, type: 'User', site_admin: false }
+    )
+    stub_github(
+      'https://api.github.com/user/526302',
+      body: { login: 'yegor257', id: 526_302, type: 'User', site_admin: false }
+    )
+    stub_github('https://api.github.com/user/404001', body: '', status: 404)
+    stub_github('https://api.github.com/user/404002', body: '', status: 404)
+    fb = Factbase.new
+    fb.insert.then do |f|
+      f._id = 1
+      f.where = 'github'
+      f.who = 526_301
+    end
+    fb.insert.then do |f|
+      f._id = 2
+      f.where = 'github'
+      f.who = 404_001
+    end
+    fb.insert.then do |f|
+      f._id = 3
+      f.where = 'github'
+      f.who = 526_301
+    end
+    fb.insert.then do |f|
+      f._id = 4
+      f.where = 'github'
+      f.who = 404_002
+    end
+    fb.insert.then do |f|
+      f._id = 5
+      f.where = 'github'
+      f.who = 526_302
+    end
+    fb.insert.then do |f|
+      f._id = 6
+      f.where = 'gitlab'
+      f.who = 404_003
+    end
+    fb.insert.then do |f|
+      f._id = 7
+      f.where = 'gitlab'
+      f.who = 526_303
+    end
+    fb.insert.then do |f|
+      f._id = 8
+      f.where = 'github'
+    end
+    fb.insert.then do |f|
+      f._id = 9
+      f.where = 'gitlab'
+    end
+    load_it('eliminate-ghosts', fb)
+    assert_equal(5, fb.query('(exists who)').each.to_a.size)
+    assert_equal(4, fb.query('(not (exists who))').each.to_a.size)
+    assert_equal(3, fb.query('(and (eq where "github") (exists who))').each.to_a.size)
+    assert_equal(3, fb.query('(and (eq where "github") (not (exists who)))').each.to_a.size)
+    assert_equal(2, fb.query('(and (eq where "gitlab") (exists who))').each.to_a.size)
+    assert_equal(1, fb.query('(and (eq where "gitlab") (not (exists who)))').each.to_a.size)
+  end
+end


### PR DESCRIPTION
Test fail, because this https://github.com/zerocracy/fbe/pull/174 PR need merge before

Closes #544