### PR TITLE
#658: set "repositories" to current repo by default

### DIFF
--- a/entries/defaults-to-current-repo.sh
+++ b/entries/defaults-to-current-repo.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Zerocracy
+# SPDX-License-Identifier: MIT
+
+set -ex -o pipefail
+
+SELF=$1
+
+name=$(LC_ALL=C tr -dc '[:lower:]' </dev/urandom | head -c 16 || true)
+
+BUNDLE_GEMFILE="${SELF}/Gemfile"
+export BUNDLE_GEMFILE
+bundle exec judges eval "${name}.fb" "\$fb.insert" > /dev/null
+
+env "GITHUB_WORKSPACE=$(pwd)" \
+  "GITHUB_REPOSITORY=zerocracy/judges-action" \
+  "GITHUB_REPOSITORY_OWNER=zerocracy" \
+  "GITHUB_SERVER_URL=https://github.com" \
+  "GITHUB_RUN_ID=12345" \
+  'INPUT_DRY-RUN=true' \
+  'INPUT_GITHUB-TOKEN=test-token' \
+  "INPUT_FACTBASE=${name}.fb" \
+  'INPUT_CYCLES=1' \
+  'INPUT_VERBOSE=true' \
+  'INPUT_TOKEN=something' \
+  "${SELF}/entry.sh" 2>&1 | tee log.txt
+
+test -e "${name}.fb"
+
+grep "The 'repositories' plugin parameter is not set, using current repository: zerocracy/judges-action" 'log.txt'
+grep " --option=repositories=zerocracy/judges-action" 'log.txt'

--- a/entry.sh
+++ b/entry.sh
@@ -94,7 +94,8 @@ while IFS= read -r o; do
     options+=("--option=${k}=${v}");
 done <<< "${INPUT_OPTIONS}"
 if [ -z "${INPUT_REPOSITORIES}" ]; then
-    echo "The 'repositories' plugin parameter is not set"
+    echo "The 'repositories' plugin parameter is not set, using current repository: ${GITHUB_REPOSITORY}"
+    options+=("--option=repositories=${GITHUB_REPOSITORY}");
 else
     options+=("--option=repositories=${INPUT_REPOSITORIES}");
 fi


### PR DESCRIPTION
Closes https://github.com/zerocracy/judges-action/issues/658.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Automatically defaults to the current repository when the repositories input is not provided.
  - Adds clearer logs indicating when the repositories parameter is missing and which repository is used by default.

- Tests
  - Introduces a test harness that simulates a GitHub Actions environment to verify defaulting behavior and corresponding logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->