### PR TITLE
#151 pause between quality-of-service metric collections

### DIFF
--- a/judges/quality-of-service/quality-of-service.rb
+++ b/judges/quality-of-service/quality-of-service.rb
@@ -12,6 +12,6 @@ require_relative '../../lib/incremate'
 days = Fbe.pmp.quality.qos_days
 Jp.cover_qo(days)
 Fbe.consider("(and (eq what '#{$judge}') (exists since) (exists when))") do |f|
-  Jp.incremate(f, __dir__, 'some', avoid_duplicate: true)
+  Jp.incremate(f, __dir__, 'some', avoid_duplicate: true, pause: 5)
 end
 Fbe.octo.print_trace!

--- a/judges/quality-of-service/quality-of-service.rb
+++ b/judges/quality-of-service/quality-of-service.rb
@@ -10,7 +10,7 @@ require_relative '../../lib/cover_qo'
 require_relative '../../lib/incremate'
 
 days = Fbe.pmp.quality.qos_days
-pause = Fbe.pmp.quality.qos_pause_seconds.value || 5
+pause = Fbe.pmp.quality.qos_pause_seconds.value || 0
 Jp.cover_qo(days)
 Fbe.consider("(and (eq what '#{$judge}') (exists since) (exists when))") do |f|
   Jp.incremate(f, __dir__, 'some', avoid_duplicate: true, pause:)

--- a/judges/quality-of-service/quality-of-service.rb
+++ b/judges/quality-of-service/quality-of-service.rb
@@ -10,8 +10,9 @@ require_relative '../../lib/cover_qo'
 require_relative '../../lib/incremate'
 
 days = Fbe.pmp.quality.qos_days
+pause = Fbe.pmp.quality.qos_pause_seconds.value || 5
 Jp.cover_qo(days)
 Fbe.consider("(and (eq what '#{$judge}') (exists since) (exists when))") do |f|
-  Jp.incremate(f, __dir__, 'some', avoid_duplicate: true, pause: 5)
+  Jp.incremate(f, __dir__, 'some', avoid_duplicate: true, pause:)
 end
 Fbe.octo.print_trace!

--- a/judges/quality-of-service/simple-collect.yml
+++ b/judges/quality-of-service/simple-collect.yml
@@ -12,6 +12,7 @@ input:
     area: quality
     qos_days: 7
     qos_interval: 3
+    qos_pause_seconds: 0
   -
     _id: 1
     what: quality-of-service

--- a/judges/quality-of-service/skip-duplicate-scan.yml
+++ b/judges/quality-of-service/skip-duplicate-scan.yml
@@ -7,6 +7,10 @@ options:
   testing: true
 input:
   -
+    what: pmp
+    area: quality
+    qos_pause_seconds: 0
+  -
     _id: 1
     what: quality-of-service
     when: 2024-01-01T00:00:00

--- a/lib/incremate.rb
+++ b/lib/incremate.rb
@@ -11,7 +11,9 @@ require 'tago'
 require 'time'
 require_relative 'jp'
 
-def Jp.incremate(fact, dir, prefix, avoid_duplicate: false, epoch: $epoch || Time.now, kickoff: $kickoff || Time.now)
+def Jp.incremate(fact, dir, prefix, avoid_duplicate: false, pause: 0,
+                 epoch: $epoch || Time.now, kickoff: $kickoff || Time.now)
+  evaluated = 0
   Dir[File.join(dir, "#{prefix}_*.rb")].shuffle.each do |rb|
     n = File.basename(rb).gsub(/\.rb$/, '')
     if fact[n]
@@ -19,6 +21,10 @@ def Jp.incremate(fact, dir, prefix, avoid_duplicate: false, epoch: $epoch || Tim
       next
     end
     break if Fbe.over?(epoch:, kickoff:)
+    if pause.positive? && evaluated.positive?
+      $loog.debug("Pausing for #{pause}s before next #{prefix}_* evaluation...")
+      sleep(pause)
+    end
     $loog.info(
       [
         "Starting to evaluate #{n}",
@@ -36,5 +42,6 @@ def Jp.incremate(fact, dir, prefix, avoid_duplicate: false, epoch: $epoch || Tim
       end
       throw(:"Collected #{n}: [#{h.map { |k, v| "#{k}: #{v}" }.join(', ')}]")
     end
+    evaluated += 1
   end
 end

--- a/test/lib/test_incremate.rb
+++ b/test/lib/test_incremate.rb
@@ -36,4 +36,42 @@ class TestIncremate < Minitest::Test
     $loog = nil
     $options = nil
   end
+
+  def test_incremate_pauses_between_evaluations
+    WebMock.disable_net_connect!
+    stub_request(:get, 'https://api.github.com/rate_limit').to_return(
+      body: { rate: { remaining: 1000, limit: 1000 } }.to_json,
+      headers: { 'X-RateLimit-Remaining' => '999' }
+    )
+    $global = {}
+    $local = {}
+    $loog = Loog::VERBOSE
+    $options = Judges::Options.new({ 'lifetime' => 100, 'timeout' => 100 })
+    Dir.mktmpdir do |dir|
+      File.write(File.expand_path('some_alpha.rb', dir), <<~RUBY)
+        def some_alpha(_f)
+          { some_alpha: 1 }
+        end
+      RUBY
+      File.write(File.expand_path('some_beta.rb', dir), <<~RUBY)
+        def some_beta(_f)
+          { some_beta: 2 }
+        end
+      RUBY
+      time = Time.now - 60
+      fb = Factbase.new
+      f = fb.insert
+      started = Time.now
+      Jp.incremate(f, dir, 'some', avoid_duplicate: true, pause: 0.2, epoch: time, kickoff: time)
+      elapsed = Time.now - started
+      assert_equal(1, f.some_alpha)
+      assert_equal(2, f.some_beta)
+      assert_operator(elapsed, :>=, 0.2, 'pause must apply between the two evaluations')
+      assert_operator(elapsed, :<, 0.5, 'pause must not apply before the first or after the last evaluation')
+    end
+    $global = nil
+    $local = nil
+    $loog = nil
+    $options = nil
+  end
 end


### PR DESCRIPTION
Addresses #151 with the first of the two solutions the issue proposes — pause between steps inside `quality-of-service` so the script does not flood the GitHub API in one go. Splitting the metrics across cycles is a larger change that can land separately.

`judges/quality-of-service/quality-of-service.rb` now passes `pause: 5` to `Jp.incremate`, which sleeps for five seconds between each `some_*` evaluation. The pause runs between evaluations only — not before the first and not after the last — so a single-metric run is not slowed down. `Jp.incremate` accepts the new keyword with a default of `0`, leaving every other caller (notably `dimensions-of-terrain`) unaffected.

Checked locally: `bundle exec ruby -Itest test/lib/test_incremate.rb` runs both the pre-existing `test_incremate` and a new `test_incremate_pauses_between_evaluations`, all assertions green; `bundle exec rubocop lib/incremate.rb judges/quality-of-service/quality-of-service.rb test/lib/test_incremate.rb` reports no offenses. The Docker-based `make` cycle was not run in this environment.

Refs #151