### PR TITLE
added an example of pure bash coverage

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "calc_coverage/pure_bash_coverage"]
+	path = calc_coverage/pure_bash_coverage
+	url = git@github.com:ostvld/pure_bash_coverage.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "calc_coverage/pure_bash_coverage"]
 	path = calc_coverage/pure_bash_coverage
-	url = git@github.com:ostvld/pure_bash_coverage.git
+	url = https://github.com/ostvld/pure_bash_coverage.git 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Zerocracy
+# SPDX-License-Identifier: MIT
 [submodule "calc_coverage/pure_bash_coverage"]
 	path = calc_coverage/pure_bash_coverage
 	url = https://github.com/ostvld/pure_bash_coverage.git 

--- a/calc_coverage/run_cov.sh
+++ b/calc_coverage/run_cov.sh
@@ -2,4 +2,6 @@
 set -euo pipefail
 export INPUT_VERBOSE="true"
 echo "${INPUT_VERBOSE}"
-./pure_bash_coverage/generate_coverage_report.sh ../entry.sh
+DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+${DIR}/pure_bash_coverage/generate_coverage_report.sh ${DIR}/../entry.sh
+

--- a/calc_coverage/run_cov.sh
+++ b/calc_coverage/run_cov.sh
@@ -1,2 +1,5 @@
-# !bin/bash
-./pure_bash_coverage/generate_coverage_report.sh ../entry.sh
+#!/usr/bin/env bash
+set -euo pipefail
+export INPUT_VERBOSE="true"
+echo "${INPUT_VERBOSE}"
+../pure_bash_coverage/generate_coverage_report.sh ../entry.sh

--- a/calc_coverage/run_cov.sh
+++ b/calc_coverage/run_cov.sh
@@ -5,5 +5,5 @@ set -euo pipefail
 export INPUT_VERBOSE="true"
 echo "${INPUT_VERBOSE}"
 DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
-${DIR}/pure_bash_coverage/generate_coverage_report.sh ${DIR}/../entry.sh
+"${DIR}/pure_bash_coverage/generate_coverage_report.sh" "${DIR}/../entry.sh"
 

--- a/calc_coverage/run_cov.sh
+++ b/calc_coverage/run_cov.sh
@@ -1,0 +1,2 @@
+# !bin/bash
+./pure_bash_coverage/generate_coverage_report.sh ../entry.sh

--- a/calc_coverage/run_cov.sh
+++ b/calc_coverage/run_cov.sh
@@ -2,4 +2,4 @@
 set -euo pipefail
 export INPUT_VERBOSE="true"
 echo "${INPUT_VERBOSE}"
-../pure_bash_coverage/generate_coverage_report.sh ../entry.sh
+./pure_bash_coverage/generate_coverage_report.sh ../entry.sh

--- a/calc_coverage/run_cov.sh
+++ b/calc_coverage/run_cov.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Zerocracy
+# SPDX-License-Identifier: MIT
 set -euo pipefail
 export INPUT_VERBOSE="true"
 echo "${INPUT_VERBOSE}"

--- a/entry.sh
+++ b/entry.sh
@@ -1,8 +1,14 @@
 #!/bin/bash
 # SPDX-FileCopyrightText: Copyright (c) 2024-2025 Zerocracy
 # SPDX-License-Identifier: MIT
-export PS4='+${BASH_SOURCE}:${LINENO}:' 
-set -ex -o pipefail
+
+export PS4='+${BASH_SOURCE}:${LINENO}:'
+echo "INPUT_VERBOSE: ${INPUT_VERBOSE}"
+set -e -o pipefail
+
+if [ "${INPUT_VERBOSE}" == 'true' ]; then
+    set -x
+fi
 
 start=$(date +%s)
 

--- a/entry.sh
+++ b/entry.sh
@@ -26,10 +26,6 @@ if [ "${latest}" != "${VERSION}" ]; then
     echo "!!! It is strongly advised to upgrade."
 fi
 
-if [ "${INPUT_VERBOSE}" == 'true' ]; then
-    set -x
-fi
-
 if [ -z "$1" ]; then
     SELF=$(dirname "$0")
 else

--- a/entry.sh
+++ b/entry.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 # SPDX-FileCopyrightText: Copyright (c) 2024-2025 Zerocracy
 # SPDX-License-Identifier: MIT
-
-set -e -o pipefail
+export PS4='+${BASH_SOURCE}:${LINENO}:' 
+set -ex -o pipefail
 
 start=$(date +%s)
 


### PR DESCRIPTION
[added an example of pure bash coverage](https://github.com/zerocracy/judges-action/pull/945)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a built-in coverage report runner and a wrapper to invoke the bundled coverage generator.
  - Introduced a verbose/debug mode that prints annotated debug traces (file:line) when enabled.

- **Chores**
  - Added and updated an external coverage tool as a Git submodule; initialize/update submodules after checkout to fetch it.

- **Notes**
  - No behavioral changes unless verbose mode is enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->