### PR TITLE
#1376: add missing .each on inner Fbe.fb.query in eliminate-ghosts.rb

### DIFF
--- a/judges/eliminate-ghosts/eliminate-ghosts.rb
+++ b/judges/eliminate-ghosts/eliminate-ghosts.rb
@@ -34,7 +34,7 @@ bad.each do |u|
 end
 
 Fbe.fb.query('(and (eq where "github") (exists who) (unique who) (eq stale "who"))').each do |f|
-  Fbe.fb.query("(and (eq who #{f.who}) (not (eq stale 'who')) (eq where 'github'))") do |ff|
+  Fbe.fb.query("(and (eq who #{f.who}) (not (eq stale 'who')) (eq where 'github'))").each do |ff|
     ff.stale = 'who'
   end
 end

--- a/test/judges/test-eliminate-ghosts.rb
+++ b/test/judges/test-eliminate-ghosts.rb
@@ -109,6 +109,18 @@ class TestEliminateGhosts < Jp::Test
     assert(fb.has?(where: 'github', who: 333))
   end
 
+  def test_marks_sibling_facts_stale_when_one_fact_already_stale_for_good_user
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/user/777', body: { login: 'user777', id: 777, type: 'User' })
+    fb = Factbase.new
+    fb.with(_id: 1, where: 'github', who: 777, what: 'something-a', stale: 'who')
+      .with(_id: 2, where: 'github', who: 777, what: 'something-b')
+      .with(_id: 3, where: 'github', who: 777, what: 'something-c')
+    load_it('eliminate-ghosts', fb)
+    assert_equal(3, fb.picks(where: 'github', who: 777, stale: 'who').count)
+  end
+
   def test_marks_user_stale_on_forbidden_lookup
     WebMock.disable_net_connect!
     rate_limit_up


### PR DESCRIPTION
Closes #1376.

## Summary

In `judges/eliminate-ghosts/eliminate-ghosts.rb:37`, the inner `Fbe.fb.query(...)` call was given a block but no `.each` was chained on the query. Because `Factbase#query` returns a `Factbase::Query` object and does not accept a block, the block was silently discarded and `ff.stale = 'who'` was never executed. As a result, when a ghost user had at least one fact already marked `stale: 'who'`, sibling non-stale facts for the same user remained live, and subsequent judges continued to count or score that ghost.

The fix is a single-character change: add `.each` to the inner query so the block runs, mirroring the pattern already used elsewhere in the same file (lines 15, 31, 36).

## Proof that issue #1376 is solved

### 1. Root cause confirmed in the gem

`vendor/.../factbase-0.19.10/lib/factbase.rb:135` defines `query` as:

```ruby
def query(term, maps = nil)
  maps ||= @maps
  term = to_term(term) if term.is_a?(String)
  require_relative 'factbase/query'
  Factbase::Query.new(maps, term, self)
end
```

It returns a `Factbase::Query` instance and ignores any block. Only `Factbase::Query#each` accepts a block. Therefore the previous code on line 37 silently discarded the block.

### 2. Fix

```diff
-  Fbe.fb.query("(and (eq who #{f.who}) (not (eq stale 'who')) (eq where 'github'))") do |ff|
+  Fbe.fb.query("(and (eq who #{f.who}) (not (eq stale 'who')) (eq where 'github'))").each do |ff|
     ff.stale = 'who'
   end
```

### 3. Regression test that the original code does NOT pass

The issue notes that the pre-existing test `test_process_unique_users_first_and_set_stale_property_later_for_other_facts` cannot detect this defect because every fact for user 555 in that fixture already has `stale: 'who'`, so the inner block has no work to do regardless.

This PR adds `test_marks_sibling_facts_stale_when_one_fact_already_stale_for_good_user` in `test/judges/test-eliminate-ghosts.rb`. It sets up a single GitHub user (777, returning HTTP 200 — i.e., not a ghost from GitHub's perspective) who already has one fact tagged `stale: 'who'` and two sibling facts that are not. After running the judge, all three facts must be marked stale; this is exactly the code path that the third loop guards.

**Without the fix (block silently dropped):**

```
D: Found 1/3 fact(s) by (and (eq where 'github') (exists who) (unique who) (eq stale 'who'))
  test_marks_sibling_facts_stale_when_one_fact_already_stale_for_good_user FAIL (0.13s)
        Expected: 3
          Actual: 1
1 tests, 1 assertions, 1 failures, 0 errors, 0 skips
```

**With the fix:**

```
D: Found 1/3 fact(s) by (and (eq where 'github') (exists who) (unique who) (eq stale 'who')) in 126μs
D: Found 2/3 fact(s) by (and (eq who 777) (not (eq stale 'who')) (eq where 'github')) in 90μs
  test_marks_sibling_facts_stale_when_one_fact_already_stale_for_good_user PASS (0.16s)
1 tests, 1 assertions, 0 failures, 0 errors, 0 skips
```

The full test file passes after the fix:

```
4 tests, 16 assertions, 0 failures, 0 errors, 0 skips
Line Coverage: 97.22% (35 / 36)
```

## Test plan
- [x] `bundle exec ruby test/judges/test-eliminate-ghosts.rb -n test_marks_sibling_facts_stale_when_one_fact_already_stale_for_good_user` passes with the fix
- [x] The same test fails without the fix (Expected: 3, Actual: 1)
- [x] All 4 tests in `test/judges/test-eliminate-ghosts.rb` pass after the change
- [ ] `make` (full Docker build) — to be run by CI

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)