### PR TITLE
#645: fix iterator return and extend test in `label-was-attached`

### DIFF
--- a/judges/label-was-attached/label-was-attached.rb
+++ b/judges/label-was-attached/label-was-attached.rb
@@ -38,7 +38,7 @@ Fbe.iterate do
       rescue Octokit::NotFound, Octokit::Deprecated => e
         $loog.info("Can't find issue ##{issue} in repository ##{repository}: #{e.message}")
         Jp.issue_was_lost('github', repository, issue)
-        next
+        next issue
       end
     events.each do |te|
       next unless te[:event] == 'labeled'

--- a/test/judges/test-label-was-attached.rb
+++ b/test/judges/test-label-was-attached.rb
@@ -33,9 +33,16 @@ class TestLabelWasAttached < Jp::Test
         }
       ]
     )
+    stub_github(
+      'https://api.github.com/repos/foo/foo/issues/45/timeline?per_page=100',
+      status: 404,
+      body: { message: 'Not Found', documentation_url: 'https://docs.github.com', status: '404' }
+    )
     fb = Factbase.new
     fb.with(_id: 1, what: 'issue-was-opened', repository: 42, issue: 44, where: 'github')
+    fb.with(_id: 2, what: 'issue-was-opened', repository: 42, issue: 45, where: 'github')
     load_it('label-was-attached', fb)
     assert(fb.one?(what: 'label-was-attached', repository: 42, issue: 44, where: 'github', label: 'bug', who: 421))
+    assert(fb.one?(what: 'issue-was-opened', repository: 42, issue: 45, where: 'github', stale: 'issue'))
   end
 end


### PR DESCRIPTION
Refs #645. The bare `next` in the `label-was-attached` rescue clause returned `nil`, while `Fbe.iterate` requires an Integer (every other judge uses `next issue`). Extends the existing test to cover the rescue path, raising isolated line coverage of `label-was-attached.rb` from 70.91% to 81.82%.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for unavailable issue timelines. The system now correctly marks issues as stale when their timeline data cannot be fetched due to missing or deprecated endpoints, ensuring more reliable processing of issue data across GitHub repositories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->