### PR TITLE
#1349: fix NoMethodError in fetch_workflows for check runs with nil app

### DIFF
--- a/lib/pull_request.rb
+++ b/lib/pull_request.rb
@@ -47,7 +47,7 @@ def Jp.fetch_workflows(pr, repo: nil)
   repo = pr.dig(:base, :repo, :full_name) if repo.nil?
   return {} if repo.nil?
   Fbe.octo.check_runs_for_ref(repo, pr.dig(:head, :sha))[:check_runs].each do |run|
-    next unless run[:app][:slug] == 'github-actions'
+    next unless run.dig(:app, :slug) == 'github-actions'
     workflow = Fbe.octo.workflow_run(repo, Fbe.octo.workflow_run_job(repo, run[:id])[:run_id])
     next unless workflow[:event] == 'pull_request'
     case workflow[:conclusion]

--- a/test/lib/test_pull_request.rb
+++ b/test/lib/test_pull_request.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+# SPDX-License-Identifier: MIT
+
+require_relative '../../lib/pull_request'
+require_relative '../test__helper'
+
+class TestPullRequest < Jp::Test
+  def test_fetch_workflows_skips_check_runs_with_nil_app
+    WebMock.disable_net_connect!
+    rate_limit_up
+    pr = { base: { repo: { full_name: 'foo/foo' } }, head: { sha: 'abc123' } }
+    stub_github(
+      'https://api.github.com/repos/foo/foo/commits/abc123/check-runs?per_page=100',
+      body: {
+        total_count: 3,
+        check_runs: [
+          { id: 1, app: nil },
+          { id: 2, app: { slug: 'other-app' } },
+          { id: 3, app: { slug: 'github-actions' } }
+        ]
+      }
+    )
+    stub_github('https://api.github.com/repos/foo/foo/actions/jobs/3', body: { id: 3, run_id: 99 })
+    stub_github(
+      'https://api.github.com/repos/foo/foo/actions/runs/99',
+      body: { id: 99, event: 'pull_request', conclusion: 'success' }
+    )
+    $options = Judges::Options.new({})
+    $global = {}
+    $loog = Loog::NULL
+    result = Jp.fetch_workflows(pr)
+    assert_equal({ succeeded_builds: 1, failed_builds: 0 }, result)
+  end
+end


### PR DESCRIPTION
Closes #1349.

## Summary
- `Jp.fetch_workflows` in `lib/pull_request.rb` called `run[:app][:slug]` directly, which raised `NoMethodError: undefined method '[]' for nil` for check runs whose `app` is `nil` (GitHub returns `app: null` for required status checks not associated with a GitHub App).
- Changed to `run.dig(:app, :slug)` so such check runs are silently skipped, as already intended by the surrounding `next unless ... == 'github-actions'` filter.

## Test plan
- Added `test/lib/test_pull_request.rb` covering three check runs in one response: one with `app: nil`, one with `app.slug: 'other-app'`, and one with `app.slug: 'github-actions'`. Asserts the helper returns `{succeeded_builds: 1, failed_builds: 0}` without raising.
- Verified the new test fails on master with the same `NoMethodError` from the issue, and passes after the fix.
- `bundle exec rake test` — 169 tests, 0 failures.
- `bundle exec rubocop lib/pull_request.rb test/lib/test_pull_request.rb` — clean.