### PR TITLE
Fix NoMethodError when repo size is nil (#1160)

### DIFF
--- a/judges/dimensions-of-terrain/total_commits.rb
+++ b/judges/dimensions-of-terrain/total_commits.rb
@@ -12,7 +12,7 @@ def total_commits(_fact)
   repos = []
   Fbe.unmask_repos do |repo|
     json = Fbe.octo.repository(repo)
-    next if json[:size].zero?
+    next if json[:size].nil? || json[:size].zero?
     repos << [*repo.split('/'), json[:default_branch]]
   end
   commits = Fbe.github_graph.total_commits(repos:).sum { _1['total_commits'] } unless repos.empty?

--- a/judges/dimensions-of-terrain/total_contributors.rb
+++ b/judges/dimensions-of-terrain/total_contributors.rb
@@ -9,7 +9,8 @@ require 'fbe/unmask_repos'
 def total_contributors(_fact)
   contributors = Set.new
   Fbe.unmask_repos do |repo|
-    next if Fbe.octo.repository(repo)[:size].zero?
+    json = Fbe.octo.repository(repo)
+    next if json[:size].nil? || json[:size].zero?
     Fbe.octo.contributors(repo).each do |contributor|
       contributors << contributor[:id]
     end

--- a/judges/dimensions-of-terrain/total_files.rb
+++ b/judges/dimensions-of-terrain/total_files.rb
@@ -10,7 +10,7 @@ def total_files(_fact)
   files = 0
   Fbe.unmask_repos do |repo|
     info = Fbe.octo.repository(repo)
-    next if info[:size].zero?
+    next if info[:size].nil? || info[:size].zero?
     Fbe.octo.tree(repo, info[:default_branch], recursive: true).then do |json|
       files += json[:tree].count { |item| item[:type] == 'blob' }
     end

--- a/test/judges/test-dimensions-of-terrain.rb
+++ b/test/judges/test-dimensions-of-terrain.rb
@@ -330,6 +330,9 @@ class TestDimensionsOfTerrain < Jp::Test
                 Judges::Options.new({ 'repositories' => 'foo/foo,foo/nil-size' }))
         f = fb.query("(eq what 'dimensions-of-terrain')").each.first
         assert_equal(Time.parse('2024-09-29 21:00:00 UTC'), f.when)
+        assert_equal(2, f.total_repositories)
+        assert_equal(0, f.total_files)
+        assert_equal(0, f.total_contributors)
       end
     end
   end

--- a/test/judges/test-dimensions-of-terrain.rb
+++ b/test/judges/test-dimensions-of-terrain.rb
@@ -326,8 +326,7 @@ class TestDimensionsOfTerrain < Jp::Test
     fb = Factbase.new
     Fbe.stub(:github_graph, Fbe::Graph::Fake.new) do
       Time.stub(:now, Time.parse('2024-09-29 21:00:00 UTC')) do
-        load_it('dimensions-of-terrain', fb,
-                Judges::Options.new({ 'repositories' => 'foo/foo,foo/nil-size' }))
+        load_it('dimensions-of-terrain', fb, Judges::Options.new({ 'repositories' => 'foo/foo,foo/nil-size' }))
         f = fb.query("(eq what 'dimensions-of-terrain')").each.first
         assert_equal(Time.parse('2024-09-29 21:00:00 UTC'), f.when)
         assert_equal(2, f.total_repositories)

--- a/test/judges/test-dimensions-of-terrain.rb
+++ b/test/judges/test-dimensions-of-terrain.rb
@@ -331,6 +331,7 @@ class TestDimensionsOfTerrain < Jp::Test
         f = fb.query("(eq what 'dimensions-of-terrain')").each.first
         assert_equal(Time.parse('2024-09-29 21:00:00 UTC'), f.when)
         assert_equal(2, f.total_repositories)
+        assert_equal(1484, f.total_commits)
         assert_equal(0, f.total_files)
         assert_equal(0, f.total_contributors)
       end

--- a/test/judges/test-dimensions-of-terrain.rb
+++ b/test/judges/test-dimensions-of-terrain.rb
@@ -273,6 +273,67 @@ class TestDimensionsOfTerrain < Jp::Test
     assert_equal(1484, f.total_commits)
   end
 
+  def test_total_commits_with_nil_size_repo
+    WebMock.disable_net_connect!
+    stub_request(:get, 'https://api.github.com/rate_limit').to_return(
+      { body: '{"rate":{"remaining":222}}', headers: { 'X-RateLimit-Remaining' => '222' } }
+    )
+    stub_github(
+      'https://api.github.com/repos/foo/foo',
+      body: {
+        name: 'foo',
+        full_name: 'foo/foo',
+        private: false,
+        created_at: Time.parse('2024-07-11 20:35:25 UTC'),
+        updated_at: Time.parse('2024-09-23 07:23:36 UTC'),
+        pushed_at: Time.parse('2024-09-23 20:22:51 UTC'),
+        size: 19_366,
+        stargazers_count: 1,
+        forks: 1,
+        default_branch: 'master'
+      }
+    )
+    stub_github(
+      'https://api.github.com/repos/foo/nil-size',
+      body: {
+        name: 'nil-size',
+        full_name: 'foo/nil-size',
+        private: false,
+        created_at: Time.parse('2024-07-10 20:35:25 UTC'),
+        updated_at: Time.parse('2024-09-22 07:23:36 UTC'),
+        pushed_at: Time.parse('2024-09-22 20:22:51 UTC'),
+        size: nil,
+        stargazers_count: 0,
+        forks: 0,
+        default_branch: 'master'
+      }
+    )
+    stub_github('https://api.github.com/repos/foo/foo/releases?per_page=100', body: [])
+    stub_github('https://api.github.com/repos/foo/nil-size/releases?per_page=100', body: [])
+    stub_github(
+      'https://api.github.com/repos/foo/foo/git/trees/master?recursive=true',
+      body: { sha: 'abc012345f', tree: [], truncated: false }
+    )
+    stub_github('https://api.github.com/repos/foo/foo/contributors?per_page=100', body: [])
+    stub_github(
+      'https://api.github.com/search/commits?per_page=100&q=repo:foo/foo%20author-date:%3E2024-08-30',
+      body: { total_count: 0, incomplete_results: false, items: [] }
+    )
+    stub_github(
+      'https://api.github.com/search/commits?per_page=100&q=repo:foo/nil-size%20author-date:%3E2024-08-30',
+      body: { total_count: 0, incomplete_results: false, items: [] }
+    )
+    fb = Factbase.new
+    Fbe.stub(:github_graph, Fbe::Graph::Fake.new) do
+      Time.stub(:now, Time.parse('2024-09-29 21:00:00 UTC')) do
+        load_it('dimensions-of-terrain', fb,
+                Judges::Options.new({ 'repositories' => 'foo/foo,foo/nil-size' }))
+        f = fb.query("(eq what 'dimensions-of-terrain')").each.first
+        assert_equal(Time.parse('2024-09-29 21:00:00 UTC'), f.when)
+      end
+    end
+  end
+
   def test_total_files
     WebMock.disable_net_connect!
     stub_request(:get, 'https://api.github.com/rate_limit').to_return(


### PR DESCRIPTION
Fixes #1160
Added `nil?` check before `.zero?` on repository size in `total_commits.rb`, `total_contributors.rb`, and `total_files.rb`. Added test for nil size scenario.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Repositories with missing (nil) or zero size are now excluded from commit, contributor, and file counts, improving accuracy of aggregate repository metrics.

* **Tests**
  * Added a test that verifies repositories with nil size are excluded and that overall totals (repositories, commits, files, contributors, and timestamp) are computed as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->