### PR TITLE
#1334: fix parse error when alive list is empty in who-has-name

### DIFF
--- a/judges/who-has-name/who-has-name.rb
+++ b/judges/who-has-name/who-has-name.rb
@@ -62,15 +62,17 @@ Fbe.consider(
 end
 
 alive.uniq!
-Fbe.fb.query(
-  "(and
-    (exists _id)
-    (eq stale 'who')
-    (exists who)
-    (or #{alive.map { |u| "(eq who #{u})" }.join}))"
-).each do |f|
-  next unless f.stale == 'who'
-  Fbe.delete_one(f, 'stale', 'who')
+unless alive.empty?
+  Fbe.fb.query(
+    "(and
+      (exists _id)
+      (eq stale 'who')
+      (exists who)
+      (or #{alive.map { |u| "(eq who #{u})" }.join}))"
+  ).each do |f|
+    next unless f.stale == 'who'
+    Fbe.delete_one(f, 'stale', 'who')
+  end
 end
 
 Fbe.octo.print_trace!

--- a/test/judges/test-who-has-name.rb
+++ b/test/judges/test-who-has-name.rb
@@ -41,6 +41,14 @@ class TestWhoHasName < Jp::Test
     assert_equal(1, fb.query('(exists who)').each.to_a.size)
   end
 
+  def test_does_not_crash_when_all_users_resolved
+    WebMock.disable_net_connect!
+    rate_limit_up
+    fb = Factbase.new
+    load_it('who-has-name', fb)
+    assert_equal(0, fb.all.size)
+  end
+
   def test_overwrite_name_if_user_login_changed
     WebMock.disable_net_connect!
     rate_limit_up


### PR DESCRIPTION
Closes #1334 

When `alive` list is empty (no users were successfully resolved), the query in `who-has-name.rb` generates an invalid `(or )` expression, causing a parse error crash.

The fix adds a guard `unless alive.empty?` — when there are no resolved users, there is nothing to clean up, so the query is skipped entirely.

A new test `test_does_not_crash_when_all_users_resolved` covers this case.