### PR TITLE
#709: improve query and decrease repeats for `type-was-attached` judges

### DIFF
--- a/judges/type-was-attached/type-was-attached.rb
+++ b/judges/type-was-attached/type-was-attached.rb
@@ -22,9 +22,20 @@ events = %w[issue_type_added issue_type_changed]
 
 Fbe.iterate do
   as 'types-were-scanned'
-  by "(agg (and (eq repository $repository) (eq what 'issue-was-opened') (gt issue $before)) (min issue))"
+  by "(agg
+        (and
+          (eq repository $repository)
+          (eq what 'issue-was-opened')
+          (gt issue $before)
+          (empty
+            (and
+              (eq where 'github')
+              (eq repository $repository)
+              (eq issue $issue)
+              (eq what 'type-was-attached'))))
+        (min issue))"
   quota_aware
-  repeats 20
+  repeats 5
   over do |repository, issue|
     begin
       Fbe.octo.issue_timeline(repository, issue).each do |te|

--- a/test/judges/test-type-was-attached.rb
+++ b/test/judges/test-type-was-attached.rb
@@ -195,18 +195,6 @@ class TestTypeWasAttached < Jp::Test
     stub_github('https://api.github.com/repos/foo/foo', body: { id: 42, full_name: 'foo/foo' })
     stub_github('https://api.github.com/repositories/42', body: { id: 42, full_name: 'foo/foo' })
     stubs = []
-    stubs << stub_github(
-      'https://api.github.com/repositories/42/issues/42/timeline?per_page=100',
-      body: [
-        {
-          event: 'issue_type_added', node_id: 'ITAE_examplevq862Ga8lzwAAAAQZanzv',
-          actor: { id: 42 }, created_at: Time.now
-        }
-      ]
-    )
-    [43, 44, 45, 46].each do |issue|
-      stubs << stub_github("https://api.github.com/repositories/42/issues/#{issue}/timeline?per_page=100", body: [])
-    end
     fb = Factbase.new
     fb.with(what: 'issue-was-opened', repository: 42, issue: 42, where: 'github')
       .with(what: 'issue-was-opened', repository: 42, issue: 43, where: 'github')
@@ -216,34 +204,58 @@ class TestTypeWasAttached < Jp::Test
       .with(what: 'issue-was-opened', repository: 42, issue: 47, where: 'github')
       .with(what: 'issue-was-opened', repository: 42, issue: 48, where: 'github')
     Fbe.stub(:github_graph, Fbe::Graph::Fake.new) do
-      load_it('type-was-attached', fb)
-      assert(fb.one?(what: 'type-was-attached', repository: 42, issue: 42, where: 'github',
-                     type: 'Bug', who: 526_301))
-      assert(fb.one?(what: 'types-were-scanned', repository: 42, latest: 46, where: 'github'))
-      stubs.each { WebMock.remove_request_stub(_1) }.clear
-      [47, 48].each do |issue|
-        stubs << stub_github("https://api.github.com/repositories/42/issues/#{issue}/timeline?per_page=100", body: [])
+      begin
+        stubs << stub_github(
+          'https://api.github.com/repositories/42/issues/42/timeline?per_page=100',
+          body: [
+            {
+              event: 'issue_type_added', node_id: 'ITAE_examplevq862Ga8lzwAAAAQZanzv',
+              actor: { id: 42 }, created_at: Time.now
+            }
+          ]
+        )
+        [43, 44, 45, 46].each do |issue|
+          stubs << stub_github("https://api.github.com/repositories/42/issues/#{issue}/timeline?per_page=100",
+                               body: [])
+        end
+        load_it('type-was-attached', fb)
+        assert(fb.one?(what: 'type-was-attached', repository: 42, issue: 42, where: 'github',
+                       type: 'Bug', who: 526_301))
+        assert(fb.one?(what: 'types-were-scanned', repository: 42, latest: 46, where: 'github'))
+      ensure
+        stubs.each { WebMock.remove_request_stub(_1) }.clear
       end
-      load_it('type-was-attached', fb)
-      assert(fb.one?(what: 'types-were-scanned', repository: 42, latest: 0, where: 'github'))
-      stubs.each { WebMock.remove_request_stub(_1) }.clear
-      [43, 44, 45, 46].each do |issue|
-        stubs << stub_github("https://api.github.com/repositories/42/issues/#{issue}/timeline?per_page=100", body: [])
+      begin
+        [47, 48].each do |issue|
+          stubs << stub_github("https://api.github.com/repositories/42/issues/#{issue}/timeline?per_page=100",
+                               body: [])
+        end
+        load_it('type-was-attached', fb)
+        assert(fb.one?(what: 'types-were-scanned', repository: 42, latest: 0, where: 'github'))
+      ensure
+        stubs.each { WebMock.remove_request_stub(_1) }.clear
       end
-      stubs << stub_github(
-        'https://api.github.com/repositories/42/issues/47/timeline?per_page=100',
-        body: [
-          {
-            event: 'issue_type_added', node_id: 'ITAE_examplevq862Ga8lzwAAAAQZanzv',
-            actor: { id: 42 }, created_at: Time.now
-          }
-        ]
-      )
-      load_it('type-was-attached', fb)
-      assert(fb.one?(what: 'type-was-attached', repository: 42, issue: 47, where: 'github',
-                     type: 'Bug', who: 526_301))
-      assert(fb.one?(what: 'types-were-scanned', repository: 42, latest: 47, where: 'github'))
-      stubs.each { WebMock.remove_request_stub(_1) }.clear
+      begin
+        [43, 44, 45, 46].each do |issue|
+          stubs << stub_github("https://api.github.com/repositories/42/issues/#{issue}/timeline?per_page=100",
+                               body: [])
+        end
+        stubs << stub_github(
+          'https://api.github.com/repositories/42/issues/47/timeline?per_page=100',
+          body: [
+            {
+              event: 'issue_type_added', node_id: 'ITAE_examplevq862Ga8lzwAAAAQZanzv',
+              actor: { id: 42 }, created_at: Time.now
+            }
+          ]
+        )
+        load_it('type-was-attached', fb)
+        assert(fb.one?(what: 'type-was-attached', repository: 42, issue: 47, where: 'github',
+                       type: 'Bug', who: 526_301))
+        assert(fb.one?(what: 'types-were-scanned', repository: 42, latest: 47, where: 'github'))
+      ensure
+        stubs.each { WebMock.remove_request_stub(_1) }.clear
+      end
     end
   end
 end


### PR DESCRIPTION
Closes #709 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved issue scanning to avoid processing issues that already have a 'type-was-attached' record.
	- Reduced the number of issues processed per run for better efficiency.
- **Tests**
	- Added new tests to verify correct behavior when scanning multiple issues and handling repeated runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->