### PR TITLE
#601: handle 403 error in github-events

### DIFF
--- a/judges/github-events/github-events.rb
+++ b/judges/github-events/github-events.rb
@@ -302,6 +302,8 @@ Fbe.iterate do
     else
       skip_event(json)
     end
+  rescue Octokit::Forbidden
+    raise "@#{Fbe.octo.user[:login]} doesn't have access to the #{rname} repository, maybe it's private"
   end
 
   over do |repository, latest|

--- a/test/judges/test-github-events.rb
+++ b/test/judges/test-github-events.rb
@@ -1267,6 +1267,47 @@ class TestGithubEvents < Jp::Test
     assert_equal(2, f.failed_builds)
   end
 
+  def test_no_have_access_to_resource_by_integration
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github(
+      'https://api.github.com/repos/foo/foo',
+      body: { id: 42, name: 'foo', full_name: 'foo/foo', default_branch: 'master' }
+    )
+    stub_github(
+      'https://api.github.com/repositories/42',
+      body: { id: 42, name: 'foo', full_name: 'foo/foo', default_branch: 'master' }
+    )
+    stub_github(
+      'https://api.github.com/repositories/42/events?per_page=100',
+      body: [{
+        id: '11111',
+        type: 'PushEvent',
+        actor: { id: 43, login: 'yegor256' },
+        repo: { id: 42, name: 'foo/foo' },
+        payload: { push_id: 2412, ref: 'refs/heads/master', head: 'f5d59b035' },
+        created_at: '2025-05-05 19:03:16 UTC'
+      }]
+    )
+    stub_github(
+      'https://api.github.com/repos/foo/foo/commits/f5d59b035/pulls?per_page=100',
+      status: 403,
+      body: {
+        message: 'Resource not accessible by integration',
+        documentation_url: 'https://docs.github.com/rest/commits/commits#list-pull-requests-associated-with-a-commit',
+        status: '403'
+      }
+    )
+    stub_github('https://api.github.com/user', body: { id: 123, login: 'GithubUser' })
+    fb = Factbase.new
+    ex =
+      assert_raises(RuntimeError) do
+        load_it('github-events', fb)
+      end
+    assert_equal("@GithubUser doesn't have access to the foo/foo repository, maybe it's private", ex.message)
+    assert_equal(0, fb.size)
+  end
+
   private
 
   def stub_event(*json)


### PR DESCRIPTION
Closes #601 