### PR TITLE
#852: fix fetch comments info for PullRequestEvent

### DIFF
--- a/judges/github-events/github-events.rb
+++ b/judges/github-events/github-events.rb
@@ -143,8 +143,8 @@ Fbe.iterate do
       when 'closed'
         fact.what = "pull-was-#{pl[:merged_at].nil? ? 'closed' : 'merged'}"
         fact.hoc = pl[:additions] + pl[:deletions]
-        Jp.fill_fact_by_hash(fact, Jp.comments_info(pl))
-        Jp.fill_fact_by_hash(fact, Jp.fetch_workflows(pl))
+        Jp.fill_fact_by_hash(fact, Jp.comments_info(pl, repo: rname))
+        Jp.fill_fact_by_hash(fact, Jp.fetch_workflows(pl, repo: rname))
         fact.branch = pl[:head][:ref]
         fact.details =
           "The pull request #{Fbe.issue(fact)} " \

--- a/lib/pull_request.rb
+++ b/lib/pull_request.rb
@@ -55,10 +55,10 @@ end
 #
 # @param [Sawyer::Resource] pr The pull request
 # @return [Hash] count of success/failure builds
-def Jp.fetch_workflows(pr)
+def Jp.fetch_workflows(pr, repo: nil)
   succeeded_builds = 0
   failed_builds = 0
-  repo = pr.dig(:base, :repo, :full_name)
+  repo = pr.dig(:base, :repo, :full_name) if repo.nil?
   return {} if repo.nil?
   Fbe.octo.check_runs_for_ref(repo, pr.dig(:head, :sha))[:check_runs].each do |run|
     next unless run[:app][:slug] == 'github-actions'


### PR DESCRIPTION
Test fail, because this https://github.com/zerocracy/fbe/pull/260 PR need merge before
Closes #852


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of pull request events when repository names have changed, ensuring accurate processing even if the event payload contains outdated repository names.

* **Tests**
  * Added a new test to verify correct processing of pull request events with old repository names, including proper handling of GitHub API redirects.
  * Updated existing tests to use new repository identifiers and names for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->