### PR TITLE
#1068: assign branch to fact in `find-latest-issue` judge

### DIFF
--- a/judges/find-latest-issue/find-latest-issue.rb
+++ b/judges/find-latest-issue/find-latest-issue.rb
@@ -30,6 +30,14 @@ Fbe.iterate do
       next if f.nil?
       f.when = json[:created_at]
       f.who = json.dig(:user, :id)
+      if json[:pull_request]
+        ref = Fbe.octo.pull_request(repo, f.issue).dig(:head, :ref)
+        if ref
+          f.branch = ref
+        else
+          f.stale = 'branch'
+        end
+      end
       f.details = "The issue #{Fbe.issue(f)} is the first we found, opened by #{Fbe.who(f)}."
       $loog.info("The opening of #{Fbe.issue(f)} by #{Fbe.who(f)} was found")
     end

--- a/test/judges/test-find-latest-issue.rb
+++ b/test/judges/test-find-latest-issue.rb
@@ -62,10 +62,18 @@ class TestFindLatestIssue < Jp::Test
           number: 548,
           title: 'Some title',
           user: { id: 44, login: 'user' },
-          pull_request: { merged_at: nil },
+          pull_request: { merged_at: '2025-09-14 20:03:16 UTC' },
           created_at: '2025-09-14 20:03:16 UTC'
         }
       ]
+    )
+    stub_github(
+      'https://api.github.com/repos/foo/foo/pulls/548',
+      body: {
+        id: 1234,
+        number: 548,
+        head: { ref: '547' }
+      }
     )
     stub_github('https://api.github.com/user/44', body: { id: 44, login: 'user' })
     fb = Factbase.new
@@ -74,7 +82,7 @@ class TestFindLatestIssue < Jp::Test
     assert(
       fb.one?(
         what: 'pull-was-opened', issue: 548, repository: 42, where: 'github',
-        who: 44, when: Time.parse('2025-09-14 20:03:16 UTC'),
+        who: 44, branch: '547', when: Time.parse('2025-09-14 20:03:16 UTC'),
         details: 'The issue foo/foo#548 is the first we found, opened by @user.'
       )
     )


### PR DESCRIPTION
Closes #1068 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Pull request events now display the source branch name, providing clearer context in activity feeds and notifications.
  - When branch information isn’t available, the event is flagged as stale to highlight incomplete context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->