### PR TITLE
#1241: set sqlite_cache_min_age option to 1 hour as default

### DIFF
--- a/entries/passes-options.sh
+++ b/entries/passes-options.sh
@@ -42,3 +42,6 @@ log_contains \
 log_contains \
   " --option=bots=test-bot,another-bot" \
   "This indicates INPUT_BOTS parameter is not being processed correctly"
+log_contains \
+  " --option=sqlite_cache_min_age=3600" \
+  "This indicates sqlite_cache_min_age option with default value is not being processed correctly"

--- a/entry.sh
+++ b/entry.sh
@@ -163,6 +163,17 @@ if [ "${bots_found}" == "false" ]; then
     fi
 fi
 
+cache_min_age=false
+for opt in "${options[@]}"; do
+    if [[ "${opt}" == "--option=sqlite_cache_min_age="* ]]; then
+        cache_min_age=true
+        break
+    fi
+done
+if [ "${cache_min_age}" == "false" ]; then
+    options+=("--option=sqlite_cache_min_age=3600");
+fi
+
 owner="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
 if [ "$(printenv "INPUT_DRY-RUN" || echo 'false')" == 'true' ]; then
     echo "We are in 'dry' mode; skipping 'pull'"


### PR DESCRIPTION
Closes #1241 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * SQLite cache minimum age is now automatically configured with optimized defaults to improve performance.

* **Bug Fixes**
  * Pull operation now executes correctly during normal runs (previously may have been skipped).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->