### PR TITLE
#1345: fix four metric-correctness bugs in quality-of-service and quantity-of-deliverables

### DIFF
--- a/judges/quality-of-service/some_merged_pulls.rb
+++ b/judges/quality-of-service/some_merged_pulls.rb
@@ -11,7 +11,7 @@ def some_merged_pulls(fact)
   rejected = []
   Fbe.unmask_repos do |repo|
     pulls << Fbe.octo.search_issues(
-      "repo:#{repo} type:pr closed:#{fact.since.utc.iso8601}..#{fact.when.utc.iso8601}"
+      "repo:#{repo} type:pr is:merged closed:#{fact.since.utc.iso8601}..#{fact.when.utc.iso8601}"
     )[:total_count]
     rejected << Fbe.octo.search_issues(
       "repo:#{repo} type:pr is:unmerged closed:#{fact.since.utc.iso8601}..#{fact.when.utc.iso8601}"

--- a/judges/quality-of-service/some_release_hoc_size.rb
+++ b/judges/quality-of-service/some_release_hoc_size.rb
@@ -12,7 +12,8 @@ def some_release_hoc_size(fact)
   commits = []
   Fbe.unmask_repos do |repo|
     Fbe.octo.releases(repo).each do |json|
-      break if json[:published_at] < fact.since || json[:published_at] > fact.when
+      next if json[:published_at] > fact.when
+      break if json[:published_at] < fact.since
       (grouped[repo] ||= []) << json
     end
   end

--- a/judges/quality-of-service/some_release_interval.rb
+++ b/judges/quality-of-service/some_release_interval.rb
@@ -10,7 +10,8 @@ def some_release_interval(fact)
   dates = []
   Fbe.unmask_repos do |repo|
     Fbe.octo.releases(repo).each do |json|
-      break if json[:published_at] < fact.since || json[:published_at] > fact.when
+      next if json[:published_at] > fact.when
+      break if json[:published_at] < fact.since
       dates << json[:published_at]
     end
   end

--- a/judges/quantity-of-deliverables/total_builds_ran.rb
+++ b/judges/quantity-of-deliverables/total_builds_ran.rb
@@ -10,7 +10,11 @@ def total_builds_ran(fact)
   total =
     Fbe.unmask_repos.sum do |repo|
       Fbe.octo.with_disable_auto_paginate do |octo|
-        octo.repository_workflow_runs(repo, created: ">#{fact.since.utc.iso8601[0..9]}", per_page: 1)[:total_count]
+        octo.repository_workflow_runs(
+          repo,
+          created: "#{fact.since.utc.iso8601[0..9]}..#{fact.when.utc.iso8601[0..9]}",
+          per_page: 1
+        )[:total_count]
       end
     end
   { total_builds_ran: total }

--- a/judges/quantity-of-deliverables/total_reviews_submitted.rb
+++ b/judges/quantity-of-deliverables/total_reviews_submitted.rb
@@ -22,10 +22,7 @@ def total_reviews_submitted(fact)
     end
     until queue.empty?
       pulls = Fbe.github_graph.pull_request_reviews(owner, name, pulls: queue.shift(10))
-      total +=
-        pulls.sum do |pull|
-          pull['reviews'].count { |r| r['submitted_at'] > fact.since && r['submitted_at'] <= fact.when }
-        end
+      total += pulls.sum { |pull| pull['reviews'].count { |r| r['submitted_at'] > fact.since } }
       pulls.select { _1['reviews_has_next_page'] }.each do |p|
         queue.push([p['number'], p['reviews_next_cursor']])
       end

--- a/judges/quantity-of-deliverables/total_reviews_submitted.rb
+++ b/judges/quantity-of-deliverables/total_reviews_submitted.rb
@@ -22,7 +22,10 @@ def total_reviews_submitted(fact)
     end
     until queue.empty?
       pulls = Fbe.github_graph.pull_request_reviews(owner, name, pulls: queue.shift(10))
-      total += pulls.sum { |pull| pull['reviews'].count { |r| r['submitted_at'] > fact.since } }
+      total +=
+        pulls.sum do |pull|
+          pull['reviews'].count { |r| r['submitted_at'] > fact.since && r['submitted_at'] <= fact.when }
+        end
       pulls.select { _1['reviews_has_next_page'] }.each do |p|
         queue.push([p['number'], p['reviews_next_cursor']])
       end

--- a/test/judges/test-quality-of-service.rb
+++ b/test/judges/test-quality-of-service.rb
@@ -178,6 +178,15 @@ class TestQualityOfService < Jp::Test
       'https://api.github.com/repos/foo/foo/releases?per_page=100',
       body: [
         {
+          id: 173_480,
+          author: { login: 'yegor256', id: 526_301, type: 'User', site_admin: false },
+          tag_name: '0.0.6', target_commitish: 'master',
+          name: 'Release 6', draft: false, prerelease: false,
+          created_at: Time.parse('2024-08-15 07:30:14 UTC'),
+          published_at: Time.parse('2024-08-15 07:30:40 UTC'),
+          assets: [], body: 'Some description', mentions_count: 4
+        },
+        {
           id: 173_470,
           author: { login: 'yegor256', id: 526_301, type: 'User', site_admin: false },
           tag_name: '0.0.5', target_commitish: 'master',
@@ -1386,6 +1395,11 @@ class TestQualityOfService < Jp::Test
     )
     stub_github(
       'https://api.github.com/search/issues?per_page=100&' \
+      'q=repo:foo/foo%20type:pr%20is:merged%20closed:2024-07-02T22:00:00Z..2024-07-09T22:00:00Z',
+      body: { total_count: 0, incomplete_results: false, items: [] }
+    )
+    stub_github(
+      'https://api.github.com/search/issues?per_page=100&' \
       'q=repo:foo/foo%20type:pr%20is:unmerged%20closed:2024-07-02T22:00:00Z..2024-07-09T22:00:00Z',
       body: { total_count: 0, incomplete_results: false, items: [] }
     )
@@ -1512,6 +1526,19 @@ class TestQualityOfService < Jp::Test
     )
     stub_github(
       'https://api.github.com/search/issues?per_page=100&' \
+      'q=repo:foo/foo%20type:pr%20is:merged%20closed:2024-08-02T21:00:00Z..2024-08-09T21:00:00Z',
+      body: {
+        total_count: 1, incomplete_results: false,
+        items: [
+          {
+            id: 50, number: 12, title: 'Awesome 12',
+            pull_request: { merged_at: Time.parse('2024-08-23 18:30:00 UTC') }
+          }
+        ]
+      }
+    )
+    stub_github(
+      'https://api.github.com/search/issues?per_page=100&' \
       'q=repo:foo/foo%20type:issue%20created:2024-08-02T21:00:00Z..2024-08-09T21:00:00Z',
       body: { total_count: 0, incomplete_results: false, items: [] }
     )
@@ -1575,7 +1602,7 @@ class TestQualityOfService < Jp::Test
       assert_nil(second['some_triage_time'])
       refute_nil(second['some_backlog_size'])
       assert_nil(second['some_release_interval'])
-      assert_equal([2], second['some_merged_pulls'])
+      assert_equal([1], second['some_merged_pulls'])
       assert_equal([1], second['some_unmerged_pulls'])
       assert_nil(second['some_issue_lifetime'])
       assert_nil(second['some_pull_lifetime'])

--- a/test/judges/test-quantity-of-deliverables.rb
+++ b/test/judges/test-quantity-of-deliverables.rb
@@ -23,7 +23,7 @@ class TestQuantityOfDeliverables < Jp::Test
       body: { id: 42, full_name: 'foo/foo', open_issues: 0, size: 10 }
     )
     stub_github(
-      'https://api.github.com/repos/foo/foo/actions/runs?created=%3E2024-07-11&per_page=1',
+      'https://api.github.com/repos/foo/foo/actions/runs?created=2024-07-11..2024-08-12&per_page=1',
       body: { total_count: 0, workflow_runs: [] }
     )
     fb = Factbase.new
@@ -49,7 +49,7 @@ class TestQuantityOfDeliverables < Jp::Test
       body: { id: 42, full_name: 'foo/foo', open_issues: 0, size: 0 }
     )
     stub_github(
-      'https://api.github.com/repos/foo/foo/actions/runs?created=%3E2024-07-11&per_page=1',
+      'https://api.github.com/repos/foo/foo/actions/runs?created=2024-07-11..2024-08-12&per_page=1',
       body: { total_count: 0, workflow_runs: [] }
     )
     fb = Factbase.new
@@ -75,7 +75,7 @@ class TestQuantityOfDeliverables < Jp::Test
       body: { id: 42, full_name: 'foo/foo', open_issues: 0, size: 100 }
     )
     stub_github(
-      'https://api.github.com/repos/foo/foo/actions/runs?created=%3E2024-08-02&per_page=1',
+      'https://api.github.com/repos/foo/foo/actions/runs?created=2024-08-02..2024-08-09&per_page=1',
       body: { total_count: 0, workflow_runs: [] }
     )
     fb = Factbase.new
@@ -104,7 +104,7 @@ class TestQuantityOfDeliverables < Jp::Test
       body: { id: 42, full_name: 'foo/foo', open_issues: 0, size: 100 }
     )
     stub_github(
-      'https://api.github.com/repos/foo/foo/actions/runs?created=%3E2024-08-02&per_page=1',
+      'https://api.github.com/repos/foo/foo/actions/runs?created=2024-08-02..2024-08-09&per_page=1',
       body: {
         total_count: 0,
         workflow_runs: []
@@ -121,7 +121,7 @@ class TestQuantityOfDeliverables < Jp::Test
         f = fb.query('(eq what "quantity-of-deliverables")').each.first
         assert_equal(Time.parse('2024-08-03 00:00:00 +03:00'), f.since)
         assert_equal(Time.parse('2024-08-09 21:00:00 UTC'), f.when)
-        assert_equal(4, f.total_reviews_submitted)
+        assert_equal(0, f.total_reviews_submitted)
       end
     end
   end
@@ -136,7 +136,7 @@ class TestQuantityOfDeliverables < Jp::Test
       body: { id: 42, full_name: 'foo/foo', open_issues: 0, size: 100 }
     )
     stub_github(
-      'https://api.github.com/repos/foo/foo/actions/runs?created=%3E2024-08-02&per_page=1',
+      'https://api.github.com/repos/foo/foo/actions/runs?created=2024-08-02..2024-08-09&per_page=1',
       body: {
         total_count: 3,
         workflow_runs: [
@@ -175,9 +175,13 @@ class TestQuantityOfDeliverables < Jp::Test
       'https://api.github.com/repos/foo/foo',
       body: { id: 42, full_name: 'foo/foo', open_issues: 0, size: 100 }
     )
-    %w[2025-09-01 2025-09-05 2025-09-15].each do |date|
+    [
+      %w[2025-09-01 2025-09-05],
+      %w[2025-09-05 2025-09-15],
+      %w[2025-09-15 2025-09-25]
+    ].each do |since, whn|
       stub_github(
-        "https://api.github.com/repos/foo/foo/actions/runs?created=%3E#{date}&per_page=1",
+        "https://api.github.com/repos/foo/foo/actions/runs?created=#{since}..#{whn}&per_page=1",
         body: {
           total_count: 0,
           workflow_runs: []

--- a/test/judges/test-quantity-of-deliverables.rb
+++ b/test/judges/test-quantity-of-deliverables.rb
@@ -121,7 +121,7 @@ class TestQuantityOfDeliverables < Jp::Test
         f = fb.query('(eq what "quantity-of-deliverables")').each.first
         assert_equal(Time.parse('2024-08-03 00:00:00 +03:00'), f.since)
         assert_equal(Time.parse('2024-08-09 21:00:00 UTC'), f.when)
-        assert_equal(0, f.total_reviews_submitted)
+        assert_equal(4, f.total_reviews_submitted)
       end
     end
   end
@@ -179,9 +179,9 @@ class TestQuantityOfDeliverables < Jp::Test
       %w[2025-09-01 2025-09-05],
       %w[2025-09-05 2025-09-15],
       %w[2025-09-15 2025-09-25]
-    ].each do |since, whn|
+    ].each do |since, upper|
       stub_github(
-        "https://api.github.com/repos/foo/foo/actions/runs?created=#{since}..#{whn}&per_page=1",
+        "https://api.github.com/repos/foo/foo/actions/runs?created=#{since}..#{upper}&per_page=1",
         body: {
           total_count: 0,
           workflow_runs: []


### PR DESCRIPTION
Closes #1345 (partially — bug 5 deferred, see below).

Addresses four of the five bugs listed by @vitaly-andr. Fixing forward only as @yegor256 requested in the issue thread (no backfill of past slices).

## Fixes

1. **`some_merged_pulls` counted all closed PRs, not merged.** `judges/quality-of-service/some_merged_pulls.rb` — added `is:merged` to the search query, mirroring the `is:unmerged` filter used by the companion `some_unmerged_pulls`.

2. **`some_release_interval` skipped in-window releases when the newest was past `fact.when`.** `judges/quality-of-service/some_release_interval.rb` — changed the loop to `next` for releases newer than `fact.when` and `break` only when older than `fact.since` (releases come newest-first).

3. **Same break-on-newest-first bug in `some_release_hoc_size`.** Same fix in `judges/quality-of-service/some_release_hoc_size.rb`.

4. **`total_builds_ran` ignored slice end.** `judges/quantity-of-deliverables/total_builds_ran.rb` — switched the query from `created:>SINCE` to `created:SINCE..WHEN` so backfilled slices stop accumulating future builds.

## Bug 5 deferred

I prepared the same upper-bound fix for `total_reviews_submitted` (`r['submitted_at'] <= fact.when`), but it breaks the integration test `judges/quantity-of-deliverables/count-all.yml`. That test asserts `total_reviews_submitted != 0` against `Fbe::Graph::Fake`, whose review fixtures are dated `2025-10-XX` while the test's slice is `2023-12-25..2024-01-01` — the fix correctly excludes them, leaving the count at 0 and failing the assertion. The proper fix needs either updated fake data in `fbe`, or a slice adjustment in `count-all.yml`. Happy to follow up in a separate PR once we agree on the path.

## Test plan
- [x] Adapted existing tests in `test/judges/test-quality-of-service.rb` and `test/judges/test-quantity-of-deliverables.rb` to the corrected behaviour.
- [x] In `test_quality_of_service_some_release_hocs_size_and_commits_size` added a Release `0.0.6` published past `fact.when`. Without the fix the test fails (`Expected: [52, 24, 99], Actual: nil` because the old `break` on the newest release abandoned the in-window ones); with the fix it passes — locking in regression coverage for bugs 2 and 3.
- [x] `bundle exec rake test` — 168 tests, 0 failures.
- [x] `bundle exec rake judges` — all 28 judges and 59 integration tests pass.
- [x] `bundle exec rubocop` on all changed files — clean.