### PR TITLE
Fix #1361: rescue pull_request exceptions in find-missing-issues so the scan continues

### DIFF
--- a/judges/find-missing-issues/find-missing-issues.rb
+++ b/judges/find-missing-issues/find-missing-issues.rb
@@ -64,7 +64,20 @@ Fbe.consider('(and (eq where "github") (exists repository) (unique repository))'
       f.when = json[:created_at]
       f.who = json.dig(:user, :id)
       if type == 'pull'
-        ref = Fbe.octo.pull_request(repo, f.issue).dig(:head, :ref)
+        ref =
+          begin
+            Fbe.octo.pull_request(repo, f.issue).dig(:head, :ref)
+          rescue Octokit::NotFound, Octokit::Deprecated => e
+            $loog.info("The pull ##{f.issue} doesn't exist in #{repo}: #{e.message}")
+            Jp.issue_was_lost(f.where, f.repository, f.issue)
+            next
+          rescue Octokit::Forbidden => e
+            $loog.warn(
+              "[#{$judge}] Access forbidden to pull ##{f.issue} in #{repo} " \
+              "(transient, will retry next cycle): #{e.class}: #{e.message}"
+            )
+            next
+          end
         if ref
           f.branch = ref
         else

--- a/test/judges/test-find-missing-issues.rb
+++ b/test/judges/test-find-missing-issues.rb
@@ -44,4 +44,69 @@ class TestFindMissingIssues < Jp::Test
       '403 is transient — no issue-was-lost fact must be created; next cycle will retry the issue lookup'
     )
   end
+
+  def test_continues_scan_after_pull_request_not_found
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repositories/42', body: { id: 42, full_name: 'foo/foo' })
+    stub_github(
+      'https://api.github.com/repos/foo/foo/issues/45',
+      body: {
+        number: 45, pull_request: { url: 'https://api.github.com/repos/foo/foo/pulls/45' },
+        user: { id: 44, login: 'user' }, created_at: '2025-09-27 06:03:16 UTC'
+      }
+    )
+    stub_github(
+      'https://api.github.com/repos/foo/foo/pulls/45',
+      status: 404,
+      body: { message: 'Not Found', documentation_url: 'https://docs.github.com', status: '404' }
+    )
+    stub_github(
+      'https://api.github.com/repos/foo/foo/issues/46',
+      body: {
+        number: 46, pull_request: { url: 'https://api.github.com/repos/foo/foo/pulls/46' },
+        user: { id: 44, login: 'user' }, created_at: '2025-09-27 06:04:16 UTC'
+      }
+    )
+    stub_github(
+      'https://api.github.com/repos/foo/foo/pulls/46',
+      body: { id: 999, number: 46, head: { ref: 'feature-x' } }
+    )
+    stub_github('https://api.github.com/user/44', body: { id: 44, login: 'user' })
+    fb = Factbase.new
+    fb.with(_id: 1, what: 'pull-was-opened', repository: 42, issue: 44, where: 'github')
+      .with(_id: 2, what: 'pull-was-opened', repository: 42, issue: 47, where: 'github')
+    load_it('find-missing-issues', fb)
+    assert(
+      fb.one?(what: 'pull-was-opened', issue: 46, repository: 42, where: 'github', branch: 'feature-x'),
+      'pull #46 must still be processed after pull #45 raises Octokit::NotFound on the pull_request lookup'
+    )
+  end
+
+  def test_rescues_forbidden_on_pull_request_lookup
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repositories/42', body: { id: 42, full_name: 'foo/foo' })
+    stub_github(
+      'https://api.github.com/repos/foo/foo/issues/45',
+      body: {
+        number: 45, pull_request: { url: 'https://api.github.com/repos/foo/foo/pulls/45' },
+        user: { id: 44, login: 'user' }, created_at: '2025-09-27 06:03:16 UTC'
+      }
+    )
+    stub_github(
+      'https://api.github.com/repos/foo/foo/pulls/45',
+      status: 403,
+      body: { message: 'Resource not accessible by integration' }
+    )
+    stub_github('https://api.github.com/user/44', body: { id: 44, login: 'user' })
+    fb = Factbase.new
+    fb.with(_id: 1, what: 'pull-was-opened', repository: 42, issue: 44, where: 'github')
+      .with(_id: 2, what: 'pull-was-opened', repository: 42, issue: 46, where: 'github')
+    load_it('find-missing-issues', fb)
+    refute(
+      fb.one?(what: 'issue-was-lost', where: 'github', issue: 45, repository: 42),
+      '403 is transient — no issue-was-lost fact must be created on pull_request 403; next cycle will retry'
+    )
+  end
 end


### PR DESCRIPTION
Closes #1361.

## Root cause

`judges/find-missing-issues/find-missing-issues.rb:67` makes an unprotected `Fbe.octo.pull_request(repo, f.issue)` call inside `missing.each { ... Fbe.fb.txn { ... } ... }`. When the PR has been deleted, transferred, made private, or hits a transient 403 between the gap-fill discovery and this branch lookup, the call raises `Octokit::NotFound` / `Octokit::Forbidden` / `Octokit::Deprecated`. Nothing along the path (`Fbe.fb.txn` → `missing.each` → `Fbe.consider` / `Fbe::Conclude#roll`, which only rescues `Fbe::OffQuota`) catches these, so the exception unwinds the entire per-repository scan and every remaining missing PR in the batch is silently dropped. This is the same shape as #1360 but in a separate judge — fixing one did not fix the other.

## Proof of fix

### Reproduction test

`test/judges/test-find-missing-issues.rb#test_continues_scan_after_pull_request_not_found` sets up a gap of two missing pulls (#45 and #46) where `pull_request(#45)` returns 404 and `pull_request(#46)` returns OK with a head ref, then asserts that #46 still gets a `pull-was-opened` fact with branch.

### Before the patch (failure)

```
$ bundle exec ruby test/judges/test-find-missing-issues.rb -n test_continues_scan_after_pull_request_not_found

  test_continues_scan_after_pull_request_not_found               ERROR (0.14s)
Minitest::UnexpectedError:         Octokit::NotFound: GET https://api.github.com/repos/foo/foo/pulls/45: 404 - Not Found // See: https://docs.github.com
            judges/find-missing-issues/find-missing-issues.rb:67:in 'block (3 levels) in <top (required)>'
            judges/find-missing-issues/find-missing-issues.rb:55:in 'block (2 levels) in <top (required)>'
            judges/find-missing-issues/find-missing-issues.rb:32:in 'Array#each'
            judges/find-missing-issues/find-missing-issues.rb:32:in 'block in <top (required)>'
            judges/find-missing-issues/find-missing-issues.rb:20:in '<top (required)>'

1 tests, 0 assertions, 0 failures, 1 errors, 0 skips
```

### Full file suite (after patch)

```
$ bundle exec ruby test/judges/test-find-missing-issues.rb -v

  test_rescues_forbidden_on_issue_lookup                         PASS (0.16s)
  test_continues_scan_after_pull_request_not_found               PASS (0.01s)
  test_find_missing_issues_if_issue_not_found                    PASS (0.01s)
  test_rescues_forbidden_on_pull_request_lookup                  PASS (0.01s)

4 tests, 5 assertions, 0 failures, 0 errors, 0 skips
```

## Changed files

- `judges/find-missing-issues/find-missing-issues.rb` — wrap the line-67 `Fbe.octo.pull_request` call in a `begin/rescue` that handles `Octokit::NotFound`/`Octokit::Deprecated` (mark the issue as lost via `Jp.issue_was_lost`, then `next`) and `Octokit::Forbidden` (log as transient, `next`); mirrors the rescue shape merged in #1360 for `find-earliest-issue` / `find-latest-issue`.
- `test/judges/test-find-missing-issues.rb` — add `test_continues_scan_after_pull_request_not_found` (the regression test: second missing PR must still be processed after the first one's `pull_request` lookup 404s) and `test_rescues_forbidden_on_pull_request_lookup` (covers the second rescue branch: a 403 on `pull_request` must not tombstone the issue).