### PR TITLE
#1144: add `review` property to `pull-was-merged` fact

### DIFF
--- a/judges/github-events/github-events.rb
+++ b/judges/github-events/github-events.rb
@@ -155,6 +155,14 @@ Fbe.iterate do
         Jp.fill_fact_by_hash(fact, Jp.comments_info(pl, repo: rname))
         Jp.fill_fact_by_hash(fact, Jp.fetch_workflows(pl, repo: rname))
         fact.branch = pl[:head][:ref]
+        review =
+          begin
+            Fbe.octo.pull_request_reviews(rname, fact.issue).first
+          rescue Octokit::NotFound
+            $loog.warn("The pull request ##{fact.issue} doesn't exist in #{rname}")
+            nil
+          end
+        fact.review = review[:submitted_at] if review
         fact.details =
           "The pull request #{Fbe.issue(fact)} " \
           "has been #{json[:payload][:action]} by #{Fbe.who(fact)}, " \

--- a/judges/pull-was-merged/pull-was-merged.rb
+++ b/judges/pull-was-merged/pull-was-merged.rb
@@ -84,6 +84,8 @@ Fbe.iterate do
         nn.stale = 'who'
       end
       nn.when = json[:closed_at] ? Time.parse(json[:closed_at].iso8601) : Time.now
+      review = Fbe.octo.pull_request_reviews(repo, issue).first
+      nn.review = review[:submitted_at] if review
       nn.details = "Apparently, #{Fbe.issue(nn)} has been #{nn.what.inspect}."
       $loog.info("Just found out that #{Fbe.issue(nn)} has been #{nn.what.inspect}")
     end

--- a/test/judges/test-pull-was-merged.rb
+++ b/test/judges/test-pull-was-merged.rb
@@ -36,6 +36,7 @@ class TestPullWasMerged < Jp::Test
         closed_by: { login: 'user2', id: 422 }
       }
     )
+    stub_github('https://api.github.com/repos/foo/foo/pulls/44/reviews?per_page=100', body: [])
     stub_github('https://api.github.com/repos/foo/foo/pulls/44/comments?per_page=100', body: [])
     stub_github(
       'https://api.github.com/repos/foo/foo/issues/44/comments?per_page=100',
@@ -85,6 +86,7 @@ class TestPullWasMerged < Jp::Test
         closed_by: { login: 'user2', id: 422 }
       }
     )
+    stub_github('https://api.github.com/repos/foo/foo/pulls/44/reviews?per_page=100', body: [])
     stub_github(
       'https://api.github.com/repos/foo/foo/pulls/44/comments?per_page=100',
       body: [{ id: 100, user: nil }]
@@ -130,6 +132,7 @@ class TestPullWasMerged < Jp::Test
         base: { repo: { id: 42, full_name: 'foo/foo' } }
       }
     )
+    stub_github('https://api.github.com/repos/foo/foo/pulls/44/reviews?per_page=100', body: [])
     stub_github('https://api.github.com/repos/foo/foo/pulls/44/comments?per_page=100', body: [])
     stub_github('https://api.github.com/repos/foo/foo/issues/44/comments?per_page=100', body: [])
     stub_github(
@@ -153,6 +156,63 @@ class TestPullWasMerged < Jp::Test
           what: 'pull-was-closed', where: 'github', who: 422, repository: 42, issue: 44, hoc: 17,
           comments: 0, comments_appreciated: 0, comments_by_author: 0, comments_by_reviewers: 0,
           comments_resolved: 0, comments_to_code: 0, succeeded_builds: 0, branch: '40',
+          details: 'Apparently, foo/foo#44 has been "pull-was-closed".'
+        )
+      )
+    end
+  end
+
+  def test_pull_was_merged_with_exist_review
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repositories/42', body: { id: 42, full_name: 'foo/foo' })
+    stub_github('https://api.github.com/repos/foo/foo', body: { id: 42, name: 'foo', full_name: 'foo/foo' })
+    stub_github(
+      'https://api.github.com/repos/foo/foo/pulls/44',
+      body: {
+        id: 50, number: 44, user: { id: 421, login: 'user' }, state: 'closed',
+        closed_at: Time.parse('2025-09-30 18:00:00 UTC'),
+        closed_by: { login: 'user2', id: 422 },
+        created_at: Time.parse('2025-09-30 15:35:30 UTC'),
+        additions: 12, deletions: 5,
+        head: { ref: '40', sha: 'aa123' },
+        base: { repo: { id: 42, full_name: 'foo/foo' } }
+      }
+    )
+    stub_github(
+      'https://api.github.com/repos/foo/foo/issues/44',
+      body: {
+        number: 50, title: 'some title 50', state: 'closed',
+        closed_at: Time.parse('2025-09-30 18:00:00 UTC'),
+        closed_by: { login: 'user2', id: 422 }
+      }
+    )
+    stub_github(
+      'https://api.github.com/repos/foo/foo/pulls/44/reviews?per_page=100',
+      body: [{ id: 123, user: { id: 142, login: 'user2' }, submitted_at: '2025-09-29 05:05:46 UTC' }]
+    )
+    stub_github(
+      'https://api.github.com/repos/foo/foo/pulls/44/comments?per_page=100',
+      body: []
+    )
+    stub_github(
+      'https://api.github.com/repos/foo/foo/issues/44/comments?per_page=100',
+      body: []
+    )
+    stub_github('https://api.github.com/repos/foo/foo/pulls/comments/100/reactions', body: [])
+    stub_github(
+      'https://api.github.com/repos/foo/foo/commits/aa123/check-runs?per_page=100', body: { check_runs: [] }
+    )
+    fb = Factbase.new
+    fb.with(_id: 1, what: 'pull-was-opened', repository: 42, issue: 44, where: 'github')
+    Fbe.stub(:github_graph, Fbe::Graph::Fake.new) do
+      load_it('pull-was-merged', fb)
+      assert(
+        fb.one?(
+          what: 'pull-was-closed', where: 'github', who: 422, repository: 42, issue: 44, hoc: 17,
+          comments: 0, comments_appreciated: 0, comments_by_author: 0, comments_by_reviewers: 0,
+          comments_resolved: 0, comments_to_code: 0, succeeded_builds: 0, branch: '40',
+          review: Time.parse('2025-09-29 05:05:46 UTC'),
           details: 'Apparently, foo/foo#44 has been "pull-was-closed".'
         )
       )


### PR DESCRIPTION
Closes #1144

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pull request review timestamps are now captured for closed/merged PRs, improving event data and timelines.

* **Tests**
  * Expanded test coverage to validate review timestamp capture across closed/merged PR scenarios and ensure correct handling when review data is present or absent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->