### PR TITLE
#1017: fix `github-events` judge for saving latest event id

### DIFF
--- a/judges/github-events/github-events.rb
+++ b/judges/github-events/github-events.rb
@@ -335,8 +335,8 @@ Fbe.iterate do
       $loog.info("Finished scanning #{rname} correctly in #{rstart.ago}, next time will scan until ##{first}")
       first
     else
-      $loog.info("Scanning of #{rname} wasn't completed in #{rstart.ago}, next time will try again, from ##{latest}")
-      latest
+      $loog.info("Finished scanning #{rname} correctly in #{rstart.ago}, next time will scan until ##{id}")
+      id
     end
   end
 end

--- a/test/judges/test-github-events.rb
+++ b/test/judges/test-github-events.rb
@@ -1932,7 +1932,7 @@ class TestGithubEvents < Jp::Test
     assert_equal(0, fb.all.size)
   end
 
-  def test_not_completed_scanning
+  def test_finished_scanning_with_saving_latest_event_id
     WebMock.disable_net_connect!
     rate_limit_up
     stub_github(
@@ -1958,7 +1958,7 @@ class TestGithubEvents < Jp::Test
     fb.with(_id: 1, _time: Time.now.utc, where: 'github', repository: 42, events_were_scanned: 12, what: 'iterate')
     load_it('github-events', fb)
     assert_equal(2, fb.all.size)
-    assert(fb.one?(what: 'iterate', where: 'github', repository: 42, events_were_scanned: 12))
+    assert(fb.one?(what: 'iterate', where: 'github', repository: 42, events_were_scanned: 15))
     assert(fb.one?(what: 'tag-was-created', where: 'github', event_type: 'CreateEvent', repository: 42, event_id: 15))
   end
 


### PR DESCRIPTION
Closes #1017 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrects end-of-scan handling for repository events, advancing the scan boundary to the latest observed event. This reduces duplicate processing, improves progress between runs, and provides clearer completion logs for easier monitoring and troubleshooting.

* **Tests**
  * Updated tests to align with the new scan completion behavior, validating that the latest scanned event ID is saved and reported accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->