### PR TITLE
Add by_owner flag to track if push events are from repository owner

### DIFF
--- a/judges/github-events/github-events.rb
+++ b/judges/github-events/github-events.rb
@@ -114,8 +114,10 @@ Fbe.iterate do
       fact.push_id = json[:payload][:push_id]
       fact.ref = json[:payload][:ref]
       fact.commit = json[:payload][:head]
-      fact.default_branch = Fbe.octo.repository(rname)[:default_branch]
+      repo = Fbe.octo.repository(rname)
+      fact.default_branch = repo[:default_branch]
       fact.to_master = fact.default_branch == fact.ref.split('/')[2] ? 1 : 0
+      fact.by_owner = repo.dig(:owner, :id) == fact.who ? 1 : 0
       if fact.to_master.zero?
         $loog.debug("Push #{fact.commit} has been made to non-default branch '#{fact.default_branch}', ignoring it")
         skip_event(json)


### PR DESCRIPTION
Closes #685 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Push events now indicate whether the repository owner performed the push, enabling clearer attribution in analytics and reporting.

- Bug Fixes
  - Improved default branch detection for push events, ensuring more accurate event processing across repositories.

- Tests
  - Added test coverage for owner vs non-owner push scenarios to validate accurate attribution and default branch handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->