### PR TITLE
#957: add setup-test-env helper for 'entries/' tests.

### DIFF
--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,2 @@
+external-sources=true
+source-path=SCRIPTDIR

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -27,6 +27,7 @@ path = [
     "Gemfile.lock",
     "README.md",
     "renovate.json",
+    ".shellcheckrc",
 ]
 precedence = "override"
 SPDX-FileCopyrightText = "Copyright (c) 2025 Yegor Bugayenko"

--- a/entries/defaults-to-current-repo.sh
+++ b/entries/defaults-to-current-repo.sh
@@ -2,15 +2,10 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024-2025 Zerocracy
 # SPDX-License-Identifier: MIT
 
-set -ex -o pipefail
-
 SELF=$1
 
-name=$(LC_ALL=C tr -dc '[:lower:]' </dev/urandom | head -c 16 || true)
-
-BUNDLE_GEMFILE="${SELF}/Gemfile"
-export BUNDLE_GEMFILE
-bundle exec judges eval "${name}.fb" "\$fb.insert" > /dev/null
+source "${SELF}/makes/setup-test-env.sh"
+setup_test_env "${SELF}" name
 
 env "GITHUB_WORKSPACE=$(pwd)" \
   "GITHUB_REPOSITORY=zerocracy/judges-action" \

--- a/entries/fails-fast.sh
+++ b/entries/fails-fast.sh
@@ -2,15 +2,10 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024-2025 Zerocracy
 # SPDX-License-Identifier: MIT
 
-set -ex -o pipefail
-
 SELF=$1
 
-name=$(LC_ALL=C tr -dc '[:lower:]' </dev/urandom | head -c 16 || true)
-
-BUNDLE_GEMFILE="${SELF}/Gemfile"
-export BUNDLE_GEMFILE
-bundle exec judges eval "${name}.fb" "\$fb.insert" > /dev/null
+source "${SELF}/makes/setup-test-env.sh"
+setup_test_env "${SELF}" name
 
 env "GITHUB_WORKSPACE=$(pwd)" \
   'INPUT_DRY-RUN=false' \

--- a/entries/fails-without-dry-run.sh
+++ b/entries/fails-without-dry-run.sh
@@ -2,15 +2,10 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024-2025 Zerocracy
 # SPDX-License-Identifier: MIT
 
-set -ex -o pipefail
-
 SELF=$1
 
-name=$(LC_ALL=C tr -dc '[:lower:]' </dev/urandom | head -c 16 || true)
-
-BUNDLE_GEMFILE="${SELF}/Gemfile"
-export BUNDLE_GEMFILE
-bundle exec judges eval "${name}.fb" "\$fb.insert" > /dev/null
+source "${SELF}/makes/setup-test-env.sh"
+setup_test_env "${SELF}" name
 
 (env "GITHUB_WORKSPACE=$(pwd)" \
   "INPUT_FACTBASE=${name}.fb" \

--- a/entries/fails-without-github-token.sh
+++ b/entries/fails-without-github-token.sh
@@ -2,15 +2,10 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024-2025 Zerocracy
 # SPDX-License-Identifier: MIT
 
-set -ex -o pipefail
-
 SELF=$1
 
-name=$(LC_ALL=C tr -dc '[:lower:]' </dev/urandom | head -c 16 || true)
-
-BUNDLE_GEMFILE="${SELF}/Gemfile"
-export BUNDLE_GEMFILE
-bundle exec judges eval "${name}.fb" "\$fb.insert" > /dev/null
+source "${SELF}/makes/setup-test-env.sh"
+setup_test_env "${SELF}" name
 
 (env "GITHUB_WORKSPACE=$(pwd)" \
   'INPUT_DRY-RUN=true' \

--- a/entries/passes-github-token.sh
+++ b/entries/passes-github-token.sh
@@ -2,15 +2,10 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024-2025 Zerocracy
 # SPDX-License-Identifier: MIT
 
-set -ex -o pipefail
-
 SELF=$1
 
-name=$(LC_ALL=C tr -dc '[:lower:]' </dev/urandom | head -c 16 || true)
-
-BUNDLE_GEMFILE="${SELF}/Gemfile"
-export BUNDLE_GEMFILE
-bundle exec judges eval "${name}.fb" "\$fb.insert" > /dev/null
+source "${SELF}/makes/setup-test-env.sh"
+setup_test_env "${SELF}" name
 
 env "GITHUB_WORKSPACE=$(pwd)" \
   "INPUT_FACTBASE=${name}.fb" \

--- a/entries/passes-job-id.sh
+++ b/entries/passes-job-id.sh
@@ -2,15 +2,10 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024-2025 Zerocracy
 # SPDX-License-Identifier: MIT
 
-set -ex -o pipefail
-
 SELF=$1
 
-name=$(LC_ALL=C tr -dc '[:lower:]' </dev/urandom | head -c 16 || true)
-
-BUNDLE_GEMFILE="${SELF}/Gemfile"
-export BUNDLE_GEMFILE
-bundle exec judges eval "${name}.fb" "\$fb.insert" > /dev/null
+source "${SELF}/makes/setup-test-env.sh"
+setup_test_env "${SELF}" name
 
 env "GITHUB_WORKSPACE=$(pwd)" \
   "GITHUB_RUN_ID=99999" \

--- a/entries/passes-options.sh
+++ b/entries/passes-options.sh
@@ -2,15 +2,10 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024-2025 Zerocracy
 # SPDX-License-Identifier: MIT
 
-set -ex -o pipefail
-
 SELF=$1
 
-name=$(LC_ALL=C tr -dc '[:lower:]' </dev/urandom | head -c 16 || true)
-
-BUNDLE_GEMFILE="${SELF}/Gemfile"
-export BUNDLE_GEMFILE
-bundle exec judges eval "${name}.fb" "\$fb.insert" > /dev/null
+source "${SELF}/makes/setup-test-env.sh"
+setup_test_env "${SELF}" name
 
 opts=$(cat << 'EOF'
   foo42=bar

--- a/entries/scans-one-repo.sh
+++ b/entries/scans-one-repo.sh
@@ -2,15 +2,10 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024-2025 Zerocracy
 # SPDX-License-Identifier: MIT
 
-set -ex -o pipefail
-
 SELF=$1
 
-name=$(LC_ALL=C tr -dc '[:lower:]' </dev/urandom | head -c 16 || true)
-
-BUNDLE_GEMFILE="${SELF}/Gemfile"
-export BUNDLE_GEMFILE
-bundle exec judges eval "${name}.fb" "\$fb.insert" > /dev/null
+source "${SELF}/makes/setup-test-env.sh"
+setup_test_env "${SELF}" name
 
 env "GITHUB_WORKSPACE=$(pwd)" \
   'INPUT_DRY-RUN=true' \

--- a/entries/with-sqlite-cache.sh
+++ b/entries/with-sqlite-cache.sh
@@ -2,15 +2,10 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024-2025 Zerocracy
 # SPDX-License-Identifier: MIT
 
-set -ex -o pipefail
-
 SELF=$1
 
-name=$(LC_ALL=C tr -dc '[:lower:]' </dev/urandom | head -c 16 || true)
-
-BUNDLE_GEMFILE="${SELF}/Gemfile"
-export BUNDLE_GEMFILE
-bundle exec judges eval "${name}.fb" "\$fb.insert" > /dev/null
+source "${SELF}/makes/setup-test-env.sh"
+setup_test_env "${SELF}" name
 
 env "GITHUB_WORKSPACE=$(pwd)" \
   'INPUT_DRY-RUN=false' \

--- a/makes/setup-test-env.sh
+++ b/makes/setup-test-env.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Zerocracy
+# SPDX-License-Identifier: MIT
+
+# Sets up common test environment and returns a random factbase name
+# Usage (preferred): setup_test_env "$1" name
+# Backward-compat: still echoes the name to stdout
+setup_test_env() {
+  set -ex -o pipefail
+
+  local SELF=$1
+  local name=$2
+
+  if [ -z "${SELF:-}" ] || [ -z "${name:-}" ]; then
+    echo "missing required arguments: SELF='${SELF:-}' name='${name:-}'" >&2
+    return 1
+  fi
+
+  if [ ! -f "${SELF}/Gemfile" ]; then
+    echo "Gemfile not found at ${SELF}/Gemfile" >&2
+    return 1
+  fi
+
+  declare -g "${name}=$(LC_ALL=C tr -dc '[:lower:]' </dev/urandom | head -c 16 || true)"
+
+  BUNDLE_GEMFILE="${SELF}/Gemfile"
+  export BUNDLE_GEMFILE
+  bundle exec judges eval "${!name}.fb" "\$fb.insert" > /dev/null
+}


### PR DESCRIPTION
Closes https://github.com/zerocracy/judges-action/issues/957.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Tests
  - Consolidated test setup into a shared helper and standardized env-driven execution across multiple test scenarios.
  - Switched tests to run via a unified entrypoint, improved environment provisioning, and enabled richer log capture and post-run verifications.
- Chores
  - Relaxed ShellCheck rules to allow external sources and standardized source paths.
  - Added the ShellCheck config file to reuse/annotation tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->