### PR TITLE
#1358 rescue pull_request lookup in pull-was-opened

### DIFF
--- a/judges/pull-was-opened/pull-was-opened.rb
+++ b/judges/pull-was-opened/pull-was-opened.rb
@@ -55,7 +55,20 @@ Fbe.conclude do
     n.what = $judge
     n.when = json[:created_at]
     n.who = json.dig(:user, :id)
-    ref = Fbe.octo.pull_request(repo, f.issue).dig(:head, :ref)
+    ref =
+      begin
+        Fbe.octo.pull_request(repo, f.issue).dig(:head, :ref)
+      rescue Octokit::NotFound, Octokit::Deprecated => e
+        $loog.info("The pull ##{f.issue} disappeared from #{repo} between issue and pull lookups: #{e.message}")
+        Jp.issue_was_lost(f.where, f.repository, f.issue)
+        throw(:rollback)
+      rescue Octokit::Forbidden => e
+        $loog.warn(
+          "[#{$judge}] Access forbidden to pull ##{f.issue} in #{repo} " \
+          "(transient, will retry next cycle): #{e.class}: #{e.message}"
+        )
+        throw(:rollback)
+      end
     if ref
       n.branch = ref
     else

--- a/test/judges/test-pull-was-opened.rb
+++ b/test/judges/test-pull-was-opened.rb
@@ -31,4 +31,60 @@ class TestPullWasOpened < Jp::Test
       '403 is transient — fact must NOT be marked stale; next cycle will retry the issue lookup'
     )
   end
+
+  def test_rescues_not_found_on_pull_request_lookup
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repos/foo/foo', body: { id: 42, full_name: 'foo/foo' })
+    stub_github('https://api.github.com/repositories/42', body: { id: 42, full_name: 'foo/foo' })
+    stub_github(
+      'https://api.github.com/repos/foo/foo/issues/44',
+      body: {
+        number: 44, state: 'open', user: { id: 421, login: 'user' },
+        created_at: Time.parse('2025-09-30 15:35:30 UTC')
+      }
+    )
+    stub_github('https://api.github.com/repos/foo/foo/pulls/44', status: 404, body: { message: 'Not Found' })
+    fb = Factbase.new
+    fb.with(_id: 1, what: 'pull-was-reviewed', repository: 42, issue: 44, where: 'github')
+    load_it('pull-was-opened', fb)
+    refute(
+      fb.one?(what: 'pull-was-opened', repository: 42, issue: 44, where: 'github'),
+      'partial pull-was-opened fact must be rolled back when the pull_request lookup 404s'
+    )
+    assert(
+      fb.one?(what: 'pull-was-reviewed', repository: 42, issue: 44, where: 'github', stale: 'issue'),
+      'a 404 on the follow-up pull_request lookup must mark the seed fact as stale'
+    )
+  end
+
+  def test_rescues_forbidden_on_pull_request_lookup
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repos/foo/foo', body: { id: 42, full_name: 'foo/foo' })
+    stub_github('https://api.github.com/repositories/42', body: { id: 42, full_name: 'foo/foo' })
+    stub_github(
+      'https://api.github.com/repos/foo/foo/issues/44',
+      body: {
+        number: 44, state: 'open', user: { id: 421, login: 'user' },
+        created_at: Time.parse('2025-09-30 15:35:30 UTC')
+      }
+    )
+    stub_github(
+      'https://api.github.com/repos/foo/foo/pulls/44',
+      status: 403,
+      body: { message: 'Resource not accessible by integration' }
+    )
+    fb = Factbase.new
+    fb.with(_id: 1, what: 'pull-was-reviewed', repository: 42, issue: 44, where: 'github')
+    load_it('pull-was-opened', fb)
+    refute(
+      fb.one?(what: 'pull-was-opened', repository: 42, issue: 44, where: 'github'),
+      'partial pull-was-opened fact must be rolled back when the pull_request lookup 403s'
+    )
+    refute(
+      fb.one?(what: 'issue-was-lost', repository: 42, issue: 44, where: 'github'),
+      '403 is transient — the issue must NOT be marked lost; next cycle will retry'
+    )
+  end
 end


### PR DESCRIPTION
Closes #1358

The `Fbe.octo.pull_request(repo, f.issue).dig(:head, :ref)` call on what was line 58 of `judges/pull-was-opened/pull-was-opened.rb` runs immediately after the rescued `Fbe.octo.issue` lookup, with no rescue of its own. Between the two API calls the pull request can be deleted, transferred, made private, or hit a transient 403, and the resulting `Octokit::NotFound`, `Octokit::Deprecated`, or `Octokit::Forbidden` propagates out of the `Fbe.conclude + draw` block and crashes the whole judge cycle. The patch wraps the call in the same `throw(:rollback)` rescue used a few lines above for the issue lookup — `NotFound`/`Deprecated` mark the issue lost and roll the txn back, `Forbidden` logs the transient failure and rolls the txn back so the next cycle retries.

After the patch, a 404 on the pull lookup rolls back the partially-populated `pull-was-opened` fact and marks the seed fact (`pull-was-merged`, `pull-was-reviewed`, …) stale through `Jp.issue_was_lost`, and a 403 rolls back the partial fact without staling anything so the next cycle retries.

I ran `bundle exec ruby test/judges/test-pull-was-opened.rb -v` and the three tests in the file all pass (`test_rescues_forbidden_on_issue_lookup`, `test_rescues_not_found_on_pull_request_lookup`, `test_rescues_forbidden_on_pull_request_lookup`). I also ran `bin/rubocop judges/pull-was-opened/pull-was-opened.rb test/judges/test-pull-was-opened.rb` and both files are clean.
