### PR TITLE
Fix #1337: rescue Forbidden no longer marks facts stale (transient errors will retry)

### DIFF
--- a/judges/add-review-comments/add-review-comments.rb
+++ b/judges/add-review-comments/add-review-comments.rb
@@ -27,8 +27,10 @@ Fbe.consider(
       f.stale = 'repository'
       next
     rescue Octokit::Forbidden => e
-      $loog.warn("[#{$judge}] Access forbidden to repository #{f.repository}: #{e.class}: #{e.message}")
-      f.stale = 'repository'
+      $loog.warn(
+        "[#{$judge}] Access forbidden to repository #{f.repository} " \
+        "(transient, will retry next cycle): #{e.class}: #{e.message}"
+      )
       next
     end
   json =
@@ -39,8 +41,10 @@ Fbe.consider(
       Jp.issue_was_lost(f.where, f.repository, f.issue)
       next
     rescue Octokit::Forbidden => e
-      $loog.warn("[#{$judge}] Access forbidden to issue ##{f.issue} in #{repo}: #{e.class}: #{e.message}")
-      Jp.issue_was_lost(f.where, f.repository, f.issue)
+      $loog.warn(
+        "[#{$judge}] Access forbidden to issue ##{f.issue} in #{repo} " \
+        "(transient, will retry next cycle): #{e.class}: #{e.message}"
+      )
       next
     end
   c = json[:review_comments]

--- a/judges/find-all-issues/find-all-issues.rb
+++ b/judges/find-all-issues/find-all-issues.rb
@@ -37,10 +37,9 @@ require_relative '../../lib/issue_was_lost'
           next 0
         rescue Octokit::Forbidden => e
           $loog.warn(
-            "[#{$judge}] Access forbidden to #{type} ##{issue}, " \
-            "time to start from zero: #{e.class}: #{e.message}"
+            "[#{$judge}] Access forbidden to #{type} ##{issue} " \
+            "(transient, will retry next cycle): #{e.class}: #{e.message}"
           )
-          Jp.issue_was_lost('github', repository, issue)
           next 0
         end
       if after.nil?

--- a/judges/find-missing-issues/find-missing-issues.rb
+++ b/judges/find-missing-issues/find-missing-issues.rb
@@ -39,8 +39,10 @@ Fbe.consider('(and (eq where "github") (exists repository) (unique repository))'
         Jp.issue_was_lost('github', r.repository, i)
         next
       rescue Octokit::Forbidden => e
-        $loog.warn("[#{$judge}] Access forbidden to issue #{repo}##{i}: #{e.class}: #{e.message}")
-        Jp.issue_was_lost('github', r.repository, i)
+        $loog.warn(
+          "[#{$judge}] Access forbidden to issue #{repo}##{i} " \
+          "(transient, will retry next cycle): #{e.class}: #{e.message}"
+        )
         next
       end
     checked << i

--- a/judges/fix-missing-branch/fix-missing-branch.rb
+++ b/judges/fix-missing-branch/fix-missing-branch.rb
@@ -30,8 +30,10 @@ Fbe.consider(
       Jp.issue_was_lost(f.where, f.repository, f.issue)
       next
     rescue Octokit::Forbidden => e
-      $loog.warn("[#{$judge}] Access forbidden to #{Fbe.issue(f)} in #{repo}: #{e.class}: #{e.message}")
-      Jp.issue_was_lost(f.where, f.repository, f.issue)
+      $loog.warn(
+        "[#{$judge}] Access forbidden to #{Fbe.issue(f)} in #{repo} " \
+        "(transient, will retry next cycle): #{e.class}: #{e.message}"
+      )
       next
     end
   ref = json.dig(:pull_request, :head, :ref)

--- a/judges/issue-was-assigned/issue-was-assigned.rb
+++ b/judges/issue-was-assigned/issue-was-assigned.rb
@@ -41,10 +41,9 @@ Fbe.iterate do
         next issue
       rescue Octokit::Forbidden => e
         $loog.warn(
-          "[#{$judge}] Access forbidden to issue events for issue ##{issue} in #{repo}: " \
-          "#{e.class}: #{e.message}"
+          "[#{$judge}] Access forbidden to issue events for issue ##{issue} in #{repo} " \
+          "(transient, will retry next cycle): #{e.class}: #{e.message}"
         )
-        Jp.issue_was_lost('github', repository, issue)
         next issue
       end
     events.each do |event|

--- a/judges/issue-was-closed/issue-was-closed.rb
+++ b/judges/issue-was-closed/issue-was-closed.rb
@@ -51,8 +51,10 @@ Fbe.iterate do
         Jp.issue_was_lost('github', repository, issue)
         next issue
       rescue Octokit::Forbidden => e
-        $loog.warn("[#{$judge}] Access forbidden to issue #{repo}##{issue}: #{e.class}: #{e.message}")
-        Jp.issue_was_lost('github', repository, issue)
+        $loog.warn(
+          "[#{$judge}] Access forbidden to issue #{repo}##{issue} " \
+          "(transient, will retry next cycle): #{e.class}: #{e.message}"
+        )
         next issue
       end
     unless json[:state] == 'closed'

--- a/judges/issue-was-opened/issue-was-opened.rb
+++ b/judges/issue-was-opened/issue-was-opened.rb
@@ -48,8 +48,10 @@ Fbe.conclude do
         Jp.issue_was_lost(f.where, f.repository, f.issue)
         throw(:rollback)
       rescue Octokit::Forbidden => e
-        $loog.warn("[#{$judge}] Access forbidden to issue ##{f.issue} in #{repo}: #{e.class}: #{e.message}")
-        Jp.issue_was_lost(f.where, f.repository, f.issue)
+        $loog.warn(
+          "[#{$judge}] Access forbidden to issue ##{f.issue} in #{repo} " \
+          "(transient, will retry next cycle): #{e.class}: #{e.message}"
+        )
         throw(:rollback)
       end
     n.what = $judge

--- a/judges/issue-was-unassigned/issue-was-unassigned.rb
+++ b/judges/issue-was-unassigned/issue-was-unassigned.rb
@@ -33,10 +33,9 @@ Fbe.consider(
         next
       rescue Octokit::Forbidden => e
         $loog.warn(
-          "[#{$judge}] Access forbidden to issue events for issue ##{f.issue} in #{repo}: " \
-          "#{e.class}: #{e.message}"
+          "[#{$judge}] Access forbidden to issue events for issue ##{f.issue} in #{repo} " \
+          "(transient, will retry next cycle): #{e.class}: #{e.message}"
         )
-        Jp.issue_was_lost('github', f.repository, f.issue)
         next
       end
     next if event.nil?

--- a/judges/label-was-attached/label-was-attached.rb
+++ b/judges/label-was-attached/label-was-attached.rb
@@ -41,10 +41,9 @@ Fbe.iterate do
         next issue
       rescue Octokit::Forbidden => e
         $loog.warn(
-          "[#{$judge}] Access forbidden to issue ##{issue} in repository ##{repository}: " \
-          "#{e.class}: #{e.message}"
+          "[#{$judge}] Access forbidden to issue ##{issue} in repository ##{repository} " \
+          "(transient, will retry next cycle): #{e.class}: #{e.message}"
         )
-        Jp.issue_was_lost('github', repository, issue)
         next issue
       end
     events.each do |te|

--- a/judges/pull-was-merged/pull-was-merged.rb
+++ b/judges/pull-was-merged/pull-was-merged.rb
@@ -59,8 +59,10 @@ Fbe.iterate do
         Jp.issue_was_lost('github', repository, issue)
         next issue
       rescue Octokit::Forbidden => e
-        $loog.warn("[#{$judge}] Access forbidden to pull ##{issue} in #{repo}: #{e.class}: #{e.message}")
-        Jp.issue_was_lost('github', repository, issue)
+        $loog.warn(
+          "[#{$judge}] Access forbidden to pull ##{issue} in #{repo} " \
+          "(transient, will retry next cycle): #{e.class}: #{e.message}"
+        )
         next issue
       end
     unless json[:state] == 'closed'

--- a/judges/pull-was-opened/pull-was-opened.rb
+++ b/judges/pull-was-opened/pull-was-opened.rb
@@ -46,8 +46,10 @@ Fbe.conclude do
         Jp.issue_was_lost(f.where, f.repository, f.issue)
         throw(:rollback)
       rescue Octokit::Forbidden => e
-        $loog.warn("[#{$judge}] Access forbidden to pull ##{f.issue} in #{repo}: #{e.class}: #{e.message}")
-        Jp.issue_was_lost(f.where, f.repository, f.issue)
+        $loog.warn(
+          "[#{$judge}] Access forbidden to pull ##{f.issue} in #{repo} " \
+          "(transient, will retry next cycle): #{e.class}: #{e.message}"
+        )
         throw(:rollback)
       end
     n.what = $judge

--- a/test/judges/test-add-review-comments.rb
+++ b/test/judges/test-add-review-comments.rb
@@ -100,7 +100,10 @@ class TestAddReviewComments < Jp::Test
     load_it('add-review-comments', fb)
     f = fb.query('(eq issue 44)').each.first
     refute_nil(f)
-    assert_equal('repository', f.stale, 'seed fact should get stale=repository when the repo lookup returns 403')
+    assert_nil(
+      f['stale'],
+      '403 is transient — seed fact must NOT be marked stale=repository; next cycle will retry the repo lookup'
+    )
   end
 
   def test_rescues_forbidden_on_pull_request_lookup
@@ -121,10 +124,7 @@ class TestAddReviewComments < Jp::Test
     load_it('add-review-comments', fb)
     f = fb.query('(eq issue 44)').each.first
     refute_nil(f)
-    assert_equal(
-      'issue', f.stale,
-      'Jp.issue_was_lost should mark the fact stale=issue when the pull lookup returns 403'
-    )
+    assert_nil(f['stale'], '403 is transient — fact must NOT be marked stale; pull lookup will retry next cycle')
   end
 
   def stub(repo, *pulls)

--- a/test/judges/test-find-all-issues.rb
+++ b/test/judges/test-find-all-issues.rb
@@ -323,9 +323,9 @@ class TestFindAllIssues < Jp::Test
     load_it('find-all-issues', fb)
     fact = fb.query('(eq issue 87)').each.first
     refute_nil(fact, 'seed fact should still be present after 403 rescue')
-    assert_equal(
-      'issue', fact.stale,
-      'Jp.issue_was_lost should mark the matching fact stale=issue on 403 (same recovery as NotFound)'
+    assert_nil(
+      fact['stale'],
+      '403 is transient — fact must NOT be marked stale; next cycle will retry the issue lookup'
     )
   end
 end

--- a/test/judges/test-find-missing-issues.rb
+++ b/test/judges/test-find-missing-issues.rb
@@ -39,9 +39,9 @@ class TestFindMissingIssues < Jp::Test
     fb.with(_id: 1, what: 'issue-was-opened', repository: 42, issue: 44, where: 'github')
       .with(_id: 2, what: 'issue-was-opened', repository: 42, issue: 46, where: 'github')
     load_it('find-missing-issues', fb)
-    assert(
-      fb.one?(what: 'issue-was-lost', where: 'github', issue: 45, repository: 42, stale: 'issue'),
-      'Jp.issue_was_lost should create an issue-was-lost fact on 403 (same recovery as NotFound)'
+    refute(
+      fb.one?(what: 'issue-was-lost', where: 'github', issue: 45, repository: 42),
+      '403 is transient — no issue-was-lost fact must be created; next cycle will retry the issue lookup'
     )
   end
 end

--- a/test/judges/test-fix-missing-branch.rb
+++ b/test/judges/test-fix-missing-branch.rb
@@ -24,6 +24,6 @@ class TestFixMissingBranch < Jp::Test
     load_it('fix-missing-branch', fb)
     f = fb.query('(eq issue 44)').each.first
     refute_nil(f)
-    assert_equal('issue', f.stale, 'Jp.issue_was_lost should mark the fact stale=issue when issue lookup returns 403')
+    assert_nil(f['stale'], '403 is transient — fact must NOT be marked stale; next cycle will retry the issue lookup')
   end
 end

--- a/test/judges/test-issue-was-assigned.rb
+++ b/test/judges/test-issue-was-assigned.rb
@@ -97,9 +97,9 @@ class TestIssueWasAssigned < Jp::Test
     load_it('issue-was-assigned', fb)
     f = fb.query('(eq issue 44)').each.first
     refute_nil(f)
-    assert_equal(
-      'issue', f.stale,
-      'Jp.issue_was_lost should mark the fact stale=issue when events lookup returns 403'
+    assert_nil(
+      f['stale'],
+      '403 is transient — fact must NOT be marked stale; next cycle will retry the events lookup'
     )
   end
 end

--- a/test/judges/test-issue-was-closed.rb
+++ b/test/judges/test-issue-was-closed.rb
@@ -185,7 +185,7 @@ class TestIssueWasClosed < Jp::Test
     load_it('issue-was-closed', fb)
     f = fb.query('(eq issue 44)').each.first
     refute_nil(f)
-    assert_equal('issue', f.stale, 'Jp.issue_was_lost should mark the fact stale=issue when issue lookup returns 403')
+    assert_nil(f['stale'], '403 is transient — fact must NOT be marked stale; next cycle will retry the lookup')
   end
 
   def test_rescues_forbidden_on_timeline_lookup

--- a/test/judges/test-issue-was-opened.rb
+++ b/test/judges/test-issue-was-opened.rb
@@ -24,6 +24,6 @@ class TestIssueWasOpened < Jp::Test
     load_it('issue-was-opened', fb)
     f = fb.query('(eq issue 44)').each.first
     refute_nil(f)
-    assert_equal('issue', f.stale, 'Jp.issue_was_lost should mark the fact stale=issue when issue lookup returns 403')
+    assert_nil(f['stale'], '403 is transient — fact must NOT be marked stale; next cycle will retry the lookup')
   end
 end

--- a/test/judges/test-issue-was-unassigned.rb
+++ b/test/judges/test-issue-was-unassigned.rb
@@ -136,9 +136,9 @@ class TestIssueWasUnassigned < Jp::Test
     load_it('issue-was-unassigned', fb)
     f = fb.query('(eq issue 44)').each.first
     refute_nil(f)
-    assert_equal(
-      'issue', f.stale,
-      'Jp.issue_was_lost should mark the fact stale=issue when events lookup returns 403'
+    assert_nil(
+      f['stale'],
+      '403 is transient — fact must NOT be marked stale; next cycle will retry the events lookup'
     )
   end
 end

--- a/test/judges/test-label-was-attached.rb
+++ b/test/judges/test-label-was-attached.rb
@@ -61,9 +61,9 @@ class TestLabelWasAttached < Jp::Test
     load_it('label-was-attached', fb)
     f = fb.query('(eq issue 44)').each.first
     refute_nil(f)
-    assert_equal(
-      'issue', f.stale,
-      'Jp.issue_was_lost should mark the fact stale=issue when timeline lookup returns 403'
+    assert_nil(
+      f['stale'],
+      '403 is transient — fact must NOT be marked stale; next cycle will retry the timeline lookup'
     )
   end
 end

--- a/test/judges/test-pull-was-merged.rb
+++ b/test/judges/test-pull-was-merged.rb
@@ -332,6 +332,6 @@ class TestPullWasMerged < Jp::Test
     load_it('pull-was-merged', fb)
     f = fb.query('(eq issue 44)').each.first
     refute_nil(f)
-    assert_equal('issue', f.stale, 'Jp.issue_was_lost should mark the fact stale=issue when pull lookup returns 403')
+    assert_nil(f['stale'], '403 is transient — fact must NOT be marked stale; next cycle will retry the pull lookup')
   end
 end

--- a/test/judges/test-pull-was-opened.rb
+++ b/test/judges/test-pull-was-opened.rb
@@ -23,8 +23,12 @@ class TestPullWasOpened < Jp::Test
     fb.with(_id: 1, what: 'pull-was-reviewed', repository: 42, issue: 44, where: 'github')
     load_it('pull-was-opened', fb)
     assert(
+      fb.one?(what: 'pull-was-reviewed', repository: 42, issue: 44, where: 'github'),
+      'seed fact must remain in factbase'
+    )
+    refute(
       fb.one?(what: 'pull-was-reviewed', repository: 42, issue: 44, where: 'github', stale: 'issue'),
-      'Jp.issue_was_lost should mark the fact stale=issue when issue lookup returns 403'
+      '403 is transient — fact must NOT be marked stale; next cycle will retry the issue lookup'
     )
   end
 end


### PR DESCRIPTION
Closes #1337.

#1333 added `rescue Octokit::Forbidden` next to the existing NotFound branch and copied the same body — `Jp.issue_was_lost(...)` or `f.stale = 'repository'`. That turned transient 403s into permanent tombstones on live data. This PR removes the tombstoning from the Forbidden branches; the next cycle retries naturally.

Scope is issue and repository sites only: 11 production files, 11 test assertions flipped. User-side rescues (`is-human-or-robot`, `who-has-name`, `eliminate-ghosts`, `who-is-alive`, `lib/nick_of.rb`) are untouched here because `revive-user` already auto-removes `stale='who'` on the next successful lookup.

The 12 tests that pinned the wrong semantics now assert the fact stays live (no stale, no tombstone). Batch survival (the goal of #1333) is preserved — every `rescue Forbidden` block still catches the exception, just without the permanent marking.

Already-corrupted facts from this regression window are not auto-restored by this PR. Happy to add a recovery script as a separate follow-up if you want.