### PR TITLE
Fix sqlite cache max entry option in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ The following `k=v` pairs inside the `options` may be important:
   and
   `-yegor256/judges` means an exclusion of the repo from the list.
 * `sqlite_cache_maxsize=10M` is the maximum size of HTTP cache file
-* `sqlite_cache_maxsize=10K` is the maximum size of a single HTTP entry to cache
+* `sqlite_cache_maxvsize=10K` is the maximum size of a single HTTP entry to cache
 
 The `zerocracy/pages-action` plugin is responsible for rendering
   the summary HTML page: its configuration is not explained here,


### PR DESCRIPTION
## Summary
- correct the documented per-entry cache option from `sqlite_cache_maxsize` to `sqlite_cache_maxvsize`
- align the README with the workflow example that uses separate max-size and max-entry-size keys

## Verification
- documentation-only change; no tests run

Closes #1388
