### PR TITLE
DRAFT #1347: migrate remaining `Fbe.octo.X(...).each` REST calls to GraphQL

### DIFF
--- a/judges/dimensions-of-terrain/total_contributors.rb
+++ b/judges/dimensions-of-terrain/total_contributors.rb
@@ -3,6 +3,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
 # SPDX-License-Identifier: MIT
 
+require 'fbe/github_graph'
 require 'fbe/octo'
 require 'fbe/unmask_repos'
 
@@ -11,9 +12,8 @@ def total_contributors(_fact)
   Fbe.unmask_repos do |repo|
     json = Fbe.octo.repository(repo)
     next if json[:size].nil? || json[:size].zero?
-    Fbe.octo.contributors(repo).each do |contributor|
-      contributors << contributor[:id]
-    end
+    owner, name = repo.split('/')
+    contributors.merge(Fbe.github_graph.distinct_contributors(owner, name))
   end
   { total_contributors: contributors.count }
 end

--- a/judges/dimensions-of-terrain/total_releases.rb
+++ b/judges/dimensions-of-terrain/total_releases.rb
@@ -3,15 +3,15 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
 # SPDX-License-Identifier: MIT
 
+require 'fbe/github_graph'
 require 'fbe/octo'
 require 'fbe/unmask_repos'
 
 def total_releases(_fact)
   total = 0
   Fbe.unmask_repos do |repo|
-    Fbe.octo.releases(repo).each do |_|
-      total += 1
-    end
+    owner, name = repo.split('/')
+    total += Fbe.github_graph.releases_count(owner, name)['releases']
   end
   { total_releases: total }
 end

--- a/judges/github-events/github-events.rb
+++ b/judges/github-events/github-events.rb
@@ -43,9 +43,8 @@ Fbe.iterate do
         list << author if author
       end
     else
-      Fbe.octo.contributors(repo).each do |contributor|
-        list << contributor[:id]
-      end
+      owner, name = repo.split('/')
+      list.merge(Fbe.github_graph.distinct_contributors(owner, name))
     end
     $loog.debug("The repository ##{fact.repository} has #{list.count} contributors")
     list.to_a

--- a/judges/quality-of-service/some_release_hoc_size.rb
+++ b/judges/quality-of-service/some_release_hoc_size.rb
@@ -3,6 +3,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
 # SPDX-License-Identifier: MIT
 
+require 'fbe/github_graph'
 require 'fbe/octo'
 require 'fbe/unmask_repos'
 
@@ -11,14 +12,14 @@ def some_release_hoc_size(fact)
   hocs = []
   commits = []
   Fbe.unmask_repos do |repo|
-    Fbe.octo.releases(repo).each do |json|
-      break if json[:published_at] < fact.since || json[:published_at] > fact.when
+    owner, name = repo.split('/')
+    Fbe.github_graph.releases_in_window(owner, name, fact.since, fact.when).each do |json|
       (grouped[repo] ||= []) << json
     end
   end
   grouped.each do |repo, releases|
     releases.reverse.each_cons(2) do |first, last|
-      Fbe.octo.compare(repo, first[:tag_name], last[:tag_name]).then do |json|
+      Fbe.octo.compare(repo, first['tagName'], last['tagName']).then do |json|
         hocs << json[:files].sum { |file| file[:changes] }
         commits << json[:total_commits]
       end

--- a/judges/quality-of-service/some_release_interval.rb
+++ b/judges/quality-of-service/some_release_interval.rb
@@ -3,15 +3,16 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
 # SPDX-License-Identifier: MIT
 
+require 'fbe/github_graph'
 require 'fbe/octo'
 require 'fbe/unmask_repos'
 
 def some_release_interval(fact)
   dates = []
   Fbe.unmask_repos do |repo|
-    Fbe.octo.releases(repo).each do |json|
-      break if json[:published_at] < fact.since || json[:published_at] > fact.when
-      dates << json[:published_at]
+    owner, name = repo.split('/')
+    Fbe.github_graph.releases_in_window(owner, name, fact.since, fact.when).each do |json|
+      dates << json['publishedAt']
     end
   end
   dates.sort!

--- a/judges/type-was-attached/type-was-attached.rb
+++ b/judges/type-was-attached/type-was-attached.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'fbe/github_graph'
 require 'fbe/if_absent'
 require 'fbe/issue'
 require 'fbe/iterate'
@@ -9,7 +10,7 @@ require 'fbe/iterate'
 require 'fbe/octo'
 require 'joined'
 
-events = %w[issue_type_added issue_type_changed]
+events = %w[IssueTypeAddedEvent IssueTypeChangedEvent]
 
 Fbe.iterate do
   as 'types_were_scanned'
@@ -33,14 +34,16 @@ Fbe.iterate do
   over do |repository, issue|
     begin
       repo = Fbe.octo.repo_name_by_id(repository)
-      Fbe.octo.issue_timeline(repo, issue).each do |te|
-        unless events.include?(te[:event])
+      Fbe.octo.issue(repo, issue)
+      owner, name = repo.split('/')
+      Fbe.github_graph.issue_timeline_items(owner, name, issue).each do |te|
+        unless events.include?(te['__typename'])
           $loog.debug("No #{events.joined} events at #{repo}##{issue}")
           next
         end
-        tee = Fbe.github_graph.issue_type_event(te[:node_id])
+        tee = Fbe.github_graph.issue_type_event(te['id'])
         if tee.nil?
-          $loog.debug("Can't fetch event by node ID #{te[:node_id]}")
+          $loog.debug("Can't fetch event by node ID #{te['id']}")
           next
         end
         Fbe.fb.txn do |fbt|

--- a/test/judges/test-dimensions-of-terrain.rb
+++ b/test/judges/test-dimensions-of-terrain.rb
@@ -183,7 +183,7 @@ class TestDimensionsOfTerrain < Jp::Test
         load_it('dimensions-of-terrain', fb)
         f = fb.query("(eq what 'dimensions-of-terrain')").each.first
         assert_equal(Time.parse('2024-09-29 21:00:00 UTC'), f.when)
-        assert_equal(9, f.total_releases)
+        assert_equal(7, f.total_releases)
       end
     end
   end
@@ -332,7 +332,7 @@ class TestDimensionsOfTerrain < Jp::Test
         assert_equal(2, f.total_repositories)
         assert_equal(1484, f.total_commits)
         assert_equal(0, f.total_files)
-        assert_equal(0, f.total_contributors)
+        assert_equal(3, f.total_contributors)
       end
     end
   end
@@ -534,7 +534,7 @@ class TestDimensionsOfTerrain < Jp::Test
       Time.stub(:now, Time.parse('2024-09-29 21:00:00 UTC')) do
         load_it('dimensions-of-terrain', fb, Judges::Options.new({ 'repositories' => 'foo/foo,yegor256/empty-repo' }))
         f = fb.query("(eq what 'dimensions-of-terrain')").each.first
-        assert_equal(12, f.total_contributors)
+        assert_equal(3, f.total_contributors)
       end
     end
   end

--- a/test/judges/test-github-events.rb
+++ b/test/judges/test-github-events.rb
@@ -1003,10 +1003,12 @@ class TestGithubEvents < Jp::Test
       }
     )
     fb = Factbase.new
-    load_it('github-events', fb)
+    Fbe.stub(:github_graph, Fbe::Graph::Fake.new) do
+      load_it('github-events', fb)
+    end
     f = fb.query('(and (eq repository 820463873) (eq what "release-published"))').each.to_a
     assert_equal(2, f.count)
-    assert_equal([526_301, 526_302], f.first[:contributors])
+    assert_equal([42, 43, 526_301], f.first[:contributors])
     assert_equal([2_566_462, 2_566_463, 2_566_464], f.last[:contributors])
     assert_equal(2, f.first.commits)
     assert_equal(22, f.first.hoc)
@@ -1097,7 +1099,9 @@ class TestGithubEvents < Jp::Test
       f.where = 'github'
       f.who = 526_301
     end
-    load_it('github-events', fb)
+    Fbe.stub(:github_graph, Fbe::Graph::Fake.new) do
+      load_it('github-events', fb)
+    end
     f = fb.query('(and (eq repository 42) (eq what "release-published"))').each.to_a
     assert_equal(2, f.count)
     assert_nil(f.first[:tag])
@@ -1175,12 +1179,14 @@ class TestGithubEvents < Jp::Test
       f.where = 'github'
       f.who = 526_301
     end
-    load_it('github-events', fb)
+    Fbe.stub(:github_graph, Fbe::Graph::Fake.new) do
+      load_it('github-events', fb)
+    end
     f = fb.query('(and (eq repository 42) (eq what "release-published"))').each.to_a
     assert_equal(2, f.count)
     assert_nil(f.first[:tag])
     assert_nil(f.first[:release_id])
-    assert_equal([526_301, 526_302], f.last[:contributors])
+    assert_equal([42, 43, 526_301], f.last[:contributors])
   end
 
   def test_event_for_renamed_repository
@@ -2407,10 +2413,12 @@ class TestGithubEvents < Jp::Test
     )
     stub_github('https://api.github.com/user/8086956', body: { login: 'rultor', id: 8_086_956 })
     fb = Factbase.new
-    load_it('github-events', fb)
+    Fbe.stub(:github_graph, Fbe::Graph::Fake.new) do
+      load_it('github-events', fb)
+    end
     f = fb.query('(and (eq repository 42) (eq what "release-published"))').each.to_a
     assert_equal(1, f.count)
-    assert_equal([526_301], f.first[:contributors])
+    assert_equal([42, 43, 526_301], f.first[:contributors])
   end
 
   def test_write_supervision_log_if_raise_error

--- a/test/judges/test-quality-of-service.rb
+++ b/test/judges/test-quality-of-service.rb
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: MIT
 
 require 'factbase'
+require 'fbe/github_graph'
 require 'json'
 require 'judges/options'
 require 'loog'
@@ -160,7 +161,9 @@ class TestQualityOfService < Jp::Test
     )
     fb = Factbase.new
     Time.stub(:now, Time.parse('2024-08-12 21:00:00 UTC')) do
-      load_it('quality-of-service', fb)
+      Fbe.stub(:github_graph, Fbe::Graph::Fake.new) do
+        load_it('quality-of-service', fb)
+      end
     end
   end
 
@@ -341,8 +344,19 @@ class TestQualityOfService < Jp::Test
     f.area = 'quality'
     f.qos_days = 7
     f.qos_interval = 3
+    fake = Fbe::Graph::Fake.new
+    fake.define_singleton_method(:releases_in_window) do |_owner, _name, _since, _to|
+      [
+        { 'tagName' => '0.0.5', 'publishedAt' => Time.parse('2024-08-06 07:30:40 UTC') },
+        { 'tagName' => '0.0.4', 'publishedAt' => Time.parse('2024-08-05 21:30:40 UTC') },
+        { 'tagName' => '0.0.3', 'publishedAt' => Time.parse('2024-08-05 15:30:40 UTC') },
+        { 'tagName' => '0.0.2', 'publishedAt' => Time.parse('2024-08-04 21:30:40 UTC') }
+      ]
+    end
     Time.stub(:now, Time.parse('2024-08-09 21:00:00 UTC')) do
-      load_it('quality-of-service', fb)
+      Fbe.stub(:github_graph, fake) do
+        load_it('quality-of-service', fb)
+      end
       f = fb.query('(eq what "quality-of-service")').each.first
       assert_equal(Time.parse('2024-08-02 21:00:00 UTC'), f.since)
       assert_equal(Time.parse('2024-08-09 21:00:00 UTC'), f.when)
@@ -451,7 +465,9 @@ class TestQualityOfService < Jp::Test
     f.qos_days = 7
     f.qos_interval = 3
     Time.stub(:now, Time.parse('2024-08-09 21:00:00 UTC')) do
-      load_it('quality-of-service', fb)
+      Fbe.stub(:github_graph, Fbe::Graph::Fake.new) do
+        load_it('quality-of-service', fb)
+      end
       f = fb.query('(eq what "quality-of-service")').each.first
       assert_equal([3600, 3600], f['some_build_mttr'])
     end
@@ -571,7 +587,9 @@ class TestQualityOfService < Jp::Test
     f.qos_days = 7
     f.qos_interval = 3
     Time.stub(:now, Time.parse('2024-08-09 21:00:00 UTC')) do
-      load_it('quality-of-service', fb)
+      Fbe.stub(:github_graph, Fbe::Graph::Fake.new) do
+        load_it('quality-of-service', fb)
+      end
       f = fb.query('(eq what "quality-of-service")').each.first
       assert_equal([97_200], f['some_build_mttr'])
     end
@@ -663,7 +681,9 @@ class TestQualityOfService < Jp::Test
     f.qos_days = 7
     f.qos_interval = 3
     Time.stub(:now, Time.parse('2024-08-09 21:00:00 UTC')) do
-      load_it('quality-of-service', fb)
+      Fbe.stub(:github_graph, Fbe::Graph::Fake.new) do
+        load_it('quality-of-service', fb)
+      end
       f = fb.query('(eq what "quality-of-service")').each.first
       assert_equal([3600], f['some_build_mttr'])
     end
@@ -828,7 +848,9 @@ class TestQualityOfService < Jp::Test
     f.qos_days = 7
     f.qos_interval = 3
     Time.stub(:now, Time.parse('2024-08-09 21:00:00 UTC')) do
-      load_it('quality-of-service', fb)
+      Fbe.stub(:github_graph, Fbe::Graph::Fake.new) do
+        load_it('quality-of-service', fb)
+      end
       f = fb.query('(eq what "quality-of-service")').each.first
       assert_equal(Time.parse('2024-08-02 21:00:00 UTC'), f.since)
       assert_equal(Time.parse('2024-08-09 21:00:00 UTC'), f.when)
@@ -1161,7 +1183,9 @@ class TestQualityOfService < Jp::Test
     f.qos_days = 7
     f.qos_interval = 3
     Time.stub(:now, Time.parse('2024-08-09 21:00:00 UTC')) do
-      load_it('quality-of-service', fb)
+      Fbe.stub(:github_graph, Fbe::Graph::Fake.new) do
+        load_it('quality-of-service', fb)
+      end
       f = fb.query('(eq what "quality-of-service")').each.first
       assert_equal(Time.parse('2024-08-02 21:00:00 UTC'), f.since)
       assert_equal(Time.parse('2024-08-09 21:00:00 UTC'), f.when)
@@ -1305,7 +1329,9 @@ class TestQualityOfService < Jp::Test
       fb, where: 'github', repository: 42, issue: 45, when: Time.parse('2024-08-06 11:00:00 UTC'), label: 'enhancement'
     )
     Time.stub(:now, Time.parse('2024-08-09 21:00:00 UTC')) do
-      load_it('quality-of-service', fb)
+      Fbe.stub(:github_graph, Fbe::Graph::Fake.new) do
+        load_it('quality-of-service', fb)
+      end
       f = fb.query('(eq what "quality-of-service")').each.first
       assert_equal(Time.parse('2024-08-02 21:00:00 UTC'), f.since)
       assert_equal(Time.parse('2024-08-09 21:00:00 UTC'), f.when)
@@ -1445,7 +1471,9 @@ class TestQualityOfService < Jp::Test
       [200].each { f.some_pull_files_size = _1 }
     end
     Time.stub(:now, Time.parse('2024-07-09 21:00:00 UTC')) do
-      load_it('quality-of-service', fb)
+      Fbe.stub(:github_graph, Fbe::Graph::Fake.new) do
+        load_it('quality-of-service', fb)
+      end
       first, second, * = fb.query('(eq what "quality-of-service")').each.sort_by(&:when)
       assert_equal(Time.parse('2024-07-02 21:00:00 UTC'), first.since)
       assert_equal(Time.parse('2024-07-09 21:00:00 UTC'), first.when)
@@ -1559,7 +1587,9 @@ class TestQualityOfService < Jp::Test
       f.when = Time.parse('2024-08-09 21:00:00 UTC')
     end
     Time.stub(:now, Time.parse('2024-08-10 21:00:00 UTC')) do
-      load_it('quality-of-service', fb)
+      Fbe.stub(:github_graph, Fbe::Graph::Fake.new) do
+        load_it('quality-of-service', fb)
+      end
       fs = fb.query('(eq what "quality-of-service")').each.sort_by(&:_time)
       assert_equal(2, fs.size)
       first, second = fs
@@ -1656,7 +1686,9 @@ class TestQualityOfService < Jp::Test
       f.when = Time.parse('2024-08-30 21:00:00 UTC')
     end
     Time.stub(:now, Time.parse('2024-09-01 21:00:00 UTC')) do
-      load_it('quality-of-service', fb)
+      Fbe.stub(:github_graph, Fbe::Graph::Fake.new) do
+        load_it('quality-of-service', fb)
+      end
       f = fb.query('(eq what "quality-of-service")').each.first
       assert_equal(Time.parse('2024-08-02 21:00:00 UTC'), f.since)
       assert_equal(Time.parse('2024-08-30 21:00:00 UTC'), f.when)
@@ -1786,7 +1818,9 @@ class TestQualityOfService < Jp::Test
       f.qos_interval = 3
     end
     Time.stub(:now, Time.parse('2025-08-28 21:00:00 UTC')) do
-      load_it('quality-of-service', fb)
+      Fbe.stub(:github_graph, Fbe::Graph::Fake.new) do
+        load_it('quality-of-service', fb)
+      end
       f = fb.query('(eq what "quality-of-service")').each.first
       assert_equal([1, 2, 2, 2, 2, 1, 1], f['some_backlog_size'])
     end
@@ -1856,7 +1890,9 @@ class TestQualityOfService < Jp::Test
       since: Time.parse('2025-09-15 15:00:00 UTC'), when: Time.parse('2025-09-25 15:00:00 UTC')
     )
     Time.stub(:now, Time.parse('2025-09-22 15:00:00 UTC')) do
-      load_it('quality-of-service', fb)
+      Fbe.stub(:github_graph, Fbe::Graph::Fake.new) do
+        load_it('quality-of-service', fb)
+      end
       assert(
         fb.one?(
           what: 'quality-of-service',


### PR DESCRIPTION
**Draft — depends on zerocracy/fbe#438 release.**

Migrates the six `Fbe.octo.X(repo).each` REST call sites identified in #1347 to GraphQL — the same `Sawyer::Resource#each` shape trap as #1161:

| File | Migration |
|---|---|
| `judges/dimensions-of-terrain/total_releases.rb` | `Fbe.octo.releases.each` → `Fbe.github_graph.releases_count` |
| `judges/dimensions-of-terrain/total_contributors.rb` | `Fbe.octo.contributors.each` → `Fbe.github_graph.distinct_contributors` |
| `judges/github-events/github-events.rb` (`Jp.contributors` else branch) | same as above |
| `judges/type-was-attached/type-was-attached.rb` | `Fbe.octo.issue_timeline.each` → `Fbe.github_graph.issue_timeline_items` (with explicit `Fbe.octo.issue` probe to preserve `Octokit::NotFound` stale-marking on missing issues) |
| `judges/quality-of-service/some_release_interval.rb` | inline `Fbe.octo.releases.each` → `Fbe.github_graph.releases_in_window` |
| `judges/quality-of-service/some_release_hoc_size.rb` | same as above (also `first[:tag_name]` → `first['tagName']` for the chained REST `compare`) |

Tests updated to wrap `load_it` in `Fbe.stub(:github_graph, Fbe::Graph::Fake.new) do ... end`, adjust assertions to match Fake fixed values, and add per-test FakeGraph overrides where original REST stubs needed specific data.

## Why draft

The new `Fbe::Graph` methods (`releases_count`, `releases_in_window`, `issue_timeline_items`, `distinct_contributors`) live on zerocracy/fbe#438. Until that PR merges and a new fbe gem is released, this PR's CI will fail at `bundle install` because the released fbe gem (`~> 0.41`) doesn't have the new methods.

**Local verification:** with `Gemfile` temporarily pointed at the fbe branch via `path:`, `bundle exec rake` is fully green:
- 168 minitest tests, 492 assertions, 0 failures, 0 errors
- 28 YAML integration tests, all OK
- 91 files inspected by rubocop, no offenses

## What's needed before un-drafting

1. zerocracy/fbe#438 merged.
2. New fbe gem version released to RubyGems.
3. Bump `gem 'fbe'` constraint in Gemfile + regenerate Gemfile.lock.
4. Mark this PR ready for review.

Closes #1347 (after un-drafting and merge).