### PR TITLE
#1054: fix `Time can't be coerced into Integer` error in `Jp.incremate`

### DIFF
--- a/lib/incremate.rb
+++ b/lib/incremate.rb
@@ -47,21 +47,21 @@ def Jp.incremate(fact, dir, prefix, avoid_duplicate: false, epoch: $epoch || Tim
       $loog.info("No GitHub quota left, it is time to stop at #{n}")
       break
     end
-    if $options.lifetime && Time.now - epoch > $options.lifetime * 0.9
+    if $options.lifetime && Time.now.to_f - epoch.to_f > $options.lifetime * 0.9
       $loog.info("We are doing this for too long, time to stop at #{n}")
       break
     end
-    if $options.timeout && Time.now - kickoff > $options.timeout * 0.9
-      $loog.info("We are doing this for #{t.ago}, let's stop at #{n}")
+    if $options.timeout && Time.now.to_f - kickoff.to_f > $options.timeout * 0.9
+      $loog.info("We are doing this for #{kickoff.ago}, let's stop at #{n}")
       break
     end
     $loog.info(
       [
         "Starting to evaluate #{n}",
-        (", #{($options.lifetime - Time.now + epoch).seconds} of lifetime left" if $options.lifetime),
-        (", #{($options.timeout - Time.now + kickoff).seconds} of timeout left" if $options.timeout),
+        (", #{($options.lifetime - Time.now.to_f + epoch.to_f).seconds} of lifetime left" if $options.lifetime),
+        (", #{($options.timeout - Time.now.to_f + kickoff.to_f).seconds} of timeout left" if $options.timeout),
         '...'
-      ].zip.join(' ')
+      ].compact.join
     )
     require_relative rb
     elapsed($loog, level: Logger::INFO) do

--- a/test/lib/test_incremate.rb
+++ b/test/lib/test_incremate.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Zerocracy
+# SPDX-License-Identifier: MIT
+
+require 'judges/options'
+require 'factbase'
+require_relative '../../lib/incremate'
+require_relative '../test__helper'
+
+# Test.
+class TestIncremate < Minitest::Test
+  def test_incremate
+    WebMock.disable_net_connect!
+    stub_request(:get, 'https://api.github.com/rate_limit').to_return(
+      body: { rate: { remaining: 1000, limit: 1000 } }.to_json,
+      headers: { 'X-RateLimit-Remaining' => '999' }
+    )
+    $global = {}
+    $local = {}
+    $loog = Loog::VERBOSE # Loog::NULL
+    $options = Judges::Options.new({ 'lifetime' => 100, 'timeout' => 100 })
+    Dir.mktmpdir do |dir|
+      File.write(File.expand_path('some_property.rb', dir), <<~RUBY)
+        def some_property(_f)
+          { some_property: 42 }
+        end
+      RUBY
+      time = Time.now - 60
+      fb = Factbase.new
+      f = fb.insert
+      Jp.incremate(f, dir, 'some', avoid_duplicate: true, epoch: time, kickoff: time)
+      assert_equal(42, f.some_property)
+    end
+    $global = nil
+    $local = nil
+    $loog = nil
+    $options = nil
+  end
+end


### PR DESCRIPTION
Closes #1054 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Switches internal time handling to float-based seconds for more consistent lifetime/timeout behavior and remaining-time messages.

* **Style**
  * Cleans up log message formatting to remove extraneous spacing and improve readability.

* **Tests**
  * Adds Minitest coverage for the incremate flow, including environment setup and time-based scenarios to validate insertion behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->