### PR TITLE
#1027: filter near-zero some_triage_time values from auto-applied labels

### DIFF
--- a/judges/quality-of-service/some_triage_time.rb
+++ b/judges/quality-of-service/some_triage_time.rb
@@ -5,9 +5,11 @@
 
 require 'fbe/fb'
 require 'fbe/octo'
+require 'fbe/pmp'
 require 'fbe/unmask_repos'
 
 def some_triage_time(fact)
+  threshold = Fbe.pmp.quality.qos_min_triage_seconds.value || 60
   times = []
   Fbe.unmask_repos do |repo|
     Fbe.octo.search_issues(
@@ -27,7 +29,10 @@ def some_triage_time(fact)
           (eq where 'github'))
         "
       ).each.min_by(&:when)
-      times << (ff.when - issue[:created_at]) if ff
+      next unless ff
+      delta = ff.when - issue[:created_at]
+      next if delta < threshold
+      times << delta
     end
   end
   {

--- a/test/judges/test-quality-of-service.rb
+++ b/test/judges/test-quality-of-service.rb
@@ -1286,6 +1286,7 @@ class TestQualityOfService < Jp::Test
       f.area = 'quality'
       f.qos_days = 7
       f.qos_interval = 3
+      f.qos_min_triage_seconds = 60
     end
     insert_label_was_attached_fact(
       fb, where: 'gitlab', repository: 42, issue: 40, when: Time.parse('2024-08-04 11:10:00 UTC'), label: 'bug'
@@ -1319,6 +1320,366 @@ class TestQualityOfService < Jp::Test
       assert_equal(Time.parse('2024-08-02 21:00:00 UTC'), f.since)
       assert_equal(Time.parse('2024-08-09 21:00:00 UTC'), f.when)
       assert_equal([88_200, 7_200, 147_600], f['some_triage_time'])
+    end
+  end
+
+  def test_quality_of_service_some_triage_time_filters_auto_labels
+    WebMock.disable_net_connect!
+    stub_request(:get, 'https://api.github.com/rate_limit').to_return(
+      { body: '{"rate":{"remaining":222}}', headers: { 'X-RateLimit-Remaining' => '222' } }
+    )
+    stub_github('https://api.github.com/repos/foo/foo', body: { id: 42, full_name: 'foo/foo' })
+    stub_github(
+      'https://api.github.com/repos/foo/foo/actions/runs?created=2024-08-02T21:00:00Z..2024-08-09T21:00:00Z&per_page=100',
+      body: { total_count: 0, workflow_runs: [] }
+    )
+    stub_github('https://api.github.com/repos/foo/foo/releases?per_page=100', body: [])
+    stub_github(
+      'https://api.github.com/search/issues?per_page=100&' \
+      'q=repo:foo/foo%20type:issue%20closed:2024-08-02T21:00:00Z..2024-08-09T21:00:00Z',
+      body: { total_count: 0, incomplete_results: false, items: [] }
+    )
+    stub_github(
+      'https://api.github.com/search/issues?per_page=100&q=repo:foo/foo%20type:issue%20closed:%3E2024-08-02',
+      body: { total_count: 0, incomplete_results: false, items: [] }
+    )
+    stub_github(
+      'https://api.github.com/search/issues?per_page=100&' \
+      'q=repo:foo/foo%20type:pr%20closed:2024-08-02T21:00:00Z..2024-08-09T21:00:00Z',
+      body: { total_count: 0, incomplete_results: false, items: [] }
+    )
+    stub_github(
+      'https://api.github.com/search/issues?per_page=100&q=repo:foo/foo%20type:pr%20closed:%3E2024-08-02',
+      body: { total_count: 0, incomplete_results: false, items: [] }
+    )
+    (Date.parse('2024-08-02')..Date.parse('2024-08-09')).each do |date|
+      stub_github(
+        'https://api.github.com/search/issues?advanced_search=true&per_page=100&' \
+        "q=repo:foo/foo%20type:issue%20created:*..#{date}%20(closed:%3E=#{date}%20OR%20state:open)",
+        body: { total_count: 0, items: [] }
+      )
+    end
+    stub_github(
+      'https://api.github.com/search/issues?per_page=100&' \
+      'q=repo:foo/foo%20type:pr%20is:unmerged%20closed:2024-08-02T21:00:00Z..2024-08-09T21:00:00Z',
+      body: { total_count: 0, incomplete_results: false, items: [] }
+    )
+    stub_github(
+      'https://api.github.com/search/issues?per_page=100&' \
+      'q=repo:foo/foo%20type:pr%20is:merged%20closed:2024-08-02T21:00:00Z..2024-08-09T21:00:00Z',
+      body: { total_count: 0, incomplete_results: false, items: [] }
+    )
+    stub_github(
+      'https://api.github.com/search/issues?per_page=100&' \
+      'q=repo:foo/foo%20type:issue%20created:2024-08-02T21:00:00Z..2024-08-09T21:00:00Z',
+      body: {
+        total_count: 1, incomplete_results: false,
+        items: [
+          {
+            id: 2_544_140_700,
+            number: 50,
+            title: 'Issue 50',
+            user: { login: 'yegor256', id: 526_301, type: 'User', site_admin: false },
+            labels: [
+              { id: 6_937_082_637, name: 'bug', description: "Something isn't working" }
+            ],
+            created_at: Time.parse('2024-08-04 12:00:00 UTC')
+          }
+        ]
+      }
+    )
+    fb = Factbase.new
+    fb.insert.then do |f|
+      f.what = 'pmp'
+      f.area = 'quality'
+      f.qos_days = 7
+      f.qos_interval = 3
+      f.qos_min_triage_seconds = 60
+    end
+    insert_label_was_attached_fact(
+      fb, where: 'github', repository: 42, issue: 50, when: Time.parse('2024-08-04 12:00:01 UTC'), label: 'bug'
+    )
+    insert_label_was_attached_fact(
+      fb, where: 'github', repository: 42, issue: 50, when: Time.parse('2024-08-04 14:00:00 UTC'), label: 'enhancement'
+    )
+    Time.stub(:now, Time.parse('2024-08-09 21:00:00 UTC')) do
+      load_it('quality-of-service', fb)
+      f = fb.query('(eq what "quality-of-service")').each.first
+      assert_nil(f['some_triage_time'])
+    end
+  end
+
+  def test_quality_of_service_some_triage_time_threshold_is_configurable
+    WebMock.disable_net_connect!
+    stub_request(:get, 'https://api.github.com/rate_limit').to_return(
+      { body: '{"rate":{"remaining":222}}', headers: { 'X-RateLimit-Remaining' => '222' } }
+    )
+    stub_github('https://api.github.com/repos/foo/foo', body: { id: 42, full_name: 'foo/foo' })
+    stub_github(
+      'https://api.github.com/repos/foo/foo/actions/runs?created=2024-08-02T21:00:00Z..2024-08-09T21:00:00Z&per_page=100',
+      body: { total_count: 0, workflow_runs: [] }
+    )
+    stub_github('https://api.github.com/repos/foo/foo/releases?per_page=100', body: [])
+    stub_github(
+      'https://api.github.com/search/issues?per_page=100&' \
+      'q=repo:foo/foo%20type:issue%20closed:2024-08-02T21:00:00Z..2024-08-09T21:00:00Z',
+      body: { total_count: 0, incomplete_results: false, items: [] }
+    )
+    stub_github(
+      'https://api.github.com/search/issues?per_page=100&q=repo:foo/foo%20type:issue%20closed:%3E2024-08-02',
+      body: { total_count: 0, incomplete_results: false, items: [] }
+    )
+    stub_github(
+      'https://api.github.com/search/issues?per_page=100&' \
+      'q=repo:foo/foo%20type:pr%20closed:2024-08-02T21:00:00Z..2024-08-09T21:00:00Z',
+      body: { total_count: 0, incomplete_results: false, items: [] }
+    )
+    stub_github(
+      'https://api.github.com/search/issues?per_page=100&q=repo:foo/foo%20type:pr%20closed:%3E2024-08-02',
+      body: { total_count: 0, incomplete_results: false, items: [] }
+    )
+    (Date.parse('2024-08-02')..Date.parse('2024-08-09')).each do |date|
+      stub_github(
+        'https://api.github.com/search/issues?advanced_search=true&per_page=100&' \
+        "q=repo:foo/foo%20type:issue%20created:*..#{date}%20(closed:%3E=#{date}%20OR%20state:open)",
+        body: { total_count: 0, items: [] }
+      )
+    end
+    stub_github(
+      'https://api.github.com/search/issues?per_page=100&' \
+      'q=repo:foo/foo%20type:pr%20is:unmerged%20closed:2024-08-02T21:00:00Z..2024-08-09T21:00:00Z',
+      body: { total_count: 0, incomplete_results: false, items: [] }
+    )
+    stub_github(
+      'https://api.github.com/search/issues?per_page=100&' \
+      'q=repo:foo/foo%20type:pr%20is:merged%20closed:2024-08-02T21:00:00Z..2024-08-09T21:00:00Z',
+      body: { total_count: 0, incomplete_results: false, items: [] }
+    )
+    stub_github(
+      'https://api.github.com/search/issues?per_page=100&' \
+      'q=repo:foo/foo%20type:issue%20created:2024-08-02T21:00:00Z..2024-08-09T21:00:00Z',
+      body: {
+        total_count: 1, incomplete_results: false,
+        items: [
+          {
+            id: 2_544_140_701,
+            number: 51,
+            title: 'Issue 51',
+            user: { login: 'yegor256', id: 526_301, type: 'User', site_admin: false },
+            labels: [
+              { id: 6_937_082_637, name: 'bug', description: "Something isn't working" }
+            ],
+            created_at: Time.parse('2024-08-04 12:00:00 UTC')
+          }
+        ]
+      }
+    )
+    fb = Factbase.new
+    fb.insert.then do |f|
+      f.what = 'pmp'
+      f.area = 'quality'
+      f.qos_days = 7
+      f.qos_interval = 3
+      f.qos_min_triage_seconds = 7_200
+    end
+    insert_label_was_attached_fact(
+      fb, where: 'github', repository: 42, issue: 51, when: Time.parse('2024-08-04 13:00:00 UTC'), label: 'bug'
+    )
+    Time.stub(:now, Time.parse('2024-08-09 21:00:00 UTC')) do
+      load_it('quality-of-service', fb)
+      f = fb.query('(eq what "quality-of-service")').each.first
+      assert_nil(f['some_triage_time'])
+    end
+  end
+
+  def test_quality_of_service_some_triage_time_uses_default_threshold
+    WebMock.disable_net_connect!
+    stub_request(:get, 'https://api.github.com/rate_limit').to_return(
+      { body: '{"rate":{"remaining":222}}', headers: { 'X-RateLimit-Remaining' => '222' } }
+    )
+    stub_github('https://api.github.com/repos/foo/foo', body: { id: 42, full_name: 'foo/foo' })
+    stub_github(
+      'https://api.github.com/repos/foo/foo/actions/runs?created=2024-08-02T21:00:00Z..2024-08-09T21:00:00Z&per_page=100',
+      body: { total_count: 0, workflow_runs: [] }
+    )
+    stub_github('https://api.github.com/repos/foo/foo/releases?per_page=100', body: [])
+    stub_github(
+      'https://api.github.com/search/issues?per_page=100&' \
+      'q=repo:foo/foo%20type:issue%20closed:2024-08-02T21:00:00Z..2024-08-09T21:00:00Z',
+      body: { total_count: 0, incomplete_results: false, items: [] }
+    )
+    stub_github(
+      'https://api.github.com/search/issues?per_page=100&q=repo:foo/foo%20type:issue%20closed:%3E2024-08-02',
+      body: { total_count: 0, incomplete_results: false, items: [] }
+    )
+    stub_github(
+      'https://api.github.com/search/issues?per_page=100&' \
+      'q=repo:foo/foo%20type:pr%20closed:2024-08-02T21:00:00Z..2024-08-09T21:00:00Z',
+      body: { total_count: 0, incomplete_results: false, items: [] }
+    )
+    stub_github(
+      'https://api.github.com/search/issues?per_page=100&q=repo:foo/foo%20type:pr%20closed:%3E2024-08-02',
+      body: { total_count: 0, incomplete_results: false, items: [] }
+    )
+    (Date.parse('2024-08-02')..Date.parse('2024-08-09')).each do |date|
+      stub_github(
+        'https://api.github.com/search/issues?advanced_search=true&per_page=100&' \
+        "q=repo:foo/foo%20type:issue%20created:*..#{date}%20(closed:%3E=#{date}%20OR%20state:open)",
+        body: { total_count: 0, items: [] }
+      )
+    end
+    stub_github(
+      'https://api.github.com/search/issues?per_page=100&' \
+      'q=repo:foo/foo%20type:pr%20is:unmerged%20closed:2024-08-02T21:00:00Z..2024-08-09T21:00:00Z',
+      body: { total_count: 0, incomplete_results: false, items: [] }
+    )
+    stub_github(
+      'https://api.github.com/search/issues?per_page=100&' \
+      'q=repo:foo/foo%20type:pr%20is:merged%20closed:2024-08-02T21:00:00Z..2024-08-09T21:00:00Z',
+      body: { total_count: 0, incomplete_results: false, items: [] }
+    )
+    stub_github(
+      'https://api.github.com/search/issues?per_page=100&' \
+      'q=repo:foo/foo%20type:issue%20created:2024-08-02T21:00:00Z..2024-08-09T21:00:00Z',
+      body: {
+        total_count: 2, incomplete_results: false,
+        items: [
+          {
+            id: 2_544_140_710,
+            number: 60,
+            title: 'Issue 60',
+            user: { login: 'yegor256', id: 526_301, type: 'User', site_admin: false },
+            labels: [
+              { id: 6_937_082_637, name: 'bug', description: "Something isn't working" }
+            ],
+            created_at: Time.parse('2024-08-04 12:00:00 UTC')
+          },
+          {
+            id: 2_544_140_711,
+            number: 61,
+            title: 'Issue 61',
+            user: { login: 'yegor256', id: 526_301, type: 'User', site_admin: false },
+            labels: [
+              { id: 6_937_082_637, name: 'bug', description: "Something isn't working" }
+            ],
+            created_at: Time.parse('2024-08-04 12:00:00 UTC')
+          }
+        ]
+      }
+    )
+    fb = Factbase.new
+    fb.insert.then do |f|
+      f.what = 'pmp'
+      f.area = 'quality'
+      f.qos_days = 7
+      f.qos_interval = 3
+    end
+    insert_label_was_attached_fact(
+      fb, where: 'github', repository: 42, issue: 60, when: Time.parse('2024-08-04 12:00:59 UTC'), label: 'bug'
+    )
+    insert_label_was_attached_fact(
+      fb, where: 'github', repository: 42, issue: 61, when: Time.parse('2024-08-04 12:01:00 UTC'), label: 'bug'
+    )
+    Time.stub(:now, Time.parse('2024-08-09 21:00:00 UTC')) do
+      load_it('quality-of-service', fb)
+      f = fb.query('(eq what "quality-of-service")').each.first
+      assert_equal([60.0], f['some_triage_time'])
+    end
+  end
+
+  def test_quality_of_service_some_triage_time_mixes_kept_and_filtered
+    WebMock.disable_net_connect!
+    stub_request(:get, 'https://api.github.com/rate_limit').to_return(
+      { body: '{"rate":{"remaining":222}}', headers: { 'X-RateLimit-Remaining' => '222' } }
+    )
+    stub_github('https://api.github.com/repos/foo/foo', body: { id: 42, full_name: 'foo/foo' })
+    stub_github(
+      'https://api.github.com/repos/foo/foo/actions/runs?created=2024-08-02T21:00:00Z..2024-08-09T21:00:00Z&per_page=100',
+      body: { total_count: 0, workflow_runs: [] }
+    )
+    stub_github('https://api.github.com/repos/foo/foo/releases?per_page=100', body: [])
+    stub_github(
+      'https://api.github.com/search/issues?per_page=100&' \
+      'q=repo:foo/foo%20type:issue%20closed:2024-08-02T21:00:00Z..2024-08-09T21:00:00Z',
+      body: { total_count: 0, incomplete_results: false, items: [] }
+    )
+    stub_github(
+      'https://api.github.com/search/issues?per_page=100&q=repo:foo/foo%20type:issue%20closed:%3E2024-08-02',
+      body: { total_count: 0, incomplete_results: false, items: [] }
+    )
+    stub_github(
+      'https://api.github.com/search/issues?per_page=100&' \
+      'q=repo:foo/foo%20type:pr%20closed:2024-08-02T21:00:00Z..2024-08-09T21:00:00Z',
+      body: { total_count: 0, incomplete_results: false, items: [] }
+    )
+    stub_github(
+      'https://api.github.com/search/issues?per_page=100&q=repo:foo/foo%20type:pr%20closed:%3E2024-08-02',
+      body: { total_count: 0, incomplete_results: false, items: [] }
+    )
+    (Date.parse('2024-08-02')..Date.parse('2024-08-09')).each do |date|
+      stub_github(
+        'https://api.github.com/search/issues?advanced_search=true&per_page=100&' \
+        "q=repo:foo/foo%20type:issue%20created:*..#{date}%20(closed:%3E=#{date}%20OR%20state:open)",
+        body: { total_count: 0, items: [] }
+      )
+    end
+    stub_github(
+      'https://api.github.com/search/issues?per_page=100&' \
+      'q=repo:foo/foo%20type:pr%20is:unmerged%20closed:2024-08-02T21:00:00Z..2024-08-09T21:00:00Z',
+      body: { total_count: 0, incomplete_results: false, items: [] }
+    )
+    stub_github(
+      'https://api.github.com/search/issues?per_page=100&' \
+      'q=repo:foo/foo%20type:pr%20is:merged%20closed:2024-08-02T21:00:00Z..2024-08-09T21:00:00Z',
+      body: { total_count: 0, incomplete_results: false, items: [] }
+    )
+    stub_github(
+      'https://api.github.com/search/issues?per_page=100&' \
+      'q=repo:foo/foo%20type:issue%20created:2024-08-02T21:00:00Z..2024-08-09T21:00:00Z',
+      body: {
+        total_count: 2, incomplete_results: false,
+        items: [
+          {
+            id: 2_544_140_720,
+            number: 70,
+            title: 'Issue 70',
+            user: { login: 'yegor256', id: 526_301, type: 'User', site_admin: false },
+            labels: [
+              { id: 6_937_082_637, name: 'bug', description: "Something isn't working" }
+            ],
+            created_at: Time.parse('2024-08-04 12:00:00 UTC')
+          },
+          {
+            id: 2_544_140_721,
+            number: 71,
+            title: 'Issue 71',
+            user: { login: 'yegor256', id: 526_301, type: 'User', site_admin: false },
+            labels: [
+              { id: 6_937_082_651, name: 'enhancement', description: 'New feature or request' }
+            ],
+            created_at: Time.parse('2024-08-04 12:00:00 UTC')
+          }
+        ]
+      }
+    )
+    fb = Factbase.new
+    fb.insert.then do |f|
+      f.what = 'pmp'
+      f.area = 'quality'
+      f.qos_days = 7
+      f.qos_interval = 3
+      f.qos_min_triage_seconds = 60
+    end
+    insert_label_was_attached_fact(
+      fb, where: 'github', repository: 42, issue: 70, when: Time.parse('2024-08-04 12:00:01 UTC'), label: 'bug'
+    )
+    insert_label_was_attached_fact(
+      fb, where: 'github', repository: 42, issue: 71, when: Time.parse('2024-08-04 14:00:00 UTC'), label: 'enhancement'
+    )
+    Time.stub(:now, Time.parse('2024-08-09 21:00:00 UTC')) do
+      load_it('quality-of-service', fb)
+      f = fb.query('(eq what "quality-of-service")').each.first
+      assert_equal([7_200.0], f['some_triage_time'])
     end
   end
 


### PR DESCRIPTION
Closes #1027.

### What was wrong

Live factbases on `gh-pages` (`zerocracy.yaml`) show `some_triage_time` as a bimodal mix of `0.0`/`1.0`/`2.0`/`3.0`-second values intermixed with realistic `2103`/`48259`/`97485`-second values. The near-zero values come from issue templates that auto-apply `bug`/`enhancement` labels at issue creation: the resulting `label-was-attached` fact's `when` equals the issue's `created_at`, so `(ff.when - issue[:created_at])` collapses to a sub-second delta that is data noise, not a triage signal. Downstream averaging over this mix yields the ~0.2-second value reported in the issue.

### Code change

`judges/quality-of-service/some_triage_time.rb` now reads a threshold once via `Fbe.pmp.quality.qos_min_triage_seconds.value || 60` and skips deltas below it:

```ruby
threshold = Fbe.pmp.quality.qos_min_triage_seconds.value || 60
…
next unless ff
delta = ff.when - issue[:created_at]
next if delta < threshold
times << delta
```

Default `60` seconds is chosen because legitimate human triage virtually never lands under one minute, while auto-applied labels overwhelmingly produce 0–14 second deltas (per the live-data sample). The `.value || 60` form is needed because `qos_min_triage_seconds` is not yet declared in `assets/pmp.xml` of the `fbe` gem — without a schema entry, `Fbe.pmp.quality.qos_min_triage_seconds` returns a `pmpv` SimpleDelegator wrapping `nil` when the local pmp fact omits the property. The fallback works in both states.

### Tests

`test/judges/test-quality-of-service.rb` now has 5 cases under `/some_triage_time/`:

1. `test_quality_of_service_some_triage_time` — extended positive case with `f.qos_min_triage_seconds = 60` in the PMP fact; expected `[88_200, 7_200, 147_600]` unchanged (all deltas >> 60).
2. `test_quality_of_service_some_triage_time_filters_auto_labels` — single issue with two labels (auto at +1s wins via `min_by(&:when)` and is filtered, human at +2h is unreachable); asserts `some_triage_time` is nil.
3. `test_quality_of_service_some_triage_time_threshold_is_configurable` — `qos_min_triage_seconds = 7_200` filters a 3_600s delta; asserts nil.
4. `test_quality_of_service_some_triage_time_uses_default_threshold` — PMP omits `qos_min_triage_seconds`; two issues with deltas 59s and 60s; asserts `[60.0]`. Pins the `|| 60` fallback (removing it makes `delta < nil` raise) AND the strict `<` boundary (flipping to `<=` drops the 60s value).
5. `test_quality_of_service_some_triage_time_mixes_kept_and_filtered` — two issues in one QoS run, one filtered (+1s) and one kept (+7_200s); asserts `[7_200.0]`. Confirms partial array population.

### Local verification

- `bundle exec rake test` — **179 tests, 507 assertions, 0 failures, 0 errors, 1 skip**.
- `bundle exec rake judges` — **28 judges, 59 integration tests passed**.
- `bundle exec rake rubocop` — **92 files inspected, 0 offenses detected**.

### Follow-up (NOT in this PR)

Open a separate PR against `zerocracy/fbe` adding `qos_min_triage_seconds` (default `60`, type `int`) to `assets/pmp.xml` under the `quality` area, mirroring the existing `qos_days` / `qos_interval` declarations. Once it lands and `Gemfile.lock` is bumped here, the read can be simplified to plain `Fbe.pmp.quality.qos_min_triage_seconds` (drop the `.value || 60` fallback).
