### PR TITLE
#878: implement `Jp.supervision` method for logged extra context upon exception

### DIFF
--- a/lib/supervision.rb
+++ b/lib/supervision.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Zerocracy
+# SPDX-License-Identifier: MIT
+
+require 'json'
+require_relative 'jp'
+
+# A decorator to wrap a method call by adding additional context that will be logged if an exception occurs.
+#
+# @param [Hash] context The data that will be written to the log if an exception occurs
+# @param [Logger] loog The logger instance for error messages
+# @yield Block with calling method
+# @raise [StandardError] If calling method raise error, it will be propagate further
+# @example
+#   $loog = Loog::VERBOSE
+#   repo = 'zerocracy/judges-action'
+#   issue = 125
+#   Jp.supervision({ 'repo' => repo, 'issue' => issue }) do
+#     Fbe.octo.issue(repo, issue) # if raise error, repo and issue will be logged
+#   end
+def Jp.supervision(context, loog: $loog)
+  yield
+rescue StandardError => e
+  loog.error("Additional context for '#{e.class}: #{e.message}':\n#{JSON.pretty_generate(context)}")
+  raise
+end

--- a/test/lib/test_supervision.rb
+++ b/test/lib/test_supervision.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 Zerocracy
+# SPDX-License-Identifier: MIT
+
+require_relative '../../lib/supervision'
+require_relative '../test__helper'
+
+# Test.
+class TestSupervision < Minitest::Test
+  def test_supervision
+    $loog = Loog::Buffer.new
+    assert_raises(RuntimeError) do
+      Jp.supervision({ 'repo' => 'zerocracy/judges-action', 'issue' => 125 }) do
+        raise 'some error'
+      end
+    end
+    $loog.to_s.then do |s|
+      assert_match('RuntimeError: some error', s)
+      assert_match('"repo": "zerocracy/judges-action"', s)
+      assert_match('"issue": 125', s)
+    end
+  end
+end

--- a/test/test__helper.rb
+++ b/test/test__helper.rb
@@ -43,13 +43,13 @@ class Jp::Test < Minitest::Test
     )
   end
 
-  def load_it(judge, fb, options = Judges::Options.new({ 'repositories' => 'foo/foo' }))
+  def load_it(judge, fb, options = Judges::Options.new({ 'repositories' => 'foo/foo' }), loog: nil)
     $fb = fb
     $global = {}
     $local = {}
     $judge = judge
     $options = options
-    $loog = ENV['RACK_RUN'] ? Loog::NULL : Loog::VERBOSE
+    $loog = loog || (ENV['RACK_RUN'] ? Loog::NULL : Loog::VERBOSE)
     $epoch = Time.now
     $kickoff = Time.now
     load(File.join(__dir__, "../judges/#{judge}/#{judge}.rb"))


### PR DESCRIPTION
Closes #878 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Supervision wrapper added around per-repository event processing with contextual error logging and preserved stop/transaction semantics.
  * Logging now emits JSON-like context when handlers raise, including repository and payload details.

* **Tests**
  * New tests cover supervision logging on exceptions and verify logged context.
  * Test harness accepts an injectable logger to capture supervision output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->