### PR TITLE
#1362: rescue NotFound/Deprecated/Forbidden around Fbe.octo.pull_request in find-all-issues

### DIFF
--- a/judges/find-all-issues/find-all-issues.rb
+++ b/judges/find-all-issues/find-all-issues.rb
@@ -69,7 +69,20 @@ require_relative '../../lib/issue_was_lost'
             f.when = json[:created_at]
             f.who = json.dig(:user, :id)
             if type == 'pull'
-              ref = Fbe.octo.pull_request(repo, f.issue).dig(:head, :ref)
+              ref =
+                begin
+                  Fbe.octo.pull_request(repo, f.issue).dig(:head, :ref)
+                rescue Octokit::NotFound, Octokit::Deprecated => e
+                  $loog.info("The pull ##{f.issue} doesn't exist in #{repo}: #{e.message}")
+                  Jp.issue_was_lost(f.where, f.repository, f.issue)
+                  next
+                rescue Octokit::Forbidden => e
+                  $loog.warn(
+                    "[#{$judge}] Access forbidden to pull ##{f.issue} in #{repo} " \
+                    "(transient, will retry next cycle): #{e.class}: #{e.message}"
+                  )
+                  next
+                end
               if ref
                 f.branch = ref
               else

--- a/test/judges/test-find-all-issues.rb
+++ b/test/judges/test-find-all-issues.rb
@@ -299,6 +299,91 @@ class TestFindAllIssues < Jp::Test
     assert_equal(5, fb.query('(eq what "iterate")').each.to_a.first.min_issue_was_found)
   end
 
+  def test_paginated_pulls_continue_after_not_found
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repos/foo/foo', body: { id: 991 })
+    stub_github('https://api.github.com/repositories/991', body: { full_name: 'foo/foo' })
+    stub_github('https://api.github.com/repos/foo/foo/issues/45', body: { created_at: Time.parse('2025-05-04') })
+    stub_github(
+      'https://api.github.com/search/issues?per_page=100&q=repo:foo/foo%20type:pull%20created:%3E=2025-05-04',
+      body: {
+        total_count: 2, incomplete_results: false,
+        items: [
+          { number: 45, created_at: Time.parse('2025-05-04'), user: { id: 4242 } },
+          { number: 46, created_at: Time.parse('2025-05-05'), user: { id: 4242 } }
+        ]
+      }
+    )
+    stub_github(
+      'https://api.github.com/repos/foo/foo/pulls/45',
+      status: 404,
+      body: { message: 'Not Found', documentation_url: 'https://docs.github.com', status: '404' }
+    )
+    stub_github(
+      'https://api.github.com/repos/foo/foo/pulls/46',
+      body: { number: 46, head: { ref: 'feature/branch-survivor' } }
+    )
+    stub_github('https://api.github.com/user/4242', body: { login: 'yegor256' })
+    fb = Factbase.new
+    fb.insert.then do |f|
+      f.issue = 45
+      f.repository = 991
+      f.what = 'pull-was-opened'
+      f.where = 'github'
+    end
+    load_it('find-all-issues', fb)
+    survivor = fb.query("(and (eq issue 46) (eq what 'pull-was-opened'))").each.first
+    refute_nil(
+      survivor,
+      'the second pull must be recorded after the first raises 404 — paginated batch must not truncate on exception'
+    )
+    assert_equal('feature/branch-survivor', survivor.branch)
+  end
+
+  def test_paginated_pulls_continue_after_forbidden
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repos/foo/foo', body: { id: 991 })
+    stub_github('https://api.github.com/repositories/991', body: { full_name: 'foo/foo' })
+    stub_github('https://api.github.com/repos/foo/foo/issues/45', body: { created_at: Time.parse('2025-05-04') })
+    stub_github(
+      'https://api.github.com/search/issues?per_page=100&q=repo:foo/foo%20type:pull%20created:%3E=2025-05-04',
+      body: {
+        total_count: 2, incomplete_results: false,
+        items: [
+          { number: 45, created_at: Time.parse('2025-05-04'), user: { id: 4242 } },
+          { number: 46, created_at: Time.parse('2025-05-05'), user: { id: 4242 } }
+        ]
+      }
+    )
+    stub_github(
+      'https://api.github.com/repos/foo/foo/pulls/45',
+      status: 403,
+      body: { message: 'Resource not accessible by integration' }
+    )
+    stub_github(
+      'https://api.github.com/repos/foo/foo/pulls/46',
+      body: { number: 46, head: { ref: 'feature/branch-survivor' } }
+    )
+    stub_github('https://api.github.com/user/4242', body: { login: 'yegor256' })
+    fb = Factbase.new
+    fb.insert.then do |f|
+      f.issue = 45
+      f.repository = 991
+      f.what = 'pull-was-opened'
+      f.where = 'github'
+    end
+    load_it('find-all-issues', fb)
+    survivor = fb.query("(and (eq issue 46) (eq what 'pull-was-opened'))").each.first
+    refute_nil(survivor, 'the second pull must be recorded after the first hits transient forbidden')
+    assert_equal('feature/branch-survivor', survivor.branch)
+    assert_empty(
+      fb.query('(eq what "issue-was-lost")').each.to_a,
+      'forbidden is transient — must not produce an issue-was-lost tombstone'
+    )
+  end
+
   def test_rescues_forbidden_issue_lookup
     WebMock.disable_net_connect!
     rate_limit_up


### PR DESCRIPTION
Closes #1362.

## Summary

- Wraps the unprotected `Fbe.octo.pull_request(repo, f.issue).dig(:head, :ref)` in `judges/find-all-issues/find-all-issues.rb` with the canonical rescue pattern from #1357 (`code-was-reviewed.rb`).
- A 404/`Octokit::NotFound` or `Octokit::Deprecated` (deleted/transferred PR) routes through `Jp.issue_was_lost`; a 403/`Octokit::Forbidden` is logged as transient and skipped without tombstoning.
- The plain `next` exits the `Fbe.fb.txn` block, so the surrounding `search_issues(...).each` continues with the remaining PRs on the page — the paginated batch is no longer truncated by the first failing entry. (Plain `next` is the right semantic here per #1331: the container is a plain `each`, not `Fbe.iterate`.)

## Test plan

- [x] `test_paginated_pulls_continue_after_not_found` — paginated batch of two PRs, first 404s; asserts the second is recorded with `branch` set.
- [x] `test_paginated_pulls_continue_after_forbidden` — same with 403; additionally asserts no `issue-was-lost` fact is created (transient).
- [x] All tests in `test/judges/test-find-all-issues.rb` pass locally (Ruby 3.4.9).

Note: `judges/find-missing-issues/find-missing-issues.rb:67` has the same shape of bug but is intentionally out of scope here — the issue body explicitly tracks them independently.
