### PR TITLE
#1067: make not run `find-latest-issue` if latest issue already found

### DIFF
--- a/judges/find-latest-issue/find-latest-issue.rb
+++ b/judges/find-latest-issue/find-latest-issue.rb
@@ -13,6 +13,7 @@ Fbe.iterate do
   as 'latest_issue_was_found'
   by '(plus 0 $before)'
   over do |repository, latest|
+    next latest if latest.positive?
     repo = Fbe.octo.repo_name_by_id(repository)
     json =
       Fbe.octo.with_disable_auto_paginate do |octo|

--- a/test/judges/test-find-latest-issue.rb
+++ b/test/judges/test-find-latest-issue.rb
@@ -137,4 +137,23 @@ class TestFindLatestIssue < Jp::Test
     )
     assert(fb.one?(what: 'iterate', latest_issue_was_found: 547, repository: 42, where: 'github'))
   end
+
+  def test_if_find_latest_issue_already_found
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github(
+      'https://api.github.com/repos/foo/foo', body: { id: 42, name: 'foo', full_name: 'foo/foo' }
+    )
+    fb = Factbase.new
+    fb.with(
+      _id: 1, what: 'issue-was-opened', issue: 547, repository: 42, where: 'github',
+      who: 44, when: Time.parse('2025-09-14 20:03:16 UTC'),
+      details: 'The issue foo/foo#547 has been opened by @user.'
+    ).with(
+      _id: 2, what: 'iterate', where: 'github', repository: 42, latest_issue_was_found: 547
+    )
+    load_it('find-latest-issue', fb)
+    assert_equal(2, fb.all.size)
+    assert(fb.one?(what: 'iterate', latest_issue_was_found: 547, repository: 42, where: 'github'))
+  end
 end


### PR DESCRIPTION
Closes #1067 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Added an early exit to skip repository lookup, network fetches, and transaction creation when the latest issue is already known, improving efficiency and reducing unnecessary processing.

* **Tests**
  * Introduced a test to verify the early-exit behavior when the latest issue has been previously found, including network stubbing and fixture validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->