### PR TITLE
#1193: add `suggestions` property to fact for `github-events` judge, refactor `pull-was-merged` judge

### DIFF
--- a/judges/github-events/github-events.rb
+++ b/judges/github-events/github-events.rb
@@ -164,7 +164,14 @@ Fbe.iterate do
             nil
           end
         fact.review = review[:submitted_at] if review
-        # @todo #1189:60min We also need to add here 'suggestions' property to fact.
+        author =
+          begin
+            Fbe.octo.pull_request(rname, fact.issue).dig(:user, :id)
+          rescue Octokit::NotFound
+            $loog.warn("The pull request ##{fact.issue} doesn't exist in #{rname}")
+            nil
+          end
+        fact.suggestions = Jp.count_suggestions(rname, fact.issue, author) if author
         fact.details =
           "The pull request #{Fbe.issue(fact)} " \
           "has been #{json[:payload][:action]} by #{Fbe.who(fact)}, " \

--- a/judges/pull-was-merged/pull-was-merged.rb
+++ b/judges/pull-was-merged/pull-was-merged.rb
@@ -83,15 +83,7 @@ Fbe.iterate do
       else
         nn.stale = 'who'
       end
-      contributor = json.dig(:user, :id)
-      nn.suggestions =
-        Fbe.octo.pull_request_reviews(repo, issue).sum do |review|
-          next 0 if review.dig(:user, :id) == contributor
-          Fbe.octo.pull_request_review_comments(repo, issue, review[:id]).sum do |comment|
-            next 0 if comment.dig(:user, :id) == contributor || !comment[:in_reply_to_id].nil?
-            1
-          end
-        end
+      nn.suggestions = Jp.count_suggestions(repo, issue, json.dig(:user, :id))
       nn.when = json[:closed_at] ? Time.parse(json[:closed_at].iso8601) : Time.now
       review = Fbe.octo.pull_request_reviews(repo, issue).first
       nn.review = review[:submitted_at] if review

--- a/lib/pull_request.rb
+++ b/lib/pull_request.rb
@@ -76,3 +76,20 @@ def Jp.fetch_workflows(pr, repo: nil)
   end
   { succeeded_builds:, failed_builds: }
 end
+
+# Count code suggestions for pull request.
+# Author suggestions are not taken into account
+#
+# @param [String] repo Github repository (e.g.: 'org/repo')
+# @param [Integer] issue Number ID of the pull request
+# @param [Integer] author Github user ID, who create pull request
+# @return [Integer] count of suggestions
+def Jp.count_suggestions(repo, issue, author)
+  Fbe.octo.pull_request_reviews(repo, issue).sum do |review|
+    next 0 if review.dig(:user, :id) == author
+    Fbe.octo.pull_request_review_comments(repo, issue, review[:id]).sum do |comment|
+      next 0 if comment.dig(:user, :id) == author || !comment[:in_reply_to_id].nil?
+      1
+    end
+  end
+end


### PR DESCRIPTION
Closes #1193 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pull requests now display code suggestion counts from reviews when author information is available.

* **Bug Fixes**
  * PR data retrieval failures are now handled gracefully with warning logs instead of crashing the process.

* **Tests**
  * Expanded test coverage for pull request scenarios including code suggestions and review comments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->