### PR TITLE
#1102: fix duplicate assigned event in `issue-was-assigned` judge

### DIFF
--- a/judges/issue-was-assigned/issue-was-assigned.rb
+++ b/judges/issue-was-assigned/issue-was-assigned.rb
@@ -5,8 +5,10 @@
 
 # Judge that monitors open issue and create missing issue-was-assigned facts.
 
+require 'fbe/issue'
 require 'fbe/iterate'
 require 'fbe/octo'
+require 'fbe/who'
 require_relative '../../lib/issue_was_lost'
 
 Fbe.iterate do
@@ -48,7 +50,10 @@ Fbe.iterate do
             n.repository = repository
             n.where = 'github'
           end
-        raise "Assignee already exists in #{repo}##{issue}" if nn.nil?
+        if nn.nil?
+          $loog.warn("Assignee already exists in #{repo}##{issue}")
+          next
+        end
         nn.assigner = event.dig(:assigner, :id)
         nn.when = event[:created_at]
         nn.details = "#{Fbe.issue(nn)} was assigned to #{Fbe.who(nn)} by #{Fbe.who(nn, :assigner)}."

--- a/test/judges/test-issue-was-assigned.rb
+++ b/test/judges/test-issue-was-assigned.rb
@@ -36,4 +36,53 @@ class TestIssueWasAssigned < Jp::Test
     assert_equal(2, fb.picks(what: 'issue-was-opened').size)
     assert_equal(0, fb.picks(what: 'issue-was-assigned').size)
   end
+
+  def test_with_duplicate_assigned_event
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repos/foo/foo', body: { id: 42, name: 'foo', full_name: 'foo/foo' })
+    stub_github('https://api.github.com/repositories/42', body: { id: 42, full_name: 'foo/foo' })
+    stub_github(
+      'https://api.github.com/repos/foo/foo/issues/44/events?per_page=100',
+      body: [
+        {
+          id: 559,
+          event: 'assigned',
+          assignee: {
+            id: 421,
+            login: 'user1'
+          },
+          assigner: {
+            id: 422,
+            login: 'user2'
+          },
+          created_at: '2025-10-01 19:05:00 UTC'
+        },
+        {
+          id: 559,
+          event: 'assigned',
+          assignee: {
+            id: 421,
+            login: 'user1'
+          },
+          assigner: {
+            id: 422,
+            login: 'user2'
+          },
+          created_at: '2025-10-02 21:05:00 UTC'
+        }
+      ]
+    )
+    stub_github('https://api.github.com/user/421', body: { id: 421, login: 'user1' })
+    stub_github('https://api.github.com/user/422', body: { id: 422, login: 'user2' })
+    fb = Factbase.new
+    fb.with(_id: 1, what: 'issue-was-opened', repository: 42, issue: 44, where: 'github')
+    load_it('issue-was-assigned', fb)
+    assert(
+      fb.one?(
+        what: 'issue-was-assigned', repository: 42, issue: 44, where: 'github', who: 421,
+        assigner: 422, details: 'foo/foo#44 was assigned to @user1 by @user2.'
+      )
+    )
+  end
 end


### PR DESCRIPTION
Closes #1102 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved stability for issue assignment processing by logging and skipping problematic events instead of erroring.
  - Deduplicates repeated “issue assigned” events so only one assignment is recorded, reducing duplicate entries/notifications.

- Tests
  - Added coverage to verify deduplication and correct recording of assignee, assigner, and details for duplicate “assigned” events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->