### PR TITLE
#1354: add upper bound to total_reviews_submitted

### DIFF
--- a/judges/quantity-of-deliverables/count-all.yml
+++ b/judges/quantity-of-deliverables/count-all.yml
@@ -3,7 +3,7 @@
 ---
 runs: 3
 options:
-  TODAY: 2024-03-03T00:00:00
+  TODAY: 2025-10-11T00:00:00
   repositories: yegor256/judges
   testing: true
 input:
@@ -13,8 +13,8 @@ input:
     qod_days: 7
   -
     what: quantity-of-deliverables
-    since: 2023-12-25T00:00:00
-    when: 2024-01-01T00:00:00
+    since: 2025-09-25T00:00:00
+    when: 2025-10-01T00:00:00
 expected:
   - /fb[count(f)=3]
   - /fb/f[what='quantity-of-deliverables']

--- a/judges/quantity-of-deliverables/total_reviews_submitted.rb
+++ b/judges/quantity-of-deliverables/total_reviews_submitted.rb
@@ -22,7 +22,8 @@ def total_reviews_submitted(fact)
     end
     until queue.empty?
       pulls = Fbe.github_graph.pull_request_reviews(owner, name, pulls: queue.shift(10))
-      total += pulls.sum { |pull| pull['reviews'].count { |r| r['submitted_at'] > fact.since } }
+      window = ->(r) { r['submitted_at'] > fact.since && r['submitted_at'] <= fact.when }
+      total += pulls.sum { |p| p['reviews'].count(&window) }
       pulls.select { _1['reviews_has_next_page'] }.each do |p|
         queue.push([p['number'], p['reviews_next_cursor']])
       end

--- a/test/judges/test-quantity-of-deliverables.rb
+++ b/test/judges/test-quantity-of-deliverables.rb
@@ -104,7 +104,7 @@ class TestQuantityOfDeliverables < Jp::Test
       body: { id: 42, full_name: 'foo/foo', open_issues: 0, size: 100 }
     )
     stub_github(
-      'https://api.github.com/repos/foo/foo/actions/runs?created=2024-08-02..2024-08-09&per_page=1',
+      'https://api.github.com/repos/foo/foo/actions/runs?created=2025-09-29..2025-10-06&per_page=1',
       body: {
         total_count: 0,
         workflow_runs: []
@@ -116,12 +116,47 @@ class TestQuantityOfDeliverables < Jp::Test
     f.area = 'scope'
     f.qod_days = 7
     Fbe.stub(:github_graph, Fbe::Graph::Fake.new) do
-      Time.stub(:now, Time.parse('2024-08-09 21:00:00 UTC')) do
+      Time.stub(:now, Time.parse('2025-10-06 21:00:00 UTC')) do
         load_it('quantity-of-deliverables', fb)
         f = fb.query('(eq what "quantity-of-deliverables")').each.first
-        assert_equal(Time.parse('2024-08-03 00:00:00 +03:00'), f.since)
-        assert_equal(Time.parse('2024-08-09 21:00:00 UTC'), f.when)
+        assert_equal(Time.parse('2025-09-30 00:00:00 +03:00'), f.since)
+        assert_equal(Time.parse('2025-10-06 21:00:00 UTC'), f.when)
         assert_equal(4, f.total_reviews_submitted)
+      end
+    end
+  end
+
+  def test_quantity_of_deliverables_total_reviews_submitted_excludes_after_when
+    WebMock.disable_net_connect!
+    stub_request(:get, 'https://api.github.com/rate_limit').to_return(
+      { body: '{"rate":{"remaining":222}}', headers: { 'X-RateLimit-Remaining' => '222' } }
+    )
+    stub_github(
+      'https://api.github.com/repos/foo/foo',
+      body: { id: 42, full_name: 'foo/foo', open_issues: 0, size: 100 }
+    )
+    stub_github(
+      'https://api.github.com/repos/foo/foo/actions/runs?created=2025-09-26..2025-10-03&per_page=1',
+      body: {
+        total_count: 0,
+        workflow_runs: []
+      }
+    )
+    fb = Factbase.new
+    f = fb.insert
+    f.what = 'pmp'
+    f.area = 'scope'
+    f.qod_days = 7
+    Fbe.stub(:github_graph, Fbe::Graph::Fake.new) do
+      Time.stub(:now, Time.parse('2025-10-03 00:00:00 UTC')) do
+        load_it('quantity-of-deliverables', fb)
+        f = fb.query('(eq what "quantity-of-deliverables")').each.first
+        assert_equal(
+          2, f.total_reviews_submitted,
+          'reviews submitted on 2025-10-03 15:58:42 UTC and 2025-10-04 15:58:42 UTC ' \
+          'must be excluded (after fact.when 2025-10-03 00:00:00 UTC); ' \
+          'only the two 2025-10-02 reviews should be counted'
+        )
       end
     end
   end


### PR DESCRIPTION
Closes #1354.

Originally identified as bug 5 in #1345; the fix was reverted in #1351 because it broke `judges/quantity-of-deliverables/count-all.yml`. This PR completes the fix.

## Code change

In `judges/quantity-of-deliverables/total_reviews_submitted.rb`, reviews are now filtered by both bounds of the slice (`fact.since < submitted_at <= fact.when`). Without the upper bound, reviews submitted after the slice were counted in it, inflating the metric for any past time window.

## Integration-test fix

The `count-all.yml` integration test runs on a 2024 window, but the fake review data in `fbe` is dated 2025-10. With a correct upper bound, all fake reviews would be excluded and `/fb/f[total_reviews_submitted != 0]` would fail.

The window is shifted to 2025-09-25..2025-10-01 with `TODAY=2025-10-11`, so that `cover_qo` produces a gap-fill slice (2025-10-01..2025-10-11) that does include the fake reviews.

## Regression test

`test_quantity_of_deliverables_total_reviews_submitted_excludes_after_when` exercises a slice ending mid-fake-review-window (`fact.when = 2025-10-03 00:00 UTC`) and asserts that only the two reviews from 2025-10-02 are counted, not the ones from 2025-10-03/04. Verified via mutation: removing the `<= fact.when` clause makes this test fail.