### PR TITLE
#957: add setup-test-env helper for `entries/` tests.

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -17,3 +17,5 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: ludeeus/action-shellcheck@master
+        with:
+          check_together: 'yes'

--- a/entries/fails-fast.sh
+++ b/entries/fails-fast.sh
@@ -2,15 +2,11 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024-2025 Zerocracy
 # SPDX-License-Identifier: MIT
 
-set -ex -o pipefail
-
 SELF=$1
 
-name=$(LC_ALL=C tr -dc '[:lower:]' </dev/urandom | head -c 16 || true)
-
-BUNDLE_GEMFILE="${SELF}/Gemfile"
-export BUNDLE_GEMFILE
-bundle exec judges eval "${name}.fb" "\$fb.insert" > /dev/null
+# shellcheck source=../makes/setup-test-env.sh
+source "${SELF}/makes/setup-test-env.sh"
+name=$(setup_test_env "${SELF}")
 
 env "GITHUB_WORKSPACE=$(pwd)" \
   'INPUT_DRY-RUN=false' \

--- a/entries/fails-without-dry-run.sh
+++ b/entries/fails-without-dry-run.sh
@@ -2,15 +2,11 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024-2025 Zerocracy
 # SPDX-License-Identifier: MIT
 
-set -ex -o pipefail
-
 SELF=$1
 
-name=$(LC_ALL=C tr -dc '[:lower:]' </dev/urandom | head -c 16 || true)
-
-BUNDLE_GEMFILE="${SELF}/Gemfile"
-export BUNDLE_GEMFILE
-bundle exec judges eval "${name}.fb" "\$fb.insert" > /dev/null
+# shellcheck source=../makes/setup-test-env.sh
+source "${SELF}/makes/setup-test-env.sh"
+name=$(setup_test_env "${SELF}")
 
 (env "GITHUB_WORKSPACE=$(pwd)" \
   "INPUT_FACTBASE=${name}.fb" \

--- a/entries/fails-without-github-token.sh
+++ b/entries/fails-without-github-token.sh
@@ -2,15 +2,11 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024-2025 Zerocracy
 # SPDX-License-Identifier: MIT
 
-set -ex -o pipefail
-
 SELF=$1
 
-name=$(LC_ALL=C tr -dc '[:lower:]' </dev/urandom | head -c 16 || true)
-
-BUNDLE_GEMFILE="${SELF}/Gemfile"
-export BUNDLE_GEMFILE
-bundle exec judges eval "${name}.fb" "\$fb.insert" > /dev/null
+# shellcheck source=../makes/setup-test-env.sh
+source "${SELF}/makes/setup-test-env.sh"
+name=$(setup_test_env "${SELF}")
 
 (env "GITHUB_WORKSPACE=$(pwd)" \
   'INPUT_DRY-RUN=true' \

--- a/entries/passes-github-token.sh
+++ b/entries/passes-github-token.sh
@@ -2,15 +2,11 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024-2025 Zerocracy
 # SPDX-License-Identifier: MIT
 
-set -ex -o pipefail
-
 SELF=$1
 
-name=$(LC_ALL=C tr -dc '[:lower:]' </dev/urandom | head -c 16 || true)
-
-BUNDLE_GEMFILE="${SELF}/Gemfile"
-export BUNDLE_GEMFILE
-bundle exec judges eval "${name}.fb" "\$fb.insert" > /dev/null
+# shellcheck source=../makes/setup-test-env.sh
+source "${SELF}/makes/setup-test-env.sh"
+name=$(setup_test_env "${SELF}")
 
 env "GITHUB_WORKSPACE=$(pwd)" \
   "INPUT_FACTBASE=${name}.fb" \

--- a/entries/passes-options.sh
+++ b/entries/passes-options.sh
@@ -2,15 +2,11 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024-2025 Zerocracy
 # SPDX-License-Identifier: MIT
 
-set -ex -o pipefail
-
 SELF=$1
 
-name=$(LC_ALL=C tr -dc '[:lower:]' </dev/urandom | head -c 16 || true)
-
-BUNDLE_GEMFILE="${SELF}/Gemfile"
-export BUNDLE_GEMFILE
-bundle exec judges eval "${name}.fb" "\$fb.insert" > /dev/null
+# shellcheck source=../makes/setup-test-env.sh
+source "${SELF}/makes/setup-test-env.sh"
+name=$(setup_test_env "${SELF}")
 
 opts=$(cat << 'EOF'
   foo42=bar

--- a/entries/scans-one-repo.sh
+++ b/entries/scans-one-repo.sh
@@ -2,15 +2,11 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024-2025 Zerocracy
 # SPDX-License-Identifier: MIT
 
-set -ex -o pipefail
-
 SELF=$1
 
-name=$(LC_ALL=C tr -dc '[:lower:]' </dev/urandom | head -c 16 || true)
-
-BUNDLE_GEMFILE="${SELF}/Gemfile"
-export BUNDLE_GEMFILE
-bundle exec judges eval "${name}.fb" "\$fb.insert" > /dev/null
+# shellcheck source=../makes/setup-test-env.sh
+source "${SELF}/makes/setup-test-env.sh"
+name=$(setup_test_env "${SELF}")
 
 env "GITHUB_WORKSPACE=$(pwd)" \
   'INPUT_DRY-RUN=true' \

--- a/entries/with-sqlite-cache.sh
+++ b/entries/with-sqlite-cache.sh
@@ -2,15 +2,11 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024-2025 Zerocracy
 # SPDX-License-Identifier: MIT
 
-set -ex -o pipefail
-
 SELF=$1
 
-name=$(LC_ALL=C tr -dc '[:lower:]' </dev/urandom | head -c 16 || true)
-
-BUNDLE_GEMFILE="${SELF}/Gemfile"
-export BUNDLE_GEMFILE
-bundle exec judges eval "${name}.fb" "\$fb.insert" > /dev/null
+# shellcheck source=../makes/setup-test-env.sh
+source "${SELF}/makes/setup-test-env.sh"
+name=$(setup_test_env "${SELF}")
 
 env "GITHUB_WORKSPACE=$(pwd)" \
   'INPUT_DRY-RUN=false' \

--- a/makes/setup-test-env.sh
+++ b/makes/setup-test-env.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Zerocracy
+# SPDX-License-Identifier: MIT
+
+# Sets up common test environment and returns a random factbase name
+# Usage: name=$(setup_test_env "$1")
+setup_test_env() {
+  set -ex -o pipefail
+
+  local SELF=$1
+
+  local name
+  name=$(LC_ALL=C tr -dc '[:lower:]' </dev/urandom | head -c 16 || true)
+
+  BUNDLE_GEMFILE="${SELF}/Gemfile"
+  export BUNDLE_GEMFILE
+  bundle exec judges eval "${name}.fb" "\$fb.insert" > /dev/null
+
+  echo "${name}"
+}


### PR DESCRIPTION
Blocked by https://github.com/zerocracy/judges-action/pull/955 to also add new test-helper for `entries/defaults-to-current-repo.sh`.

Closes https://github.com/zerocracy/judges-action/issues/957.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Tests
  - Centralized test environment setup for all scenarios.
  - Switched to a unified entry point with standardized INPUT_* parameters.
  - Added comprehensive log capture and assertions for expected messages.
  - Verified outputs including generated data files and optional cache files.
  - Expanded option coverage in tests to validate multiple parameters.

- Refactor
  - Replaced legacy, ad hoc test invocations with a consistent, environment-driven workflow.
  - Simplified initialization across tests for reliability and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->