### PR TITLE
#1345: Fix metric correctness in QoS and QoD judges (forward-only)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -45,6 +45,7 @@ Elegant/GoodMethodName:
     - total_reviews_submitted
     - cover_qo
     - fill_fact_by_hash
+    - in_window_releases
     - issue_was_lost
     - nick_of
     - comments_info

--- a/judges/quality-of-service/some_merged_pulls.rb
+++ b/judges/quality-of-service/some_merged_pulls.rb
@@ -11,7 +11,7 @@ def some_merged_pulls(fact)
   rejected = []
   Fbe.unmask_repos do |repo|
     pulls << Fbe.octo.search_issues(
-      "repo:#{repo} type:pr closed:#{fact.since.utc.iso8601}..#{fact.when.utc.iso8601}"
+      "repo:#{repo} type:pr is:merged closed:#{fact.since.utc.iso8601}..#{fact.when.utc.iso8601}"
     )[:total_count]
     rejected << Fbe.octo.search_issues(
       "repo:#{repo} type:pr is:unmerged closed:#{fact.since.utc.iso8601}..#{fact.when.utc.iso8601}"

--- a/judges/quality-of-service/some_release_hoc_size.rb
+++ b/judges/quality-of-service/some_release_hoc_size.rb
@@ -5,14 +5,14 @@
 
 require 'fbe/octo'
 require 'fbe/unmask_repos'
+require_relative '../../lib/in_window_releases'
 
 def some_release_hoc_size(fact)
   grouped = {}
   hocs = []
   commits = []
   Fbe.unmask_repos do |repo|
-    Fbe.octo.releases(repo).each do |json|
-      break if json[:published_at] < fact.since || json[:published_at] > fact.when
+    Jp.in_window_releases(repo, fact.since, fact.when) do |json|
       (grouped[repo] ||= []) << json
     end
   end

--- a/judges/quality-of-service/some_release_interval.rb
+++ b/judges/quality-of-service/some_release_interval.rb
@@ -5,12 +5,12 @@
 
 require 'fbe/octo'
 require 'fbe/unmask_repos'
+require_relative '../../lib/in_window_releases'
 
 def some_release_interval(fact)
   dates = []
   Fbe.unmask_repos do |repo|
-    Fbe.octo.releases(repo).each do |json|
-      break if json[:published_at] < fact.since || json[:published_at] > fact.when
+    Jp.in_window_releases(repo, fact.since, fact.when) do |json|
       dates << json[:published_at]
     end
   end

--- a/judges/quantity-of-deliverables/count-all.yml
+++ b/judges/quantity-of-deliverables/count-all.yml
@@ -3,7 +3,7 @@
 ---
 runs: 3
 options:
-  TODAY: 2024-03-03T00:00:00
+  TODAY: 2025-12-01T00:00:00
   repositories: yegor256/judges
   testing: true
 input:
@@ -13,8 +13,8 @@ input:
     qod_days: 7
   -
     what: quantity-of-deliverables
-    since: 2023-12-25T00:00:00
-    when: 2024-01-01T00:00:00
+    since: 2025-09-28T00:00:00
+    when: 2025-10-05T00:00:00
 expected:
   - /fb[count(f)=3]
   - /fb/f[what='quantity-of-deliverables']

--- a/judges/quantity-of-deliverables/total_builds_ran.rb
+++ b/judges/quantity-of-deliverables/total_builds_ran.rb
@@ -10,7 +10,11 @@ def total_builds_ran(fact)
   total =
     Fbe.unmask_repos.sum do |repo|
       Fbe.octo.with_disable_auto_paginate do |octo|
-        octo.repository_workflow_runs(repo, created: ">#{fact.since.utc.iso8601[0..9]}", per_page: 1)[:total_count]
+        octo.repository_workflow_runs(
+          repo,
+          created: "#{fact.since.utc.iso8601[0..9]}..#{fact.when.utc.iso8601[0..9]}",
+          per_page: 1
+        )[:total_count]
       end
     end
   { total_builds_ran: total }

--- a/judges/quantity-of-deliverables/total_reviews_submitted.rb
+++ b/judges/quantity-of-deliverables/total_reviews_submitted.rb
@@ -22,7 +22,10 @@ def total_reviews_submitted(fact)
     end
     until queue.empty?
       pulls = Fbe.github_graph.pull_request_reviews(owner, name, pulls: queue.shift(10))
-      total += pulls.sum { |pull| pull['reviews'].count { |r| r['submitted_at'] > fact.since } }
+      total +=
+        pulls.sum do |pull|
+          pull['reviews'].count { |r| r['submitted_at'] > fact.since && r['submitted_at'] <= fact.when }
+        end
       pulls.select { _1['reviews_has_next_page'] }.each do |p|
         queue.push([p['number'], p['reviews_next_cursor']])
       end

--- a/lib/in_window_releases.rb
+++ b/lib/in_window_releases.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+# SPDX-License-Identifier: MIT
+
+require 'fbe/octo'
+require_relative 'jp'
+
+def Jp.in_window_releases(repo, since, when_)
+  Fbe.octo.releases(repo).each do |json|
+    next if json[:published_at] > when_
+    break if json[:published_at] < since
+    yield(json)
+  end
+end

--- a/test/judges/test-in-window-releases.rb
+++ b/test/judges/test-in-window-releases.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+# SPDX-License-Identifier: MIT
+
+require 'fbe/octo'
+require_relative '../../lib/in_window_releases'
+require_relative '../test__helper'
+
+class TestInWindowReleases < Jp::Test
+  def test_skips_too_new_and_yields_in_window_when_newest_is_past_when
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github(
+      'https://api.github.com/repos/foo/foo/releases?per_page=100',
+      body: [
+        { tag_name: 'v3', published_at: Time.parse('2024-08-15 10:00:00 UTC') },
+        { tag_name: 'v2', published_at: Time.parse('2024-08-05 10:00:00 UTC') },
+        { tag_name: 'v1', published_at: Time.parse('2024-07-20 10:00:00 UTC') }
+      ]
+    )
+    yielded = []
+    $loog = Loog::NULL
+    $options = Judges::Options.new('repositories' => 'foo/foo')
+    $global = {}
+    Jp.in_window_releases(
+      'foo/foo',
+      Time.parse('2024-08-01 00:00:00 UTC'),
+      Time.parse('2024-08-10 00:00:00 UTC')
+    ) do |r|
+      yielded << r[:tag_name]
+    end
+    assert_equal(['v2'], yielded)
+  end
+end

--- a/test/judges/test-quality-of-service.rb
+++ b/test/judges/test-quality-of-service.rb
@@ -1386,6 +1386,16 @@ class TestQualityOfService < Jp::Test
     )
     stub_github(
       'https://api.github.com/search/issues?per_page=100&' \
+      'q=repo:foo/foo%20type:pr%20is:unmerged%20closed:2024-07-02T21:00:00Z..2024-07-09T21:00:00Z',
+      body: { total_count: 0, incomplete_results: false, items: [] }
+    )
+    stub_github(
+      'https://api.github.com/search/issues?per_page=100&' \
+      'q=repo:foo/foo%20type:pr%20is:merged%20closed:2024-07-02T22:00:00Z..2024-07-09T22:00:00Z',
+      body: { total_count: 0, incomplete_results: false, items: [] }
+    )
+    stub_github(
+      'https://api.github.com/search/issues?per_page=100&' \
       'q=repo:foo/foo%20type:pr%20is:unmerged%20closed:2024-07-02T22:00:00Z..2024-07-09T22:00:00Z',
       body: { total_count: 0, incomplete_results: false, items: [] }
     )
@@ -1575,7 +1585,7 @@ class TestQualityOfService < Jp::Test
       assert_nil(second['some_triage_time'])
       refute_nil(second['some_backlog_size'])
       assert_nil(second['some_release_interval'])
-      assert_equal([2], second['some_merged_pulls'])
+      assert_equal([1], second['some_merged_pulls'])
       assert_equal([1], second['some_unmerged_pulls'])
       assert_nil(second['some_issue_lifetime'])
       assert_nil(second['some_pull_lifetime'])

--- a/test/judges/test-quantity-of-deliverables.rb
+++ b/test/judges/test-quantity-of-deliverables.rb
@@ -23,7 +23,7 @@ class TestQuantityOfDeliverables < Jp::Test
       body: { id: 42, full_name: 'foo/foo', open_issues: 0, size: 10 }
     )
     stub_github(
-      'https://api.github.com/repos/foo/foo/actions/runs?created=%3E2024-07-11&per_page=1',
+      'https://api.github.com/repos/foo/foo/actions/runs?created=2024-07-11..2024-08-12&per_page=1',
       body: { total_count: 0, workflow_runs: [] }
     )
     fb = Factbase.new
@@ -49,7 +49,7 @@ class TestQuantityOfDeliverables < Jp::Test
       body: { id: 42, full_name: 'foo/foo', open_issues: 0, size: 0 }
     )
     stub_github(
-      'https://api.github.com/repos/foo/foo/actions/runs?created=%3E2024-07-11&per_page=1',
+      'https://api.github.com/repos/foo/foo/actions/runs?created=2024-07-11..2024-08-12&per_page=1',
       body: { total_count: 0, workflow_runs: [] }
     )
     fb = Factbase.new
@@ -75,7 +75,7 @@ class TestQuantityOfDeliverables < Jp::Test
       body: { id: 42, full_name: 'foo/foo', open_issues: 0, size: 100 }
     )
     stub_github(
-      'https://api.github.com/repos/foo/foo/actions/runs?created=%3E2024-08-02&per_page=1',
+      'https://api.github.com/repos/foo/foo/actions/runs?created=2024-08-02..2024-08-09&per_page=1',
       body: { total_count: 0, workflow_runs: [] }
     )
     fb = Factbase.new
@@ -104,7 +104,7 @@ class TestQuantityOfDeliverables < Jp::Test
       body: { id: 42, full_name: 'foo/foo', open_issues: 0, size: 100 }
     )
     stub_github(
-      'https://api.github.com/repos/foo/foo/actions/runs?created=%3E2024-08-02&per_page=1',
+      'https://api.github.com/repos/foo/foo/actions/runs?created=2025-09-28..2025-10-05&per_page=1',
       body: {
         total_count: 0,
         workflow_runs: []
@@ -116,11 +116,11 @@ class TestQuantityOfDeliverables < Jp::Test
     f.area = 'scope'
     f.qod_days = 7
     Fbe.stub(:github_graph, Fbe::Graph::Fake.new) do
-      Time.stub(:now, Time.parse('2024-08-09 21:00:00 UTC')) do
+      Time.stub(:now, Time.parse('2025-10-05 21:00:00 UTC')) do
         load_it('quantity-of-deliverables', fb)
         f = fb.query('(eq what "quantity-of-deliverables")').each.first
-        assert_equal(Time.parse('2024-08-03 00:00:00 +03:00'), f.since)
-        assert_equal(Time.parse('2024-08-09 21:00:00 UTC'), f.when)
+        assert_equal(Time.parse('2025-09-29 00:00:00 +03:00'), f.since)
+        assert_equal(Time.parse('2025-10-05 21:00:00 UTC'), f.when)
         assert_equal(4, f.total_reviews_submitted)
       end
     end
@@ -136,7 +136,7 @@ class TestQuantityOfDeliverables < Jp::Test
       body: { id: 42, full_name: 'foo/foo', open_issues: 0, size: 100 }
     )
     stub_github(
-      'https://api.github.com/repos/foo/foo/actions/runs?created=%3E2024-08-02&per_page=1',
+      'https://api.github.com/repos/foo/foo/actions/runs?created=2024-08-02..2024-08-09&per_page=1',
       body: {
         total_count: 3,
         workflow_runs: [
@@ -175,9 +175,13 @@ class TestQuantityOfDeliverables < Jp::Test
       'https://api.github.com/repos/foo/foo',
       body: { id: 42, full_name: 'foo/foo', open_issues: 0, size: 100 }
     )
-    %w[2025-09-01 2025-09-05 2025-09-15].each do |date|
+    {
+      '2025-09-01' => '2025-09-05',
+      '2025-09-05' => '2025-09-15',
+      '2025-09-15' => '2025-09-25'
+    }.each do |since, when_date|
       stub_github(
-        "https://api.github.com/repos/foo/foo/actions/runs?created=%3E#{date}&per_page=1",
+        "https://api.github.com/repos/foo/foo/actions/runs?created=#{since}..#{when_date}&per_page=1",
         body: {
           total_count: 0,
           workflow_runs: []


### PR DESCRIPTION
Per your "good catch. let's ignore all slices. only new should be fixed" reply on #1345 — fixes the five metric-correctness issues forward-only.

Forward-only is automatic: `Jp.incremate(..., avoid_duplicate: true)` already skips assignment for existing properties, so historical facts retain their (incorrect) values; only newly-computed slices use the corrected code.

## Fixes

- **`some_merged_pulls.rb`** — query missing `is:merged`; was counting all closed PRs (merged + rejected).
- **`some_release_interval.rb` / `some_release_hoc_size.rb`** — break-on-newest-first: Octokit returns releases newest-first, so an unconditional `break` on out-of-window killed the loop before any in-window release was seen. Switched to `next` for too-new, `break` only when below `since`. The shared loop is extracted into `Jp.in_window_releases` (`lib/in_window_releases.rb`).
- **`total_builds_ran.rb`** — search had no upper bound (`created: ">SINCE"`); now uses `created: SINCE..WHEN` range.
- **`total_reviews_submitted.rb`** — review predicate had no upper bound; added `&& <= fact.when`.

## Tests

- New unit test for `Jp.in_window_releases` covering the bug-fix path (newest release past window, in-window release below).
- `total_builds_ran` test stub URLs updated to range syntax.
- `total_reviews_submitted` test shifted `Time.stub` to 2025-10-05 so `Fbe::Graph::Fake`'s review dates fall within the window — this validates the upper bound is actually wired, rather than just asserting that everything ends up excluded.
- `fill_up_abandoned_facts_with_exists_when_and_absent_since`: `some_merged_pulls` expectation drops from `[2]` to `[1]`. The `[2]` was the bug-output (counting closed PRs); `[1]` matches the helper's existing `is:merged` stub which was correct all along.

Full `bundle exec rake test` + `bundle exec rubocop` clean.

Closes #1345