### PR TITLE
#1078: assign `branch` to fact in `find-latest-issue` judge

### DIFF
--- a/judges/find-earliest-issue/find-earliest-issue.rb
+++ b/judges/find-earliest-issue/find-earliest-issue.rb
@@ -31,6 +31,14 @@ Fbe.iterate do
       next if f.nil?
       f.when = json[:created_at]
       f.who = json.dig(:user, :id)
+      if json[:pull_request]
+        ref = Fbe.octo.pull_request(repo, f.issue).dig(:head, :ref)
+        if ref
+          f.branch = ref
+        else
+          f.stale = 'branch'
+        end
+      end
       f.details = "The issue #{Fbe.issue(f)} is the earliest we found, opened by #{Fbe.who(f)}."
       $loog.info("The opening of #{Fbe.issue(f)} by #{Fbe.who(f)} was found")
     end

--- a/test/judges/test-find-earliest-issue.rb
+++ b/test/judges/test-find-earliest-issue.rb
@@ -48,9 +48,17 @@ class TestFindEarliestIssue < Jp::Test
       body: [
         {
           id: 123, number: 3, title: 'Some title', user: { id: 44, login: 'user' },
-          pull_request: { merged_at: nil }, created_at: '2025-09-27 06:03:16 UTC'
+          pull_request: { merged_at: '2025-09-27 07:03:00 UTC' }, created_at: '2025-09-27 06:03:16 UTC'
         }
       ]
+    )
+    stub_github(
+      'https://api.github.com/repos/foo/foo/pulls/3',
+      body: {
+        id: 1235,
+        number: 3,
+        head: { ref: '2' }
+      }
     )
     stub_github('https://api.github.com/user/44', body: { id: 44, login: 'user' })
     fb = Factbase.new
@@ -59,7 +67,7 @@ class TestFindEarliestIssue < Jp::Test
     assert(
       fb.one?(
         what: 'pull-was-opened', issue: 3, repository: 42, where: 'github',
-        who: 44, when: Time.parse('2025-09-27 06:03:16 UTC'),
+        who: 44, branch: '2', when: Time.parse('2025-09-27 06:03:16 UTC'),
         details: 'The issue foo/foo#3 is the earliest we found, opened by @user.'
       )
     )


### PR DESCRIPTION
Closes #1078 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Earliest pull requests now display the source branch name when available.
  - If the branch reference is unavailable in PR metadata, the item is flagged as stale (“branch”).

- Tests
  - Added coverage for retrieving PR details to surface the head branch.
  - Updated assertions to include the branch field and a merged-at timestamp in pull request scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->