### PR TITLE
#589 skip search_issues calls in quality-of-service when off quota

### DIFF
--- a/judges/quality-of-service/some_issue_lifetime.rb
+++ b/judges/quality-of-service/some_issue_lifetime.rb
@@ -11,6 +11,7 @@ def some_issue_lifetime(fact)
   { issue: 'some_issue_lifetime', pr: 'some_pull_lifetime' }.each do |type, prop|
     ages = []
     Fbe.unmask_repos do |repo|
+      return {} if Fbe.octo.off_quota?
       q = "repo:#{repo} type:#{type} closed:#{fact.since.utc.iso8601}..#{fact.when.utc.iso8601}"
       ages +=
         Fbe.octo.search_issues(q)[:items].map do |json|

--- a/judges/quality-of-service/some_merged_pulls.rb
+++ b/judges/quality-of-service/some_merged_pulls.rb
@@ -10,9 +10,11 @@ def some_merged_pulls(fact)
   pulls = []
   rejected = []
   Fbe.unmask_repos do |repo|
+    return {} if Fbe.octo.off_quota?
     pulls << Fbe.octo.search_issues(
       "repo:#{repo} type:pr is:merged closed:#{fact.since.utc.iso8601}..#{fact.when.utc.iso8601}"
     )[:total_count]
+    return {} if Fbe.octo.off_quota?
     rejected << Fbe.octo.search_issues(
       "repo:#{repo} type:pr is:unmerged closed:#{fact.since.utc.iso8601}..#{fact.when.utc.iso8601}"
     )[:total_count]

--- a/judges/quality-of-service/some_pull_hoc_size.rb
+++ b/judges/quality-of-service/some_pull_hoc_size.rb
@@ -10,6 +10,7 @@ def some_pull_hoc_size(fact)
   hocs = []
   files = []
   Fbe.unmask_repos do |repo|
+    return {} if Fbe.octo.off_quota?
     Fbe.octo.search_issues(
       "repo:#{repo} type:pr is:merged closed:#{fact.since.utc.iso8601}..#{fact.when.utc.iso8601}"
     )[:items].each do |json|

--- a/judges/quality-of-service/some_review_time.rb
+++ b/judges/quality-of-service/some_review_time.rb
@@ -12,6 +12,7 @@ def some_review_time(fact)
   reviewers = []
   reviews = []
   Fbe.unmask_repos do |repo|
+    return {} if Fbe.octo.off_quota?
     Fbe.octo.search_issues(
       "repo:#{repo} type:pr is:merged closed:#{fact.since.utc.iso8601}..#{fact.when.utc.iso8601}"
     )[:items].each do |pr|

--- a/judges/quality-of-service/some_triage_time.rb
+++ b/judges/quality-of-service/some_triage_time.rb
@@ -12,6 +12,7 @@ def some_triage_time(fact)
   threshold = Fbe.pmp.quality.qos_min_triage_seconds.value || 60
   times = []
   Fbe.unmask_repos do |repo|
+    return {} if Fbe.octo.off_quota?
     Fbe.octo.search_issues(
       "repo:#{repo} type:issue created:#{fact.since.utc.iso8601}..#{fact.when.utc.iso8601}"
     )[:items].each do |issue|


### PR DESCRIPTION
Addresses #589, which reports that `quality-of-service` keeps hitting `search_issues` even after GitHub returns a 403 "API rate limit exceeded" — the same `(reqid, timestamp)` query is fired four times in the linked failing run because nothing tells the loop to back off when the quota is gone.

The sibling judge `judges/quality-of-service/some_backlog_size.rb` already follows the established pattern, `return {} if Fbe.octo.off_quota?` inside the `Fbe.unmask_repos` block. This PR applies the same guard to the five remaining `search_issues` call sites in the same directory: `some_issue_lifetime.rb`, `some_triage_time.rb`, `some_review_time.rb`, `some_pull_hoc_size.rb`, and `some_merged_pulls.rb` (two checks, one per `search_issues` call). When the quota is already exhausted on entry to a repository, the judge skips its search and returns an empty hash — the same outcome `some_backlog_size` produces today — instead of issuing another doomed request.

Verified locally with `bundle exec ruby -Ilib -Itest test/judges/test-quality-of-service.rb` from the `judges-action` checkout: 17 tests, 66 assertions, 0 failures, 0 errors, 0 skips. `bundle exec rubocop` against the five touched files reports no offences.

Refs #589
