### PR TITLE
#1066: implement `find-earliest-issue` judge

### DIFF
--- a/judges/find-earliest-issue/find-earliest-issue.rb
+++ b/judges/find-earliest-issue/find-earliest-issue.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Zerocracy
+# SPDX-License-Identifier: MIT
+
+require 'fbe/fb'
+require 'fbe/iterate'
+require 'fbe/issue'
+require 'fbe/octo'
+require 'fbe/who'
+
+Fbe.iterate do
+  as 'earliest_issue_was_found'
+  by '(plus 0 $before)'
+  over do |repository, latest|
+    next latest if latest.positive?
+    repo = Fbe.octo.repo_name_by_id(repository)
+    json =
+      Fbe.octo.with_disable_auto_paginate do |octo|
+        octo.list_issues(repo, state: :all, sort: :created, direction: :asc, page: 1, per_page: 1).first
+      end
+    next latest if json.nil?
+    Fbe.fb.txn do |fbt|
+      f =
+        Fbe.if_absent(fb: fbt) do |ff|
+          ff.issue = json[:number]
+          ff.what = "#{json[:pull_request].nil? ? 'issue' : 'pull'}-was-opened"
+          ff.repository = repository
+          ff.where = 'github'
+        end
+      next if f.nil?
+      f.when = json[:created_at]
+      f.who = json.dig(:user, :id)
+      f.details = "The issue #{Fbe.issue(f)} is the earliest we found, opened by #{Fbe.who(f)}."
+      $loog.info("The opening of #{Fbe.issue(f)} by #{Fbe.who(f)} was found")
+    end
+    json[:number]
+  end
+end
+
+Fbe.octo.print_trace!

--- a/judges/find-earliest-issue/find-issue.yml
+++ b/judges/find-earliest-issue/find-issue.yml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Zerocracy
+# SPDX-License-Identifier: MIT
+---
+options:
+  testing: true
+  repositories: foo/bazz
+input: []
+expected:
+  - /fb[count(f)=2]
+  - /fb/f[what='pull-was-opened' and repository='810' and issue='144' and where='github']
+  - /fb/f[what='iterate' and repository='810' and earliest_issue_was_found='144' and where='github']

--- a/test/judges/test-find-earliest-issue.rb
+++ b/test/judges/test-find-earliest-issue.rb
@@ -1,0 +1,131 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Zerocracy
+# SPDX-License-Identifier: MIT
+
+require 'factbase'
+require_relative '../test__helper'
+
+# Test.
+class TestFindEarliestIssue < Jp::Test
+  using SmartFactbase
+
+  def test_find_earliest_issue
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repos/foo/foo', body: { id: 42, name: 'foo', full_name: 'foo/foo' })
+    stub_github('https://api.github.com/repositories/42', body: { id: 42, name: 'foo', full_name: 'foo/foo' })
+    stub_github(
+      'https://api.github.com/repos/foo/foo/issues?direction=asc&page=1&per_page=1&sort=created&state=all',
+      body: [
+        {
+          id: 123, number: 3, title: 'Some title', user: { id: 44, login: 'user' },
+          created_at: '2025-09-27 05:03:16 UTC'
+        }
+      ]
+    )
+    stub_github('https://api.github.com/user/44', body: { id: 44, login: 'user' })
+    fb = Factbase.new
+    load_it('find-earliest-issue', fb)
+    assert_equal(2, fb.all.size)
+    assert(
+      fb.one?(
+        what: 'issue-was-opened', issue: 3, repository: 42, where: 'github',
+        who: 44, when: Time.parse('2025-09-27 05:03:16 UTC'),
+        details: 'The issue foo/foo#3 is the earliest we found, opened by @user.'
+      )
+    )
+    assert(fb.one?(what: 'iterate', earliest_issue_was_found: 3, repository: 42, where: 'github'))
+  end
+
+  def test_find_earliest_pull
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repos/foo/foo', body: { id: 42, name: 'foo', full_name: 'foo/foo' })
+    stub_github('https://api.github.com/repositories/42', body: { id: 42, name: 'foo', full_name: 'foo/foo' })
+    stub_github(
+      'https://api.github.com/repos/foo/foo/issues?direction=asc&page=1&per_page=1&sort=created&state=all',
+      body: [
+        {
+          id: 123, number: 3, title: 'Some title', user: { id: 44, login: 'user' },
+          pull_request: { merged_at: nil }, created_at: '2025-09-27 06:03:16 UTC'
+        }
+      ]
+    )
+    stub_github('https://api.github.com/user/44', body: { id: 44, login: 'user' })
+    fb = Factbase.new
+    load_it('find-earliest-issue', fb)
+    assert_equal(2, fb.all.size)
+    assert(
+      fb.one?(
+        what: 'pull-was-opened', issue: 3, repository: 42, where: 'github',
+        who: 44, when: Time.parse('2025-09-27 06:03:16 UTC'),
+        details: 'The issue foo/foo#3 is the earliest we found, opened by @user.'
+      )
+    )
+    assert(fb.one?(what: 'iterate', earliest_issue_was_found: 3, repository: 42, where: 'github'))
+  end
+
+  def test_not_found_earliest_issue
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repos/foo/foo', body: { id: 42, name: 'foo', full_name: 'foo/foo' })
+    stub_github('https://api.github.com/repositories/42', body: { id: 42, name: 'foo', full_name: 'foo/foo' })
+    stub_github(
+      'https://api.github.com/repos/foo/foo/issues?direction=asc&page=1&per_page=1&sort=created&state=all',
+      body: []
+    )
+    fb = Factbase.new
+    load_it('find-earliest-issue', fb)
+    assert_equal(0, fb.all.size)
+  end
+
+  def test_if_earliest_issue_exist
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repos/foo/foo', body: { id: 42, name: 'foo', full_name: 'foo/foo' })
+    stub_github('https://api.github.com/repositories/42', body: { id: 42, name: 'foo', full_name: 'foo/foo' })
+    stub_github(
+      'https://api.github.com/repos/foo/foo/issues?direction=asc&page=1&per_page=1&sort=created&state=all',
+      body: [
+        {
+          id: 123, number: 3, title: 'Some title', user: { id: 44, login: 'user' },
+          created_at: '2025-09-27 07:03:16 UTC'
+        }
+      ]
+    )
+    fb = Factbase.new
+    fb.with(
+      _id: 1, what: 'issue-was-opened', issue: 3, repository: 42, where: 'github',
+      who: 44, when: Time.parse('2025-09-27 07:03:16 UTC'),
+      details: 'The issue foo/foo#3 has been opened by @user.'
+    )
+    load_it('find-earliest-issue', fb)
+    assert_equal(2, fb.all.size)
+    assert(
+      fb.one?(
+        _id: 1, what: 'issue-was-opened', issue: 3, repository: 42, where: 'github',
+        who: 44, when: Time.parse('2025-09-27 07:03:16 UTC'),
+        details: 'The issue foo/foo#3 has been opened by @user.'
+      )
+    )
+    assert(fb.one?(what: 'iterate', earliest_issue_was_found: 3, repository: 42, where: 'github'))
+  end
+
+  def test_if_find_earliest_issue_already_found
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repos/foo/foo', body: { id: 42, name: 'foo', full_name: 'foo/foo' })
+    fb = Factbase.new
+    fb.with(
+      _id: 1, what: 'issue-was-opened', issue: 3, repository: 42, where: 'github',
+      who: 44, when: Time.parse('2025-09-27 07:03:16 UTC'),
+      details: 'The issue foo/foo#3 has been opened by @user.'
+    ).with(
+      _id: 2, what: 'iterate', where: 'github', repository: 42, earliest_issue_was_found: 3
+    )
+    load_it('find-earliest-issue', fb)
+    assert_equal(2, fb.all.size)
+    assert(fb.one?(what: 'iterate', earliest_issue_was_found: 3, repository: 42, where: 'github'))
+  end
+end


### PR DESCRIPTION
Closes #1066 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Automatically identifies and records the earliest GitHub issue or pull request for each repository, including metadata (who, when, details).
  - Provides clear trace/log output and gracefully handles repositories with no issues or pull requests.
  - Prevents duplicate records when an earliest item is already known.

- Tests
  - Added comprehensive automated tests covering earliest issue/PR detection, empty-result handling, deduplication behavior, and user/time parsing to ensure reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->