### PR TITLE
#646: add test for check overwrite github user login name

### DIFF
--- a/test/judges/test-who-has-name.rb
+++ b/test/judges/test-who-has-name.rb
@@ -11,6 +11,8 @@ require_relative '../test__helper'
 # Copyright:: Copyright (c) 2024 Yegor Bugayenko
 # License:: MIT
 class TestWhoHasName < Jp::Test
+  using SmartFactbase
+
   def test_finds_name
     WebMock.disable_net_connect!
     stub_request(:get, 'https://api.github.com/rate_limit').to_return(
@@ -46,5 +48,43 @@ class TestWhoHasName < Jp::Test
     f.where = 'github'
     load_it('who-has-name', fb)
     assert_equal(1, fb.query('(exists who)').each.to_a.size)
+  end
+
+  def test_overwrite_name_if_user_login_changed
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/user/12', body: { login: 'user22', id: 12, type: 'User' })
+    stub_github('https://api.github.com/user/13', body: { login: 'user3', id: 13, type: 'User' })
+    stub_github(
+      'https://api.github.com/user/14',
+      status: 404,
+      body: { message: 'Not Found', documentation_url: 'https://docs.github.com/rest', status: '404' }
+    )
+    fb = Factbase.new
+    fb.with(
+      _id: 1, what: 'who-has-name', where: 'github', who: 10, name: 'user0',
+      when: Time.parse('2025-06-19 20:00:00 UTC'), stale: 'user_old'
+    ).with(
+      _id: 2, what: 'who-has-name', where: 'github', who: 11, name: 'user1',
+      when: Time.parse('2025-06-22 20:00:00 UTC')
+    ).with(
+      _id: 3, what: 'who-has-name', where: 'github', who: 12, name: 'user2',
+      when: Time.parse('2025-06-18 20:00:00 UTC')
+    ).with(
+      _id: 4, what: 'who-has-name', where: 'github', who: 13, name: 'user3',
+      when: Time.parse('2025-06-16 20:00:00 UTC')
+    ).with(
+      _id: 5, what: 'who-has-name', where: 'github', who: 14, name: 'user4',
+      when: Time.parse('2025-06-15 20:00:00 UTC')
+    )
+    Time.stub(:now, Time.parse('2025-06-23 22:00:00 UTC')) do
+      load_it('who-has-name', fb)
+      assert_equal(5, fb.all.size)
+      assert(fb.one?(what: 'who-has-name', where: 'github', who: 10, name: 'user0', stale: 'user_old'))
+      assert(fb.one?(what: 'who-has-name', where: 'github', who: 11, name: 'user1'))
+      assert(fb.one?(what: 'who-has-name', where: 'github', who: 12, name: 'user22'))
+      assert(fb.one?(what: 'who-has-name', where: 'github', who: 13, name: 'user3'))
+      assert(fb.one?(what: 'who-has-name', where: 'github', who: 14, name: 'user4'))
+    end
   end
 end


### PR DESCRIPTION
Closes #646 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added a new test to verify that user names are updated correctly when a GitHub login changes, while handling missing users and preserving existing data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->