### PR TITLE
#1357: rescue NotFound/Forbidden around Fbe.octo.pull_request in code-was-reviewed

### DIFF
--- a/judges/code-was-reviewed/code-was-reviewed.rb
+++ b/judges/code-was-reviewed/code-was-reviewed.rb
@@ -29,7 +29,20 @@ Fbe.consider(
         (eq what '#{$judge}'))))"
 ) do |f|
   repo = Fbe.octo.repo_name_by_id(f.repository)
-  pr = Fbe.octo.pull_request(repo, f.issue)
+  pr =
+    begin
+      Fbe.octo.pull_request(repo, f.issue)
+    rescue Octokit::NotFound, Octokit::Deprecated => e
+      $loog.info("The pull request ##{f.issue} doesn't exist in #{repo}: #{e.message}")
+      Jp.issue_was_lost(f.where, f.repository, f.issue)
+      next
+    rescue Octokit::Forbidden => e
+      $loog.warn(
+        "[#{$judge}] Access forbidden to pull ##{f.issue} in #{repo} " \
+        "(transient, will retry next cycle): #{e.class}: #{e.message}"
+      )
+      next
+    end
   reviews =
     begin
       Fbe.octo.pull_request_reviews(repo, f.issue)

--- a/test/judges/test-code-was-reviewed.rb
+++ b/test/judges/test-code-was-reviewed.rb
@@ -67,4 +67,45 @@ class TestCodeWasReviewed < Jp::Test
       )
     )
   end
+
+  def test_rescues_not_found_on_pull_request_lookup
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repositories/42', body: { id: 42, full_name: 'foo/foo' })
+    stub_github(
+      'https://api.github.com/repos/foo/foo/pulls/77',
+      status: 404,
+      body: { message: 'Not Found', documentation_url: 'https://docs.github.com/...' }
+    )
+    fb = Factbase.new
+    fb.with(_id: 1, what: 'pull-was-closed', repository: 42, issue: 77, where: 'github')
+    load_it('code-was-reviewed', fb)
+    assert(
+      fb.one?(what: 'pull-was-closed', repository: 42, issue: 77, stale: 'issue'),
+      'expected the sibling pull-was-closed fact to be marked stale by Jp.issue_was_lost ' \
+      'after the unrescued 404 on Fbe.octo.pull_request'
+    )
+  end
+
+  def test_rescues_forbidden_on_pull_request_lookup
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repositories/42', body: { id: 42, full_name: 'foo/foo' })
+    stub_github(
+      'https://api.github.com/repos/foo/foo/pulls/88',
+      status: 403,
+      body: { message: 'Resource not accessible by integration' }
+    )
+    fb = Factbase.new
+    fb.with(_id: 1, what: 'pull-was-closed', repository: 42, issue: 88, where: 'github')
+    load_it('code-was-reviewed', fb)
+    refute(
+      fb.one?(what: 'issue-was-lost', where: 'github', repository: 42, issue: 88),
+      'forbidden error must not produce an issue-was-lost tombstone'
+    )
+    refute(
+      fb.one?(what: 'pull-was-closed', repository: 42, issue: 88, stale: 'issue'),
+      'forbidden error must leave the original fact untouched'
+    )
+  end
 end


### PR DESCRIPTION
@yegor256 — this PR is ready for merge. All 13 CI checks are green.

Closes #1357.

This PR adds the missing rescue around `Fbe.octo.pull_request(repo, f.issue)` on line 32 of `judges/code-was-reviewed/code-was-reviewed.rb`, mirroring the canonical pattern from `judges/pull-was-merged/pull-was-merged.rb:55-67`.

### What was wrong

The judge already protects the sibling `Fbe.octo.pull_request_reviews(repo, f.issue)` call on line 35 with a `begin/rescue Octokit::NotFound` block that tombstones the deleted PR via `Jp.issue_was_lost`. The `Fbe.octo.pull_request` call on line 32, which can 404 for the **same reason** (PR deleted between scan and review pass), is unprotected — when the PR is gone, line 32 throws `Octokit::NotFound` first, the carefully-written rescue on line 35 is never reached, the tombstone is never written, and the exception propagates out of the `Fbe.consider` block, crashing this judge for the rest of the cycle. The same applies to `Octokit::Forbidden` (private repo / transient permission flap) and `Octokit::Deprecated`.

### Two commits

1. **`#1357: add failing tests for unrescued Fbe.octo.pull_request 404/403 in code-was-reviewed`** — adds two regression tests in `test/judges/test-code-was-reviewed.rb`:
   - `test_rescues_not_found_on_pull_request_lookup` — stubs the `pull_request` endpoint with 404 and asserts the sibling `pull-was-closed` fact is marked `stale: issue` by `Jp.issue_was_lost` (rather than the exception escaping the `Fbe.consider` block).
   - `test_rescues_forbidden_on_pull_request_lookup` — stubs the same endpoint with 403 (`"Resource not accessible by integration"` to avoid the auto-retry path of `Octokit::TooManyRequests`) and asserts that no tombstone is recorded and the original fact is left untouched, since access may return on the next cycle.
   Both tests fail on master with the unrescued `Octokit::NotFound` / `Octokit::Forbidden` propagating up through `Fbe.consider`.

2. **`#1357: rescue NotFound/Deprecated/Forbidden around Fbe.octo.pull_request`** — wraps line 32 in the canonical `begin/rescue` block: `NotFound`/`Deprecated` route to `Jp.issue_was_lost` then `next` (matching the existing rescue on the sibling `pull_request_reviews` call); `Forbidden` is logged at `warn` and skipped without tombstoning, since the access flap is transient.

### Local verification

- `bundle exec ruby -Itest -Ilib test/judges/test-code-was-reviewed.rb` reports 3 tests, 0 failures, 0 errors.
- Full test suite via `Rake.application.invoke_task test`: **175 tests, 503 assertions, 0 failures, 0 errors, 1 skip**.
- Rubocop reports no offences on the two changed files.

### CI

All 13 checks are green: actionlint, bashate, checkmake, copyrights, hadolint, make, pdd, rake, reuse, shellcheck, typos, xcop, yamllint.