### PR TITLE
#1342 stop event scan with catch/throw instead of break inside Jp.supervision

### DIFF
--- a/judges/github-events/github-events.rb
+++ b/judges/github-events/github-events.rb
@@ -297,46 +297,48 @@ Fbe.iterate do
       'label-was-attached' => %w[where repository issue label],
       'type-was-attached' => %w[where repository issue type]
     }
-    Fbe.octo.repository_events(repository).each_with_index do |json, idx|
-      Jp.supervision({ 'repo' => rname, 'json' => json.to_h }) do
-        if !$options.max_events.nil? && idx >= $options.max_events
-          $loog.debug("Already scanned #{idx} events in #{rname}, stop now")
-          break
-        end
-        total += 1
-        id = Integer(json[:id])
-        first = id if first.nil?
-        if id <= latest
-          $loog.debug(
-            "The event_id ##{id} (no.#{idx}) is not larger than ##{latest}, " \
-            "good stop in #{json[:repo][:name]}"
-          )
-          break
-        end
-        Fbe.fb.txn do |fbt|
-          f =
-            Fbe.if_absent(fb: fbt) do |n|
-              n.event_id = Integer(json[:id])
-              n.where = 'github'
+    catch(:done) do
+      Fbe.octo.repository_events(repository).each_with_index do |json, idx|
+        Jp.supervision({ 'repo' => rname, 'json' => json.to_h }) do
+          if !$options.max_events.nil? && idx >= $options.max_events
+            $loog.debug("Already scanned #{idx} events in #{rname}, stop now")
+            throw :done
+          end
+          total += 1
+          id = Integer(json[:id])
+          first = id if first.nil?
+          if id <= latest
+            $loog.debug(
+              "The event_id ##{id} (no.#{idx}) is not larger than ##{latest}, " \
+              "good stop in #{json[:repo][:name]}"
+            )
+            throw :done
+          end
+          Fbe.fb.txn do |fbt|
+            f =
+              Fbe.if_absent(fb: fbt) do |n|
+                n.event_id = Integer(json[:id])
+                n.where = 'github'
+              end
+            if f.nil?
+              $loog.debug("The event ##{id} just detected is already in the factbase")
+              next
             end
-          if f.nil?
-            $loog.debug("The event ##{id} just detected is already in the factbase")
-            next
+            fill(f, json)
+            uniques.each { |w, ff| throw :rollback if twice?(fbt, f, w, ff) }
+            if f['issue']
+              throw :rollback unless Fbe.fb.query(
+                "(and
+                  (eq where '#{f.where}')
+                  (eq repository #{f.repository})
+                  (eq issue #{f.issue})
+                  (exists done))"
+              ).each.empty?
+              throw :rollback if Fbe::Tombstone.new.has?(f.where, f.repository, f.issue)
+            end
+            $loog.info("Detected new event_id ##{id} (no.#{idx}) in #{json[:repo][:name]}: #{json[:type]}")
+            detected += 1
           end
-          fill(f, json)
-          uniques.each { |w, ff| throw :rollback if twice?(fbt, f, w, ff) }
-          if f['issue']
-            throw :rollback unless Fbe.fb.query(
-              "(and
-                (eq where '#{f.where}')
-                (eq repository #{f.repository})
-                (eq issue #{f.issue})
-                (exists done))"
-            ).each.empty?
-            throw :rollback if Fbe::Tombstone.new.has?(f.where, f.repository, f.issue)
-          end
-          $loog.info("Detected new event_id ##{id} (no.#{idx}) in #{json[:repo][:name]}: #{json[:type]}")
-          detected += 1
         end
       end
     end


### PR DESCRIPTION
Addresses #1342, which reports that the two `break` statements inside `Jp.supervision { ... }` in `judges/github-events/github-events.rb` (around lines 300-341 on master) don't terminate the surrounding `each_with_index` — `break` exits the method that received the block, which here is `Jp.supervision`, not the outer enumerator. The outer loop kept iterating after `max_events` was reached or after an event id fell at or below the latest seen, so the `"Already scanned ... stop now"` and `"good stop in ..."` debug lines fired once per remaining event and the subsequent guard work was repeated for every leftover entry.

This PR wraps the scan in `catch(:done)` and replaces both `break` statements with `throw :done`. `UncaughtThrowError` is not a `StandardError`, so the throw flies through `Jp.supervision`'s `rescue StandardError` clause untouched and the outer `each_with_index` terminates on the first hit, which is what the original log wording already promised. The inner `throw :rollback` markers stay on a different symbol and keep their existing scope inside `Fbe.fb.txn`.

Verified locally with `bundle exec ruby test/judges/test-github-events.rb` — 42 tests, 127 assertions, 0 failures, 0 errors, 1 skip. `bundle exec rubocop judges/github-events/github-events.rb` reports no offences. The existing `test_stop_scanning_if_number_event_greater_than_max_events` and `test_stop_scanning_if_event_id_less_or_eq_than_latest` tests still pass, so the observable behaviour on small fixtures is unchanged; the fix shows up in production where the upstream enumerator is paginated and the old code kept asking it for more events.

Refs #1342