### PR TITLE
Fix NoMethodError in Jp.fetch_workflows when check run has nil app

### DIFF
--- a/lib/pull_request.rb
+++ b/lib/pull_request.rb
@@ -47,7 +47,7 @@ def Jp.fetch_workflows(pr, repo: nil)
   repo = pr.dig(:base, :repo, :full_name) if repo.nil?
   return {} if repo.nil?
   Fbe.octo.check_runs_for_ref(repo, pr.dig(:head, :sha))[:check_runs].each do |run|
-    next unless run[:app][:slug] == 'github-actions'
+    next unless run.dig(:app, :slug) == 'github-actions'
     workflow = Fbe.octo.workflow_run(repo, Fbe.octo.workflow_run_job(repo, run[:id])[:run_id])
     next unless workflow[:event] == 'pull_request'
     case workflow[:conclusion]

--- a/test/lib/test_pull_request.rb
+++ b/test/lib/test_pull_request.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+# SPDX-License-Identifier: MIT
+
+require 'fbe/octo'
+require_relative '../../lib/pull_request'
+require_relative '../test__helper'
+
+class TestPullRequest < Jp::Test
+  def test_fetch_workflows_skips_check_runs_with_nil_app
+    WebMock.disable_net_connect!
+    rate_limit_up
+    $options = Judges::Options.new({})
+    $global = {}
+    $loog = Loog::NULL
+    pr = { number: 44, head: { sha: 'aa123' }, base: { repo: { full_name: 'foo/foo' } } }
+    stub_github(
+      'https://api.github.com/repos/foo/foo/commits/aa123/check-runs?per_page=100',
+      body: {
+        check_runs: [
+          { id: 1, app: nil },
+          { id: 2, app: { slug: 'some-other-app' } }
+        ]
+      }
+    )
+    result = Jp.fetch_workflows(pr)
+    assert_equal({ succeeded_builds: 0, failed_builds: 0 }, result)
+  end
+
+  def test_fetch_workflows_counts_github_actions_runs
+    WebMock.disable_net_connect!
+    rate_limit_up
+    $options = Judges::Options.new({})
+    $global = {}
+    $loog = Loog::NULL
+    pr = { number: 55, head: { sha: 'bb456' }, base: { repo: { full_name: 'foo/foo' } } }
+    stub_github(
+      'https://api.github.com/repos/foo/foo/commits/bb456/check-runs?per_page=100',
+      body: {
+        check_runs: [
+          { id: 1, app: nil },
+          { id: 2, app: { slug: 'github-actions' } }
+        ]
+      }
+    )
+    stub_github('https://api.github.com/repos/foo/foo/actions/jobs/2', body: { id: 2, run_id: 9001 })
+    stub_github(
+      'https://api.github.com/repos/foo/foo/actions/runs/9001',
+      body: { id: 9001, event: 'pull_request', conclusion: 'success' }
+    )
+    result = Jp.fetch_workflows(pr)
+    assert_equal({ succeeded_builds: 1, failed_builds: 0 }, result)
+  end
+end


### PR DESCRIPTION
@yegor256 ready for review.

Fixes #1349.

## Summary

`Jp.fetch_workflows` in `lib/pull_request.rb` crashed with `NoMethodError: undefined method '[]' for nil` whenever the GitHub Check Runs API returned a check run with `app: null` (which happens for required status checks not associated with a GitHub App). The crash propagated up through any judge that calls `fetch_workflows` — including `pull-was-merged` and `github-events` — and aborted processing of an otherwise healthy pull request.

Root cause: line 50 dereferenced the `app` hash unguarded:

```ruby
next unless run[:app][:slug] == 'github-actions'
```

Fix: switch to `Hash#dig`, which yields `nil` (and therefore safely fails the equality check) when `app` is absent:

```ruby
next unless run.dig(:app, :slug) == 'github-actions'
```

## Tests

Added `test/lib/test_pull_request.rb` with two unit tests:

- `test_fetch_workflows_skips_check_runs_with_nil_app` — feeds a `check_runs` payload containing one run with `app: nil` and one with a non-`github-actions` slug. Without the fix this raises the exact `NoMethodError` from the issue; with the fix it returns `{ succeeded_builds: 0, failed_builds: 0 }`.
- `test_fetch_workflows_counts_github_actions_runs` — happy-path regression: a `github-actions` run alongside a `nil`-app run is still counted (and the `nil` one is skipped).

Locally: `bundle exec rake test rubocop` is green (170 tests, 494 assertions, 0 failures, 0 offenses). All CI checks on this PR have also passed.