### PR TITLE
Skip processing if label is already attached

### DIFF
--- a/judges/label-was-attached/label-was-attached.rb
+++ b/judges/label-was-attached/label-was-attached.rb
@@ -62,7 +62,10 @@ Fbe.iterate do
             n.repository = repository
             n.where = 'github'
           end
-        raise "A label #{badge.inspect} is already attached to #{repo}##{issue}" if nn.nil?
+      if nn.nil?
+                $loog.info("Label #{badge.inspect} is already attached to #{repo}###{issue}, skipping")
+                next
+      end
         nn.who = te[:actor][:id]
         nn.when = te[:created_at]
         nn.details =


### PR DESCRIPTION
Fixes #1088

Changed the error handling in label-was-attached.rb to gracefully skip labels that are already attached instead of raising a RuntimeError. This prevents the workflow from failing when a judge attempts to attach a label that already exists on an issue.

The fix:
- Replaces the `raise` statement with a conditional check
- Logs an informational message when a duplicate label is detected
- Uses `next` to continue processing other labels instead of crashing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents rare failures when processing label-attached events that lack a recipient; such events are now safely skipped with a clear log entry.
  * Improves overall stability by avoiding hard failures, ensuring subsequent events continue processing without interruption.
  * Reduces unnecessary error noise and potential alerts related to missing-recipient cases, improving operational reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->