### PR TITLE
#956: add parallel test execution for 'entries tests'

### DIFF
--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -21,5 +21,5 @@ jobs:
           ruby-version: 3.3
           bundler-cache: true
       - run: gem install rubocop:1.63.5
-      - run: sudo apt install parallel
+      - run: sudo apt-get update && sudo apt-get install -y parallel
       - run: make

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -21,4 +21,5 @@ jobs:
           ruby-version: 3.3
           bundler-cache: true
       - run: gem install rubocop:1.63.5
+      - run: sudo apt install parallel
       - run: make

--- a/README.md
+++ b/README.md
@@ -115,7 +115,8 @@ check its [own repository](https://github.com/zerocracy/pages-action).
 
 In order to test this action, just run (provided, you have
 [Ruby](https://www.ruby-lang.org/en/) 3+, [Bundler](https://bundler.io/),
-and [GNU make](https://www.gnu.org/software/make/) installed):
+[GNU make](https://www.gnu.org/software/make/), and
+[GNU parallel](https://www.gnu.org/software/parallel/) installed):
 
 ```bash
 bundle update

--- a/makes/entries.sh
+++ b/makes/entries.sh
@@ -7,8 +7,10 @@ set -e -o pipefail
 base=$(realpath "$(dirname "$0")/..")
 
 mkdir -p "${base}/target/entries-logs"
-while IFS= read -r sh; do
-    fqn=${base}/entries/${sh}
+
+run_test() {
+    local sh="$1"
+    local fqn="${base}/entries/${sh}"
     if [ ! -x "${fqn}" ]; then
         echo "The file is not executable: ${fqn}"
         exit 1
@@ -16,9 +18,16 @@ while IFS= read -r sh; do
     mkdir -p "${base}/target/${sh}"
     if /bin/bash -c "cd \"target/${sh}\" && exec \"${fqn}\" \"${base}\" > \"${base}/target/entries-logs/${sh}.txt\" 2>&1"; then
         echo "👍🏻 ${sh} passed"
+        return 0
     else
         cat "${base}/target/entries-logs/${sh}.txt"
         echo "❌ ${sh} failed"
-        exit 1
+        return 1
     fi
-done < <( find "${base}/entries" -name '*.sh' -exec basename {} \; )
+}
+
+export -f run_test
+export base
+
+find "${base}/entries" -name '*.sh' -exec basename {} \; | \
+    parallel --halt now,fail=1 --line-buffer run_test


### PR DESCRIPTION
This PR speed up test execution 2.5 times (from `30sec` to `12sec`) and eliminating further slowness by running tests in parallel.

Closes https://github.com/zerocracy/judges-action/issues/956.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Test suite now runs in parallel for faster execution, with per-test directories/logs and clear pass/fail output; the run halts on first failure.
* **CI**
  * GitHub Actions workflow installs GNU parallel before running the test job.
* **Documentation**
  * README prerequisites updated to list GNU parallel alongside GNU make.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->