### PR TITLE
#1360: rescue Fbe.octo.pull_request in find-earliest-issue and find-latest-issue

### DIFF
--- a/judges/find-earliest-issue/find-earliest-issue.rb
+++ b/judges/find-earliest-issue/find-earliest-issue.rb
@@ -9,7 +9,9 @@ require 'fbe/iterate'
 require 'fbe/octo'
 require 'fbe/tombstone'
 require 'fbe/who'
+require 'octokit'
 require 'tago'
+require_relative '../../lib/issue_was_lost'
 
 Fbe.iterate do
   as 'earliest_issue_was_found'
@@ -36,7 +38,20 @@ Fbe.iterate do
       f.when = json[:created_at]
       f.who = json.dig(:user, :id)
       if json[:pull_request]
-        ref = Fbe.octo.pull_request(repo, f.issue).dig(:head, :ref)
+        ref =
+          begin
+            Fbe.octo.pull_request(repo, f.issue).dig(:head, :ref)
+          rescue Octokit::NotFound, Octokit::Deprecated => e
+            $loog.info("The pull ##{f.issue} doesn't exist in #{repo}: #{e.message}")
+            Jp.issue_was_lost(f.where, f.repository, f.issue)
+            next i
+          rescue Octokit::Forbidden => e
+            $loog.warn(
+              "[#{$judge}] Access forbidden to pull ##{f.issue} in #{repo} " \
+              "(transient, will retry next cycle): #{e.class}: #{e.message}"
+            )
+            next i
+          end
         if ref
           f.branch = ref
         else

--- a/judges/find-latest-issue/find-latest-issue.rb
+++ b/judges/find-latest-issue/find-latest-issue.rb
@@ -9,7 +9,9 @@ require 'fbe/iterate'
 require 'fbe/octo'
 require 'fbe/tombstone'
 require 'fbe/who'
+require 'octokit'
 require 'tago'
+require_relative '../../lib/issue_was_lost'
 
 Fbe.iterate do
   as 'latest_issue_was_found'
@@ -36,7 +38,20 @@ Fbe.iterate do
       f.when = json[:created_at]
       f.who = json.dig(:user, :id)
       if json[:pull_request]
-        ref = Fbe.octo.pull_request(repo, f.issue).dig(:head, :ref)
+        ref =
+          begin
+            Fbe.octo.pull_request(repo, f.issue).dig(:head, :ref)
+          rescue Octokit::NotFound, Octokit::Deprecated => e
+            $loog.info("The pull ##{f.issue} doesn't exist in #{repo}: #{e.message}")
+            Jp.issue_was_lost(f.where, f.repository, f.issue)
+            next i
+          rescue Octokit::Forbidden => e
+            $loog.warn(
+              "[#{$judge}] Access forbidden to pull ##{f.issue} in #{repo} " \
+              "(transient, will retry next cycle): #{e.class}: #{e.message}"
+            )
+            next i
+          end
         if ref
           f.branch = ref
         else

--- a/test/judges/test-find-earliest-issue.rb
+++ b/test/judges/test-find-earliest-issue.rb
@@ -128,4 +128,62 @@ class TestFindEarliestIssue < Jp::Test
     assert_equal(2, fb.all.size)
     assert(fb.one?(what: 'iterate', earliest_issue_was_found: 3, repository: 42, where: 'github'))
   end
+
+  def test_rescues_not_found_on_pull_request_lookup
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repos/foo/foo', body: { id: 42, name: 'foo', full_name: 'foo/foo' })
+    stub_github('https://api.github.com/repositories/42', body: { id: 42, name: 'foo', full_name: 'foo/foo' })
+    stub_github(
+      'https://api.github.com/repos/foo/foo/issues?direction=asc&page=1&per_page=1&sort=created&state=all',
+      body: [
+        {
+          id: 123, number: 3, title: 'Some title', user: { id: 44, login: 'user' },
+          pull_request: { merged_at: '2025-09-27 07:03:00 UTC' }, created_at: '2025-09-27 06:03:16 UTC'
+        }
+      ]
+    )
+    stub_github(
+      'https://api.github.com/repos/foo/foo/pulls/3',
+      status: 404,
+      body: {
+        message: 'Not Found',
+        documentation_url: 'https://docs.github.com/rest/pulls/pulls#get-a-pull-request',
+        status: '404'
+      }
+    )
+    fb = Factbase.new
+    load_it('find-earliest-issue', fb)
+    assert(
+      fb.one?(what: 'iterate', earliest_issue_was_found: 3, repository: 42, where: 'github'),
+      'cursor must advance to the issue number after a 404 on Fbe.octo.pull_request'
+    )
+  end
+
+  def test_rescues_forbidden_on_pull_request_lookup
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repos/foo/foo', body: { id: 42, name: 'foo', full_name: 'foo/foo' })
+    stub_github('https://api.github.com/repositories/42', body: { id: 42, name: 'foo', full_name: 'foo/foo' })
+    stub_github(
+      'https://api.github.com/repos/foo/foo/issues?direction=asc&page=1&per_page=1&sort=created&state=all',
+      body: [
+        {
+          id: 123, number: 3, title: 'Some title', user: { id: 44, login: 'user' },
+          pull_request: { merged_at: '2025-09-27 07:03:00 UTC' }, created_at: '2025-09-27 06:03:16 UTC'
+        }
+      ]
+    )
+    stub_github(
+      'https://api.github.com/repos/foo/foo/pulls/3',
+      status: 403,
+      body: { message: 'Resource not accessible by integration' }
+    )
+    fb = Factbase.new
+    load_it('find-earliest-issue', fb)
+    refute(
+      fb.one?(what: 'issue-was-lost', where: 'github', repository: 42, issue: 3),
+      'forbidden error must not produce an issue-was-lost tombstone'
+    )
+  end
 end

--- a/test/judges/test-find-latest-issue.rb
+++ b/test/judges/test-find-latest-issue.rb
@@ -145,4 +145,62 @@ class TestFindLatestIssue < Jp::Test
     assert_equal(2, fb.all.size)
     assert(fb.one?(what: 'iterate', latest_issue_was_found: 547, repository: 42, where: 'github'))
   end
+
+  def test_rescues_not_found_on_pull_request_lookup
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repos/foo/foo', body: { id: 42, name: 'foo', full_name: 'foo/foo' })
+    stub_github('https://api.github.com/repositories/42', body: { id: 42, name: 'foo', full_name: 'foo/foo' })
+    stub_github(
+      'https://api.github.com/repos/foo/foo/issues?direction=desc&page=1&per_page=1&sort=created&state=all',
+      body: [
+        {
+          id: 123, number: 548, title: 'Some title', user: { id: 44, login: 'user' },
+          pull_request: { merged_at: '2025-09-14 20:03:16 UTC' }, created_at: '2025-09-14 20:03:16 UTC'
+        }
+      ]
+    )
+    stub_github(
+      'https://api.github.com/repos/foo/foo/pulls/548',
+      status: 404,
+      body: {
+        message: 'Not Found',
+        documentation_url: 'https://docs.github.com/rest/pulls/pulls#get-a-pull-request',
+        status: '404'
+      }
+    )
+    fb = Factbase.new
+    load_it('find-latest-issue', fb)
+    assert(
+      fb.one?(what: 'iterate', latest_issue_was_found: 548, repository: 42, where: 'github'),
+      'cursor must advance to the issue number after a 404 on Fbe.octo.pull_request'
+    )
+  end
+
+  def test_rescues_forbidden_on_pull_request_lookup
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repos/foo/foo', body: { id: 42, name: 'foo', full_name: 'foo/foo' })
+    stub_github('https://api.github.com/repositories/42', body: { id: 42, name: 'foo', full_name: 'foo/foo' })
+    stub_github(
+      'https://api.github.com/repos/foo/foo/issues?direction=desc&page=1&per_page=1&sort=created&state=all',
+      body: [
+        {
+          id: 123, number: 548, title: 'Some title', user: { id: 44, login: 'user' },
+          pull_request: { merged_at: '2025-09-14 20:03:16 UTC' }, created_at: '2025-09-14 20:03:16 UTC'
+        }
+      ]
+    )
+    stub_github(
+      'https://api.github.com/repos/foo/foo/pulls/548',
+      status: 403,
+      body: { message: 'Resource not accessible by integration' }
+    )
+    fb = Factbase.new
+    load_it('find-latest-issue', fb)
+    refute(
+      fb.one?(what: 'issue-was-lost', where: 'github', repository: 42, issue: 548),
+      'forbidden error must not produce an issue-was-lost tombstone'
+    )
+  end
 end


### PR DESCRIPTION
## Summary
- Fixes #1360 by wrapping the unrescued `Fbe.octo.pull_request` call in both `judges/find-earliest-issue/find-earliest-issue.rb` and `judges/find-latest-issue/find-latest-issue.rb` with the canonical rescue pattern established in `judges/pull-was-merged/pull-was-merged.rb:55-67`.
- `Octokit::NotFound` / `Octokit::Deprecated` (404, deprecated endpoint) → log, call `Jp.issue_was_lost`, advance cursor with `next i` (the integer required by `Fbe.iterate + over` — see #1331).
- `Octokit::Forbidden` (transient 403) → log warning and skip with `next i`, without tombstoning.
- Adds reproduction tests `test_rescues_not_found_on_pull_request_lookup` and `test_rescues_forbidden_on_pull_request_lookup` to both `test/judges/test-find-earliest-issue.rb` and `test/judges/test-find-latest-issue.rb`. Each stubs `list_issues` to return one PR-typed entry and `pull_request` to 404/403; both tests fail on master with the unrescued `Octokit::NotFound` / `Octokit::Forbidden` and pass with this change.

## Test plan
- [x] `ruby test/judges/test-find-earliest-issue.rb` → 7 tests, 14 assertions, 0 failures, 0 errors
- [x] `ruby test/judges/test-find-latest-issue.rb` → 7 tests, 14 assertions, 0 failures, 0 errors
- [x] `ruby test/judges/test-pull-was-merged.rb` (regression check on the canonical pattern source) → 7 tests, 9 assertions, 0 failures
- [x] Full suite across all 23 judge test files → 155 tests, 452 assertions, 0 failures, 0 errors, 1 skip
- [x] `rubocop` on the four touched files → no offenses