### PR TITLE
#1034: implement `find-latest-issue` judge

### DIFF
--- a/judges/find-latest-issue/find-issue.yml
+++ b/judges/find-latest-issue/find-issue.yml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Zerocracy
+# SPDX-License-Identifier: MIT
+---
+options:
+  testing: true
+  repositories: foo/bazz
+input: []
+expected:
+  - /fb[count(f)=2]
+  - /fb/f[what='pull-was-opened' and repository='810' and issue='144' and where='github']
+  - /fb/f[what='iterate' and repository='810' and latest_issue_was_found='144' and where='github']

--- a/judges/find-latest-issue/find-latest-issue.rb
+++ b/judges/find-latest-issue/find-latest-issue.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Zerocracy
+# SPDX-License-Identifier: MIT
+
+require 'fbe/fb'
+require 'fbe/iterate'
+require 'fbe/issue'
+require 'fbe/octo'
+require 'fbe/who'
+
+Fbe.iterate do
+  as 'latest_issue_was_found'
+  by '(plus 0 $before)'
+  over do |repository, latest|
+    repo = Fbe.octo.repo_name_by_id(repository)
+    json =
+      Fbe.octo.with_disable_auto_paginate do |octo|
+        octo.list_issues(repo, state: :all, sort: :created, direction: :desc, page: 1, per_page: 1).first
+      end
+    next latest if json.nil?
+    Fbe.fb.txn do |fbt|
+      f =
+        Fbe.if_absent(fb: fbt) do |ff|
+          ff.issue = json[:number]
+          ff.what = "#{json[:pull_request].nil? ? 'issue' : 'pull'}-was-opened"
+          ff.repository = repository
+          ff.where = 'github'
+        end
+      next if f.nil?
+      f.when = json[:created_at]
+      f.who = json.dig(:user, :id)
+      f.details = "The issue #{Fbe.issue(f)} has been opened by #{Fbe.who(f)}."
+      $loog.info("The opening of #{Fbe.issue(f)} by #{Fbe.who(f)} was found")
+    end
+    json[:number]
+  end
+end
+
+Fbe.octo.print_trace!

--- a/judges/find-latest-issue/find-latest-issue.rb
+++ b/judges/find-latest-issue/find-latest-issue.rb
@@ -30,7 +30,7 @@ Fbe.iterate do
       next if f.nil?
       f.when = json[:created_at]
       f.who = json.dig(:user, :id)
-      f.details = "The issue #{Fbe.issue(f)} has been opened by #{Fbe.who(f)}."
+      f.details = "The issue #{Fbe.issue(f)} is the first we found, opened by #{Fbe.who(f)}."
       $loog.info("The opening of #{Fbe.issue(f)} by #{Fbe.who(f)} was found")
     end
     json[:number]

--- a/test/judges/test-find-latest-issue.rb
+++ b/test/judges/test-find-latest-issue.rb
@@ -39,7 +39,7 @@ class TestFindLatestIssue < Jp::Test
       fb.one?(
         what: 'issue-was-opened', issue: 547, repository: 42, where: 'github',
         who: 44, when: Time.parse('2025-09-14 20:03:16 UTC'),
-        details: 'The issue foo/foo#547 has been opened by @user.'
+        details: 'The issue foo/foo#547 is the first we found, opened by @user.'
       )
     )
     assert(fb.one?(what: 'iterate', latest_issue_was_found: 547, repository: 42, where: 'github'))
@@ -75,7 +75,7 @@ class TestFindLatestIssue < Jp::Test
       fb.one?(
         what: 'pull-was-opened', issue: 548, repository: 42, where: 'github',
         who: 44, when: Time.parse('2025-09-14 20:03:16 UTC'),
-        details: 'The issue foo/foo#548 has been opened by @user.'
+        details: 'The issue foo/foo#548 is the first we found, opened by @user.'
       )
     )
     assert(fb.one?(what: 'iterate', latest_issue_was_found: 548, repository: 42, where: 'github'))

--- a/test/judges/test-find-latest-issue.rb
+++ b/test/judges/test-find-latest-issue.rb
@@ -1,0 +1,140 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Zerocracy
+# SPDX-License-Identifier: MIT
+
+require 'factbase'
+require_relative '../test__helper'
+
+# Test.
+class TestFindLatestIssue < Jp::Test
+  using SmartFactbase
+
+  def test_find_latest_issue
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github(
+      'https://api.github.com/repos/foo/foo', body: { id: 42, name: 'foo', full_name: 'foo/foo' }
+    )
+    stub_github(
+      'https://api.github.com/repositories/42', body: { id: 42, name: 'foo', full_name: 'foo/foo' }
+    )
+    stub_github(
+      'https://api.github.com/repos/foo/foo/issues?direction=desc&page=1&per_page=1&sort=created&state=all',
+      body: [
+        {
+          id: 123,
+          number: 547,
+          title: 'Some title',
+          user: { id: 44, login: 'user' },
+          created_at: '2025-09-14 20:03:16 UTC'
+        }
+      ]
+    )
+    stub_github('https://api.github.com/user/44', body: { id: 44, login: 'user' })
+    fb = Factbase.new
+    load_it('find-latest-issue', fb)
+    assert_equal(2, fb.all.size)
+    assert(
+      fb.one?(
+        what: 'issue-was-opened', issue: 547, repository: 42, where: 'github',
+        who: 44, when: Time.parse('2025-09-14 20:03:16 UTC'),
+        details: 'The issue foo/foo#547 has been opened by @user.'
+      )
+    )
+    assert(fb.one?(what: 'iterate', latest_issue_was_found: 547, repository: 42, where: 'github'))
+  end
+
+  def test_find_latest_pull
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github(
+      'https://api.github.com/repos/foo/foo', body: { id: 42, name: 'foo', full_name: 'foo/foo' }
+    )
+    stub_github(
+      'https://api.github.com/repositories/42', body: { id: 42, name: 'foo', full_name: 'foo/foo' }
+    )
+    stub_github(
+      'https://api.github.com/repos/foo/foo/issues?direction=desc&page=1&per_page=1&sort=created&state=all',
+      body: [
+        {
+          id: 123,
+          number: 548,
+          title: 'Some title',
+          user: { id: 44, login: 'user' },
+          pull_request: { merged_at: nil },
+          created_at: '2025-09-14 20:03:16 UTC'
+        }
+      ]
+    )
+    stub_github('https://api.github.com/user/44', body: { id: 44, login: 'user' })
+    fb = Factbase.new
+    load_it('find-latest-issue', fb)
+    assert_equal(2, fb.all.size)
+    assert(
+      fb.one?(
+        what: 'pull-was-opened', issue: 548, repository: 42, where: 'github',
+        who: 44, when: Time.parse('2025-09-14 20:03:16 UTC'),
+        details: 'The issue foo/foo#548 has been opened by @user.'
+      )
+    )
+    assert(fb.one?(what: 'iterate', latest_issue_was_found: 548, repository: 42, where: 'github'))
+  end
+
+  def test_not_found_latest_issue
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github(
+      'https://api.github.com/repos/foo/foo', body: { id: 42, name: 'foo', full_name: 'foo/foo' }
+    )
+    stub_github(
+      'https://api.github.com/repositories/42', body: { id: 42, name: 'foo', full_name: 'foo/foo' }
+    )
+    stub_github(
+      'https://api.github.com/repos/foo/foo/issues?direction=desc&page=1&per_page=1&sort=created&state=all',
+      body: []
+    )
+    fb = Factbase.new
+    load_it('find-latest-issue', fb)
+    assert_equal(0, fb.all.size)
+  end
+
+  def test_if_latest_issue_exist
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github(
+      'https://api.github.com/repos/foo/foo', body: { id: 42, name: 'foo', full_name: 'foo/foo' }
+    )
+    stub_github(
+      'https://api.github.com/repositories/42', body: { id: 42, name: 'foo', full_name: 'foo/foo' }
+    )
+    stub_github(
+      'https://api.github.com/repos/foo/foo/issues?direction=desc&page=1&per_page=1&sort=created&state=all',
+      body: [
+        {
+          id: 123,
+          number: 547,
+          title: 'Some title',
+          user: { id: 44, login: 'user' },
+          created_at: '2025-09-14 20:03:16 UTC'
+        }
+      ]
+    )
+    fb = Factbase.new
+    fb.with(
+      _id: 1, what: 'issue-was-opened', issue: 547, repository: 42, where: 'github',
+      who: 44, when: Time.parse('2025-09-14 20:03:16 UTC'),
+      details: 'The issue foo/foo#547 has been opened by @user.'
+    )
+    load_it('find-latest-issue', fb)
+    assert_equal(2, fb.all.size)
+    assert(
+      fb.one?(
+        _id: 1, what: 'issue-was-opened', issue: 547, repository: 42, where: 'github',
+        who: 44, when: Time.parse('2025-09-14 20:03:16 UTC'),
+        details: 'The issue foo/foo#547 has been opened by @user.'
+      )
+    )
+    assert(fb.one?(what: 'iterate', latest_issue_was_found: 547, repository: 42, where: 'github'))
+  end
+end


### PR DESCRIPTION
Test fail, because this https://github.com/zerocracy/fbe/pull/309 PR need merge before.
Closes #1034 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds automation to discover the latest GitHub issue or pull request for a repository, record an event with who/when/repository and a human-readable detail, and avoid duplicate entries; preserves previous value when none found.

* **Tests**
  * Adds a test suite covering issue, pull request, empty-results, and pre-existing-record scenarios.
  * Adds a YAML test configuration to validate expected outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->