### PR TITLE
#1340: fix NameError in pull-was-merged 404 rescue

### DIFF
--- a/judges/pull-was-merged/pull-was-merged.rb
+++ b/judges/pull-was-merged/pull-was-merged.rb
@@ -55,7 +55,7 @@ Fbe.iterate do
       begin
         Fbe.octo.pull_request(repo, issue)
       rescue Octokit::NotFound, Octokit::Deprecated => e
-        $loog.info("The pull ##{f.issue} doesn't exist in #{repo}: #{e.message}")
+        $loog.info("The pull ##{issue} doesn't exist in #{repo}: #{e.message}")
         Jp.issue_was_lost('github', repository, issue)
         next issue
       rescue Octokit::Forbidden => e

--- a/test/judges/test-pull-was-merged.rb
+++ b/test/judges/test-pull-was-merged.rb
@@ -334,4 +334,26 @@ class TestPullWasMerged < Jp::Test
     refute_nil(f)
     assert_equal('issue', f.stale, 'Jp.issue_was_lost should mark the fact stale=issue when pull lookup returns 403')
   end
+
+  def test_rescues_not_found_on_pull_request_lookup
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repositories/42', body: { id: 42, full_name: 'foo/foo' })
+    stub_github('https://api.github.com/repos/foo/foo', body: { id: 42, full_name: 'foo/foo' })
+    stub_github(
+      'https://api.github.com/repos/foo/foo/pulls/44',
+      status: 404,
+      body: {
+        message: 'Not Found',
+        documentation_url: 'https://docs.github.com/rest/pulls/pulls#get-a-pull-request',
+        status: '404'
+      }
+    )
+    fb = Factbase.new
+    fb.with(_id: 1, what: 'pull-was-opened', repository: 42, issue: 44, where: 'github')
+    load_it('pull-was-merged', fb)
+    f = fb.query('(eq issue 44)').each.first
+    refute_nil(f)
+    assert_equal('issue', f.stale, 'Jp.issue_was_lost should mark the fact stale=issue when pull lookup returns 404')
+  end
 end


### PR DESCRIPTION
Fixes #1340.

The 404 rescue in `pull-was-merged.rb:58` referenced `f.issue`, but `f` doesn't exist in that scope — block params on line 52 are `repository, issue`. So the log line raised `NameError`, which slipped past the rescue (different exception class), past `Jp.issue_was_lost`, past `next issue`, and out through `Fbe::Iterate#over`. The judge crashed every cycle a tracked PR returned 404, never tombstoning the deleted PR.

The neighbouring Forbidden rescue on line 62 uses `issue` correctly — looks like a copy-paste oversight when the second rescue clause was added.

The fix is one character. Added a test mirroring the existing Forbidden case that asserts `Jp.issue_was_lost` marks the fact `stale = 'issue'` after a 404 — without the fix it errors out with NameError before the assertion.

All 7 tests in `test-pull-was-merged.rb` pass.