### PR TITLE
#1088: fix duplicate labeled event in `label-was-attacked` judge

### DIFF
--- a/judges/label-was-attached/label-was-attached.rb
+++ b/judges/label-was-attached/label-was-attached.rb
@@ -62,7 +62,10 @@ Fbe.iterate do
             n.repository = repository
             n.where = 'github'
           end
-        raise "A label #{badge.inspect} is already attached to #{repo}##{issue}" if nn.nil?
+        if nn.nil?
+          $loog.warn("A label #{badge.inspect} is already attached to #{repo}##{issue}")
+          next
+        end
         nn.who = te[:actor][:id]
         nn.when = te[:created_at]
         nn.details =

--- a/test/judges/test-label-was-attached.rb
+++ b/test/judges/test-label-was-attached.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Zerocracy
+# SPDX-License-Identifier: MIT
+
+require 'factbase'
+require_relative '../test__helper'
+
+# Test.
+class TestLabelWasAttached < Jp::Test
+  using SmartFactbase
+
+  def test_label_was_attached_with_duplicate_labeled_event
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repositories/42', body: { id: 42, full_name: 'foo/foo' })
+    stub_github('https://api.github.com/repos/foo/foo', body: { id: 42, name: 'foo', full_name: 'foo/foo' })
+    stub_github(
+      'https://api.github.com/repos/foo/foo/issues/44/timeline?per_page=100',
+      body: [
+        {
+          id: 195,
+          actor: { id: 421, login: 'user' },
+          event: 'labeled',
+          created_at: '2025-09-30 06:14:38 UTC',
+          label: { name: 'bug', color: 'd73a4a' }
+        },
+        {
+          id: 196,
+          actor: { id: 421, login: 'user' },
+          event: 'labeled',
+          created_at: '2025-09-30 06:14:39 UTC',
+          label: { name: 'bug', color: 'd73a4a' }
+        }
+      ]
+    )
+
+    fb = Factbase.new
+    fb.with(_id: 1, what: 'issue-was-opened', repository: 42, issue: 44, where: 'github')
+    load_it('label-was-attached', fb)
+    assert(
+      fb.one?(what: 'label-was-attached', repository: 42, issue: 44, where: 'github', label: 'bug', who: 421)
+    )
+  end
+end


### PR DESCRIPTION
Closes #1088 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents failures when a label is already attached by logging a warning and continuing processing.
  * Avoids emitting duplicate “label attached” events when identical label actions occur from the same actor.

* **Tests**
  * Added test coverage to validate deduplication of label attachments and continued processing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->