### PR TITLE
fix jq parser error

### DIFF
--- a/entry.sh
+++ b/entry.sh
@@ -11,13 +11,9 @@ VERSION=0.0.0
 echo "The 'judges-action' ${VERSION} is running"
 
 if [ "${SKIP_VERSION_CHECKING}" != 'true' ]; then
-    set +e
-    set +o pipefail
     resp=$(curl --silent -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/zerocracy/judges-action/releases/latest)
-    latest=$(echo -n "$resp" | jq -r '.tag_name')
-    rc=$?
-    set -e -o pipefail
-    if [ "$rc" -ne 0 ] || [ -z "${latest}" ] || [ "${latest}" == "null" ]; then
+    latest=$(echo -n "$resp" | jq -Rs "try (fromjson | .tag_name) catch empty")
+    if [ -z "${latest}" ]; then
         echo "!!! Could not fetch the latest version from GitHub."
         echo "!!! GitHub returned: "
         echo "$resp"


### PR DESCRIPTION
Close #1255 

the script turns off the version checking if github api returned error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Version check now fails gracefully — errors fetching or parsing the latest release no longer abort execution.
  * If the latest-version lookup fails or yields empty results, version checking is disabled and clear diagnostics are logged.
  * Users continue to receive notifications when a valid newer version is available.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->