### PR TITLE
#711: improve query and decrease repeats for `label-was-attached` judges

### DIFF
--- a/judges/label-was-attached/label-was-attached.rb
+++ b/judges/label-was-attached/label-was-attached.rb
@@ -23,9 +23,20 @@ badges = %w[bug enhancement question]
 
 Fbe.iterate do
   as 'labels-were-scanned'
-  by "(agg (and (eq repository $repository) (eq what 'issue-was-opened') (gt issue $before)) (min issue))"
+  by "(agg
+        (and
+          (eq repository $repository)
+          (eq what 'issue-was-opened')
+          (gt issue $before)
+          (empty
+            (and
+              (eq where 'github')
+              (eq repository $repository)
+              (eq issue $issue)
+              (eq what 'label-was-attached'))))
+        (min issue))"
   quota_aware
-  repeats 20
+  repeats 5
   over do |repository, issue|
     begin
       Fbe.octo.issue_timeline(repository, issue).each do |te|


### PR DESCRIPTION
Closes #711 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved detection of newly attached labels by ensuring issues already processed are excluded from repeated checks.
  - Reduced the number of repeated checks for label attachment from 20 to 5, optimizing performance.

- **Tests**
  - Added comprehensive tests to verify correct detection and recording of label attachment events under various scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->