### PR TITLE
#1343: mask tokens in CI logs before enabling bash tracing

### DIFF
--- a/entries/masks-tokens-in-verbose-mode.sh
+++ b/entries/masks-tokens-in-verbose-mode.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+# SPDX-License-Identifier: MIT
+
+# Verifies that entry.sh emits GitHub Actions ::add-mask:: workflow commands
+# for both INPUT_GITHUB-TOKEN and INPUT_TOKEN. Without these commands, bash
+# tracing under INPUT_VERBOSE=true would leak the token values into public CI
+# logs (the trace prints "+ options+=(--option=github_token=ghp_...)" verbatim).
+
+set -e -o pipefail
+
+SELF=$1
+
+source "${SELF}/makes/setup-test-env.sh"
+source "${SELF}/makes/test-common.sh"
+setup_test_env "${SELF}" name
+
+# Distinctive token values so we can match them by exact string.
+github_token='ghp_test-secret-github-token-aaaaaaaaaaaa'
+zerocracy_token='ZRCY-test-secret-zerocracy-token-bbbbbbbbbbbb'
+
+run_entry_script "${SELF}" success \
+  "GITHUB_WORKSPACE=$(pwd)" \
+  "GITHUB_REPOSITORY=zerocracy/judges-action" \
+  "GITHUB_REPOSITORY_OWNER=zerocracy" \
+  "GITHUB_SERVER_URL=https://github.com" \
+  "GITHUB_RUN_ID=12345" \
+  "INPUT_DRY-RUN=true" \
+  "INPUT_GITHUB-TOKEN=${github_token}" \
+  "INPUT_FACTBASE=${name}.fb" \
+  "INPUT_CYCLES=1" \
+  "INPUT_VERBOSE=true" \
+  "INPUT_TOKEN=${zerocracy_token}"
+
+log_contains "::add-mask::${github_token}" \
+  "::add-mask:: workflow command for INPUT_GITHUB-TOKEN must be emitted before bash tracing"
+log_contains "::add-mask::${zerocracy_token}" \
+  "::add-mask:: workflow command for INPUT_TOKEN must be emitted before bash tracing"

--- a/entry.sh
+++ b/entry.sh
@@ -28,6 +28,17 @@ if [ "${SKIP_VERSION_CHECKING}" != 'true' ]; then
     fi
 fi
 
+# Mask token values in CI logs before enabling bash tracing.
+# Without these workflow commands, "set -x" emits the full command line
+# including "--option=github_token=ghp_..." and "--token=ZRCY-..." into
+# Actions logs, which are readable by anyone with read access to the repo.
+if [ -n "$(printenv "INPUT_GITHUB-TOKEN")" ]; then
+    echo "::add-mask::$(printenv "INPUT_GITHUB-TOKEN")"
+fi
+if [ -n "${INPUT_TOKEN}" ]; then
+    echo "::add-mask::${INPUT_TOKEN}"
+fi
+
 if [ "${INPUT_VERBOSE}" == 'true' ]; then
     set -x
 fi


### PR DESCRIPTION
Fixes #1343.

When `verbose: true` was passed to the action, `entry.sh` enabled `set -x` and the subsequent bash trace lines printed the full bundle command — including `--option=github_token=ghp_...` and `--token=ZRCY-...` — into Actions logs that are readable by anyone with read access to the repo.

Two `::add-mask::` workflow commands now go out before `set -x`. The Actions runner intercepts those and masks the values in all subsequent log output, including the bash trace.

I checked the production `zerocracy.yml` runs and didn't find any unmasked tokens in the latest 1143-line log, so this is a preventive fix — closes the gap for any consumer who enables verbose mode without realising the trace would leak.

Test added: `entries/masks-tokens-in-verbose-mode.sh` runs `entry.sh` with known token values under `INPUT_VERBOSE=true` and asserts the `::add-mask::TOKEN_VALUE` lines appear in the log. Without the fix it fails with `Expected pattern '::add-mask::ghp_test-secret-...' not found`.