### PR TITLE
#935: fix calculate average backlog size

### DIFF
--- a/judges/quality-of-service/average_backlog_size.rb
+++ b/judges/quality-of-service/average_backlog_size.rb
@@ -19,7 +19,8 @@ def average_backlog_size(fact)
       return {} if Fbe.octo.off_quota?
       count = 0
       Fbe.octo.search_issues(
-        "repo:#{repo} type:issue created:#{fact.since.utc.to_date.iso8601[0..9]}..#{date.iso8601[0..9]}"
+        "repo:#{repo} type:issue created:*..#{date.iso8601[0..9]} (closed:>=#{date.iso8601[0..9]} OR state:open)",
+        advanced_search: true
       )[:items].each do |item|
         count += 1 if item[:closed_at].nil? || item[:closed_at].utc.to_date >= date
       end


### PR DESCRIPTION
Closes #935 

Following from [this article](https://github.blog/changelog/2025-03-06-github-issues-projects-api-support-for-issues-advanced-search-and-more/) and [this doc page](https://docs.github.com/en/rest/search/search?apiVersion=2022-11-28#search-issues-and-pull-requests) after September 4, 2025 we can remove `advanced_search` parameter in [`Fbe.octo.search_issues`](https://github.com/Yegorov/judges-action/blob/66a1a2a7403b4db5292509349ac2003d7c82a90d/judges/quality-of-service/average_backlog_size.rb#L23)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Improved accuracy of backlog size calculation by using advanced search criteria, ensuring more consistent Quality of Service metrics across reporting dates.
- Tests
  - Updated tests to align with the new search semantics.
  - Added a comprehensive test validating average backlog size to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->