### PR TITLE
#1096: fix fetch duplicate facts in `issue-was-closed` judge

### DIFF
--- a/judges/issue-was-closed/issue-was-closed.rb
+++ b/judges/issue-was-closed/issue-was-closed.rb
@@ -27,6 +27,7 @@ Fbe.iterate do
         (eq what 'bug-report-was-rewarded')
         (eq what 'enhancement-suggestion-was-rewarded'))
       (eq repository $repository)
+      (unique repository issue)
       (absent stale)
       (absent tombstone)
       (absent done)


### PR DESCRIPTION
Closes #1096 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enforces per-repository, per-issue uniqueness when evaluating closed issues, preventing duplicate processing and ensuring a single, accurate closed-event outcome.

* **Tests**
  * Added coverage for scenarios with multiple facts referencing the same repository and issue to confirm correct handling of duplicates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->