### PR TITLE
#545: add erase-repository judge that delete `repository` property when GitHub repository is gone

### DIFF
--- a/judges/erase-repository/erase-repository.rb
+++ b/judges/erase-repository/erase-repository.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Zerocracy
+# SPDX-License-Identifier: MIT
+
+require 'fbe/octo'
+require 'fbe/conclude'
+require 'fbe/delete'
+
+Fbe.conclude do
+  quota_aware
+  on '(and (eq where "github") (exists repository))'
+  consider do |f|
+    Fbe.octo.repository(f.repository)
+  rescue Octokit::NotFound
+    $loog.info("GitHub repository ##{f.repository} is not found")
+    Fbe.delete(f, 'repository')
+  end
+end

--- a/judges/erase-repository/scan_repos.yml
+++ b/judges/erase-repository/scan_repos.yml
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Zerocracy
+# SPDX-License-Identifier: MIT
+---
+options:
+  testing: true
+input:
+  -
+    _id: 1
+    where: github
+    repository: 1234
+  -
+    _id: 2
+    where: github
+    repository: 404_123
+  -
+    _id: 3
+    where: gitlab
+    repository: 404_123
+  -
+    _id: 4
+    where: github
+    repository: 1235
+  -
+    _id: 5
+    where: github
+  -
+    _id: 6
+    where: github
+    repository: 404_124
+expected:
+  - /fb[count(f)=6]
+  - /fb/f[_id=1 and where='github' and repository=1234]
+  - /fb/f[_id/v[1]=7 and _id/v[2]=2 and where='github' and not(repository)]
+  - /fb/f[_id=3 and where='gitlab' and repository=404123]
+  - /fb/f[_id=4 and where='github' and repository=1235]
+  - /fb/f[_id=5 and where='github' and not(repository)]
+  - /fb/f[_id/v[1]=8 and _id/v[2]=6 and where='github' and not(repository)]

--- a/test/judges/test-erase-repository.rb
+++ b/test/judges/test-erase-repository.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Zerocracy
+# SPDX-License-Identifier: MIT
+
+require 'factbase'
+require_relative '../test__helper'
+
+# Test.
+# Author:: Yegor Bugayenko (yegor256@gmail.com)
+# Copyright:: Copyright (c) 2025 Yegor Bugayenko
+# License:: MIT
+class TestEraseRepository < Jp::Test
+  def test_erase_not_found_repository
+    WebMock.disable_net_connect!
+    stub_github('https://api.github.com/rate_limit', body: {})
+    stub_github(
+      'https://api.github.com/repositories/1234',
+      body: { id: 1234, name: 'foo', full_name: 'foo/foo' }
+    )
+    stub_github(
+      'https://api.github.com/repositories/1235',
+      body: { id: 1235, name: 'bar', full_name: 'foo/bar' }
+    )
+    stub_github('https://api.github.com/repositories/404123', body: '', status: 404)
+    stub_github('https://api.github.com/repositories/404124', body: '', status: 404)
+    fb = Factbase.new
+    fb.insert.then do |f|
+      f._id = 1
+      f.where = 'github'
+      f.repository = 1234
+    end
+    fb.insert.then do |f|
+      f._id = 2
+      f.where = 'github'
+      f.repository = 404_123
+    end
+    fb.insert.then do |f|
+      f._id = 3
+      f.where = 'github'
+      f.repository = 1235
+    end
+    fb.insert.then do |f|
+      f._id = 4
+      f.where = 'github'
+      f.repository = 404_124
+    end
+    fb.insert.then do |f|
+      f._id = 5
+      f.where = 'gitlab'
+      f.repository = 404_123
+    end
+    fb.insert.then do |f|
+      f._id = 6
+      f.where = 'github'
+    end
+    fb.insert.then do |f|
+      f._id = 7
+      f.where = 'gitlab'
+    end
+    load_it('erase-repository', fb)
+    assert_equal(3, fb.query('(exists repository)').each.to_a.size)
+    assert_equal(4, fb.query('(not (exists repository))').each.to_a.size)
+    assert_equal(2, fb.query('(and (eq where "github") (exists repository))').each.to_a.size)
+    assert_equal(3, fb.query('(and (eq where "github") (not (exists repository)))').each.to_a.size)
+    assert_equal(1, fb.query('(and (eq where "gitlab") (exists repository))').each.to_a.size)
+    assert_equal(1, fb.query('(and (eq where "gitlab") (not (exists repository)))').each.to_a.size)
+  end
+end


### PR DESCRIPTION
Test fail, because this https://github.com/zerocracy/fbe/pull/177 PR need merge before
Closes #545 