### PR TITLE
#853: make handle 404 issue events for `issue-was-assigned` judge

### DIFF
--- a/judges/issue-was-assigned/issue-was-assigned.rb
+++ b/judges/issue-was-assigned/issue-was-assigned.rb
@@ -44,6 +44,9 @@ Fbe.iterate do
       nn.details = "#{Fbe.issue(nn)} was assigned to #{Fbe.who(nn)} by #{Fbe.who(nn, :assigner)} ."
     end
     issue
+  rescue Octokit::NotFound => e
+    $loog.info("Not found issue events for issue ##{issue} in #{repo}: #{e.message}")
+    issue
   end
 end
 

--- a/test/judges/test-issue-was-assigned.rb
+++ b/test/judges/test-issue-was-assigned.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Zerocracy
+# SPDX-License-Identifier: MIT
+
+require 'factbase'
+require_relative '../test__helper'
+
+# Test.
+# Author:: Yegor Bugayenko (yegor256@gmail.com)
+# Copyright:: Copyright (c) 2024 Yegor Bugayenko
+# License:: MIT
+class TestIssueWasAssigned < Jp::Test
+  using SmartFactbase
+
+  def test_not_found_issue_events
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repos/foo/foo', body: { id: 42, name: 'foo', full_name: 'foo/foo' })
+    stub_github('https://api.github.com/repositories/42', body: { id: 42, full_name: 'foo/foo' })
+    stub_github('https://api.github.com/repos/foo/foo/issues/44/events?per_page=100', body: [])
+    stub_github(
+      'https://api.github.com/repos/foo/foo/issues/45/events?per_page=100',
+      status: 404,
+      body: {
+        message: 'Not Found',
+        documentation_url: 'https://docs.github.com/rest/issues/events#list-issue-events',
+        status: '404'
+      }
+    )
+    fb = Factbase.new
+    fb.with(_id: 1, what: 'issue-was-opened', repository: 42, issue: 44, where: 'github')
+      .with(_id: 2, what: 'issue-was-opened', repository: 42, issue: 45, where: 'github')
+    load_it('issue-was-assigned', fb)
+    assert_equal(3, fb.all.size)
+    assert_equal(2, fb.picks(what: 'issue-was-opened').size)
+    assert_equal(0, fb.picks(what: 'issue-was-assigned').size)
+    assert(fb.one?(what: 'assignees-were-scanned', repository: 42, where: 'github'))
+  end
+end


### PR DESCRIPTION
Closes #853 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when retrieving issue events from GitHub, ensuring the process continues smoothly even if some events are not found.

* **Tests**
  * Added tests to verify correct handling of missing or empty issue events from GitHub, ensuring robust and reliable behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->