### PR TITLE
#1189: add suggestions property to `pull-was-merged` judge

### DIFF
--- a/judges/github-events/github-events.rb
+++ b/judges/github-events/github-events.rb
@@ -164,6 +164,7 @@ Fbe.iterate do
             nil
           end
         fact.review = review[:submitted_at] if review
+        # @todo #1189:60min We also need to add here 'suggestions' property to fact.
         fact.details =
           "The pull request #{Fbe.issue(fact)} " \
           "has been #{json[:payload][:action]} by #{Fbe.who(fact)}, " \

--- a/judges/pull-was-merged/pull-was-merged.rb
+++ b/judges/pull-was-merged/pull-was-merged.rb
@@ -83,6 +83,15 @@ Fbe.iterate do
       else
         nn.stale = 'who'
       end
+      contributor = json.dig(:user, :id)
+      nn.suggestions =
+        Fbe.octo.pull_request_reviews(repo, issue).sum do |review|
+          next 0 if review.dig(:user, :id) == contributor
+          Fbe.octo.pull_request_review_comments(repo, issue, review[:id]).sum do |comment|
+            next 0 if comment.dig(:user, :id) == contributor || !comment[:in_reply_to_id].nil?
+            1
+          end
+        end
       nn.when = json[:closed_at] ? Time.parse(json[:closed_at].iso8601) : Time.now
       review = Fbe.octo.pull_request_reviews(repo, issue).first
       nn.review = review[:submitted_at] if review

--- a/test/judges/test-pull-was-merged.rb
+++ b/test/judges/test-pull-was-merged.rb
@@ -191,6 +191,7 @@ class TestPullWasMerged < Jp::Test
       'https://api.github.com/repos/foo/foo/pulls/44/reviews?per_page=100',
       body: [{ id: 123, user: { id: 142, login: 'user2' }, submitted_at: '2025-09-29 05:05:46 UTC' }]
     )
+    stub_github('https://api.github.com/repos/foo/foo/pulls/44/reviews/123/comments?per_page=100', body: [])
     stub_github(
       'https://api.github.com/repos/foo/foo/pulls/44/comments?per_page=100',
       body: []
@@ -213,6 +214,123 @@ class TestPullWasMerged < Jp::Test
           comments: 0, comments_appreciated: 0, comments_by_author: 0, comments_by_reviewers: 0,
           comments_resolved: 0, comments_to_code: 0, succeeded_builds: 0, branch: '40',
           review: Time.parse('2025-09-29 05:05:46 UTC'),
+          details: 'Apparently, foo/foo#44 has been "pull-was-closed".'
+        )
+      )
+    end
+  end
+
+  def test_pull_was_merged_with_review_code_suggestions
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repositories/42', body: { id: 42, full_name: 'foo/foo' })
+    stub_github('https://api.github.com/repos/foo/foo', body: { id: 42, name: 'foo', full_name: 'foo/foo' })
+    stub_github(
+      'https://api.github.com/repos/foo/foo/pulls/44',
+      body: {
+        id: 50, number: 44, user: { id: 421, login: 'user' }, state: 'closed',
+        closed_at: Time.parse('2025-09-30 18:00:00 UTC'),
+        closed_by: { login: 'user2', id: 422 },
+        created_at: Time.parse('2025-09-30 15:35:30 UTC'),
+        additions: 12, deletions: 5,
+        head: { ref: '40', sha: 'aa123' },
+        base: { repo: { id: 42, full_name: 'foo/foo' } }
+      }
+    )
+    stub_github(
+      'https://api.github.com/repos/foo/foo/issues/44',
+      body: {
+        number: 50, title: 'some title 50', state: 'closed',
+        closed_at: Time.parse('2025-09-30 18:00:00 UTC'),
+        closed_by: { login: 'user2', id: 422 }
+      }
+    )
+    stub_github(
+      'https://api.github.com/repos/foo/foo/pulls/44/reviews?per_page=100',
+      body: [
+        { id: 123, user: { id: 422, login: 'user2' }, body: 'Look good!', submitted_at: '2025-09-29 05:05:46 UTC' },
+        { id: 124, user: { id: 421, login: 'user' }, body: '', submitted_at: '2025-09-29 05:55:00 UTC' },
+        { id: 125, user: { id: 421, login: 'user' }, body: '', submitted_at: '2025-09-29 05:57:00 UTC' },
+        { id: 126, user: { id: 422, login: 'user2' }, body: '', submitted_at: '2025-09-29 06:00:00 UTC' },
+        { id: 127, user: { id: 422, login: 'user2' }, body: 'Perfect!', submitted_at: '2025-09-29 06:45:00 UTC' }
+      ]
+    )
+    stub_github(
+      'https://api.github.com/repos/foo/foo/pulls/44/reviews/123/comments?per_page=100',
+      body: [
+        {
+          id: 22_099, pull_request_review_id: 123,
+          diff_hunk: '@@ -93,4 +93,65 @@ def some_func...', path: 'lib/some/path/file.rb', commit_id: '3e695',
+          body: 'Some question0', created_at: '2025-09-29 05:05:00 UTC', user: { id: 422, login: 'user2' }
+        },
+        {
+          id: 22_100, pull_request_review_id: 123,
+          diff_hunk: '@@ -93,4 +93,65 @@ def some_func1...', path: 'lib/some/path/file1.rb', commit_id: '3e695',
+          body: 'Some question1', created_at: '2025-09-29 05:06:00 UTC', user: { id: 422, login: 'user2' }
+        },
+        {
+          id: 22_101, pull_request_review_id: 123,
+          diff_hunk: '@@ -93,4 +93,65 @@ def some_func2...', path: 'lib/some/path/file2.rb', commit_id: '3e695',
+          body: 'Some question2', created_at: '2025-09-29 05:07:00 UTC', user: { id: 422, login: 'user2' }
+        }
+      ]
+    )
+    stub_github(
+      'https://api.github.com/repos/foo/foo/pulls/44/reviews/124/comments?per_page=100',
+      body: [
+        {
+          id: 22_103, pull_request_review_id: 124,
+          diff_hunk: '@@ -93,4 +93,65 @@ def some_func...', path: 'lib/some/path/file1.rb', commit_id: '3e695',
+          body: 'Some answer1', created_at: '2025-09-29 05:45:00 UTC', user: { id: 421, login: 'user' },
+          in_reply_to_id: 22_100
+        }
+      ]
+    )
+    stub_github(
+      'https://api.github.com/repos/foo/foo/pulls/44/reviews/125/comments?per_page=100',
+      body: [
+        {
+          id: 22_104, pull_request_review_id: 125,
+          diff_hunk: '@@ -93,4 +93,65 @@ def some_func...', path: 'lib/some/path/file1.rb', commit_id: '3e695',
+          body: 'Some answer2', created_at: '2025-09-29 05:56:00 UTC', user: { id: 421, login: 'user' },
+          in_reply_to_id: 22_100
+        }
+      ]
+    )
+    stub_github(
+      'https://api.github.com/repos/foo/foo/pulls/44/reviews/126/comments?per_page=100',
+      body: [
+        {
+          id: 22_105, pull_request_review_id: 126,
+          diff_hunk: '@@ -93,4 +93,65 @@ def some_func...', path: 'lib/some/path/file1.rb', commit_id: '3e695',
+          body: 'Some question3', created_at: '2025-09-29 05:56:00 UTC', user: { id: 422, login: 'user2' },
+          in_reply_to_id: 22_100
+        }
+      ]
+    )
+    stub_github('https://api.github.com/repos/foo/foo/pulls/44/reviews/127/comments?per_page=100', body: [])
+    stub_github(
+      'https://api.github.com/repos/foo/foo/pulls/44/comments?per_page=100',
+      body: []
+    )
+    stub_github(
+      'https://api.github.com/repos/foo/foo/issues/44/comments?per_page=100',
+      body: []
+    )
+    stub_github('https://api.github.com/repos/foo/foo/pulls/comments/100/reactions', body: [])
+    stub_github(
+      'https://api.github.com/repos/foo/foo/commits/aa123/check-runs?per_page=100', body: { check_runs: [] }
+    )
+    fb = Factbase.new
+    fb.with(_id: 1, what: 'pull-was-opened', repository: 42, issue: 44, where: 'github')
+    Fbe.stub(:github_graph, Fbe::Graph::Fake.new) do
+      load_it('pull-was-merged', fb)
+      assert(
+        fb.one?(
+          what: 'pull-was-closed', where: 'github', who: 422, repository: 42, issue: 44, hoc: 17,
+          comments: 0, comments_appreciated: 0, comments_by_author: 0, comments_by_reviewers: 0,
+          comments_resolved: 0, comments_to_code: 0, succeeded_builds: 0, branch: '40',
+          suggestions: 3, review: Time.parse('2025-09-29 05:05:46 UTC'),
           details: 'Apparently, foo/foo#44 has been "pull-was-closed".'
         )
       )


### PR DESCRIPTION
Closes #1189 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Merged pull requests now track code review suggestions, calculating how many suggestions reviewers provided during reviews.

* **Tests**
  * Added test coverage validating suggestion-count calculation across multiple review and comment scenarios, ensuring accurate suggestion totals in merged-pull cases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->