### PR TITLE
#1061: fix skip exists facts by given uniques in `github-events` judge

### DIFF
--- a/judges/github-events/github-events.rb
+++ b/judges/github-events/github-events.rb
@@ -270,8 +270,18 @@ Fbe.iterate do
     raise "#{who} doesn't have access to the #{rname} repository, maybe it's private"
   end
 
-  def self.stays_twice?(what, fields)
-    Fbe.fb.query("(and (eq what '#{what}') (unique #{fields.join(' ')}))").each.to_a.size > 1
+  def self.stays_twice?(fb, fact, what, fields)
+    eqs =
+      fields.map { [_1, fact[_1]&.first] }.reject { _1.last.nil? }.map do |prop, value|
+        val =
+          case value
+          when String then "'#{value}'"
+          when Time then value.utc.iso8601
+          else value
+          end
+        "(eq #{prop} #{val})"
+      end
+    fb.query("(and (eq what '#{what}') #{eqs.join(' ')})").each.to_a.size > 1
   end
 
   over do |repository, latest|
@@ -314,7 +324,7 @@ Fbe.iterate do
           next
         end
         fill_up_event(f, json)
-        uniques.each { |w, ff| throw :rollback if stays_twice?(w, ff) }
+        uniques.each { |w, ff| throw :rollback if stays_twice?(fbt, f, w, ff) }
         if f['issue']
           throw :rollback unless Fbe.fb.query(
             "(and


### PR DESCRIPTION
Closes #1061 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Improved duplicate detection to prevent re-processing identical GitHub events.
  - Enhanced uniqueness matching with normalized values (including UTC ISO8601 times) to reduce false duplicates.
  - Rollback and event-handling now rely on the improved duplicate checks for more reliable processing.

- Tests
  - Added tests verifying events are skipped when an equivalent entry already exists.
  - Confirmed idempotent processing across different uniqueness scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->