### PR TITLE
#1129: fix duplicate opened pull request event without who

### DIFF
--- a/judges/github-events/github-events.rb
+++ b/judges/github-events/github-events.rb
@@ -303,7 +303,7 @@ Fbe.iterate do
     uniques = {
       'issue-was-opened' => %w[where repository issue who],
       'issue-was-closed' => %w[where repository issue who],
-      'pull-was-opened' => %w[where repository issue who],
+      'pull-was-opened' => %w[where repository issue],
       'pull-was-closed' => %w[where repository issue who],
       'pull-was-merged' => %w[where repository issue who],
       'label-was-attached' => %w[where repository issue label],


### PR DESCRIPTION
Closes #1129 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved duplicate detection logic for pull request events to more accurately identify identical events across different scenarios.

* **Tests**
  * Added test coverage to verify duplicate avoidance functionality for pull request events in the event processing system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->