### PR TITLE
#1206: use `Fbe.over?` in `Jp.incremate`

### DIFF
--- a/lib/incremate.rb
+++ b/lib/incremate.rb
@@ -5,6 +5,7 @@
 
 require 'elapsed'
 require 'fbe/octo'
+require 'fbe/over'
 require 'fbe/overwrite'
 require 'tago'
 require 'time'
@@ -43,18 +44,7 @@ def Jp.incremate(fact, dir, prefix, avoid_duplicate: false, epoch: $epoch || Tim
       $loog.debug("#{n} is here: #{fact[n].first}")
       next
     end
-    if Fbe.octo.off_quota?
-      $loog.info("No GitHub quota left, it is time to stop at #{n}")
-      break
-    end
-    if $options.lifetime && Time.now.to_f - epoch.to_f > $options.lifetime * 0.9
-      $loog.info("We are doing this for too long, time to stop at #{n}")
-      break
-    end
-    if $options.timeout && Time.now.to_f - kickoff.to_f > $options.timeout * 0.9
-      $loog.info("We are doing this for #{kickoff.ago}, let's stop at #{n}")
-      break
-    end
+    break if Fbe.over?(epoch:, kickoff:)
     $loog.info(
       [
         "Starting to evaluate #{n}",


### PR DESCRIPTION
Closes #1206 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Unified quota and timeout checks into a single guard to ensure consistent handling of API limits and timeouts; removed redundant exit conditions and streamlined logging/flow.

* **Tests**
  * Added a test to confirm computed repository metrics remain unset when API quota is exhausted.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->