### PR TITLE
#1380 align type-was-attached timeline rescue with siblings

### DIFF
--- a/judges/type-was-attached/type-was-attached.rb
+++ b/judges/type-was-attached/type-was-attached.rb
@@ -8,6 +8,7 @@ require 'fbe/iterate'
 
 require 'fbe/octo'
 require 'joined'
+require_relative '../../lib/issue_was_lost'
 
 events = %w[issue_type_added issue_type_changed]
 
@@ -31,41 +32,48 @@ Fbe.iterate do
       (eq where 'github'))"
   repeats 64
   over do |repository, issue|
-    begin
-      repo = Fbe.octo.repo_name_by_id(repository)
-      Fbe.octo.issue_timeline(repo, issue).each do |te|
-        unless events.include?(te[:event])
-          $loog.debug("No #{events.joined} events at #{repo}##{issue}")
-          next
-        end
-        tee = Fbe.github_graph.issue_type_event(te[:node_id])
-        if tee.nil?
-          $loog.debug("Can't fetch event by node ID #{te[:node_id]}")
-          next
-        end
-        Fbe.fb.txn do |fbt|
-          nn =
-            Fbe.if_absent(fb: fbt) do |n|
-              n.issue = issue
-              n.what = $judge
-              n.type = tee.dig('issue_type', 'name')
-              n.repository = repository
-              n.where = 'github'
-            end
-          raise(RuntimeError, "Type already attached to #{repo}##{issue}") if nn.nil?
-          nn.who = tee.dig('actor', 'id')
-          nn.when = tee['created_at']
-          nn.details =
-            "The #{nn.type.inspect} type was attached by @#{tee.dig('actor', 'login')} " \
-            "to the issue #{Fbe.issue(nn)}."
-          $loog.info("Type attached to #{Fbe.issue(nn)} found: #{nn.type.inspect}")
-        end
+    repo = Fbe.octo.repo_name_by_id(repository)
+    timeline =
+      begin
+        Fbe.octo.issue_timeline(repo, issue)
+      rescue Octokit::NotFound, Octokit::Deprecated => e
+        $loog.info("Can't find issue ##{issue} in repository ##{repository}: #{e.message}")
+        Jp.issue_was_lost('github', repository, issue)
+        next issue
+      rescue Octokit::Forbidden => e
+        $loog.warn(
+          "[#{$judge}] Access forbidden to issue ##{issue} in repository ##{repository} " \
+          "(transient, will retry next cycle): #{e.class}: #{e.message}"
+        )
+        next issue
       end
-    rescue Octokit::NotFound
-      $loog.info("Can't find issue ##{issue} in repository ##{repository}")
-      Fbe.fb.query(
-        "(and (eq issue #{issue}) (eq repository #{repository}) (eq where 'github') (absent stale))"
-      ).each { |f| f.stale = 'issue' }
+    timeline.each do |te|
+      unless events.include?(te[:event])
+        $loog.debug("No #{events.joined} events at #{repo}##{issue}")
+        next
+      end
+      tee = Fbe.github_graph.issue_type_event(te[:node_id])
+      if tee.nil?
+        $loog.debug("Can't fetch event by node ID #{te[:node_id]}")
+        next
+      end
+      Fbe.fb.txn do |fbt|
+        nn =
+          Fbe.if_absent(fb: fbt) do |n|
+            n.issue = issue
+            n.what = $judge
+            n.type = tee.dig('issue_type', 'name')
+            n.repository = repository
+            n.where = 'github'
+          end
+        raise(RuntimeError, "Type already attached to #{repo}##{issue}") if nn.nil?
+        nn.who = tee.dig('actor', 'id')
+        nn.when = tee['created_at']
+        nn.details =
+          "The #{nn.type.inspect} type was attached by @#{tee.dig('actor', 'login')} " \
+          "to the issue #{Fbe.issue(nn)}."
+        $loog.info("Type attached to #{Fbe.issue(nn)} found: #{nn.type.inspect}")
+      end
     end
     issue
   end

--- a/test/judges/test-type-was-attached.rb
+++ b/test/judges/test-type-was-attached.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+# SPDX-License-Identifier: MIT
+
+require 'factbase'
+require_relative '../test__helper'
+
+class TestTypeWasAttached < Jp::Test
+  using SmartFactbase
+
+  def test_marks_stale_when_timeline_returns_not_found
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repositories/42', body: { id: 42, full_name: 'foo/foo' })
+    stub_github('https://api.github.com/repos/foo/foo', body: { id: 42, full_name: 'foo/foo' })
+    stub_github(
+      'https://api.github.com/repos/foo/foo/issues/44/timeline?per_page=100',
+      status: 404,
+      body: { message: 'Not Found', documentation_url: 'https://docs.github.com', status: '404' }
+    )
+    fb = Factbase.new
+    fb.with(_id: 1, what: 'issue-was-opened', repository: 42, issue: 44, where: 'github')
+    load_it('type-was-attached', fb)
+    assert(
+      fb.one?(what: 'issue-was-opened', repository: 42, issue: 44, where: 'github', stale: 'issue'),
+      '404 is permanent — issue must be marked stale via Jp.issue_was_lost'
+    )
+  end
+
+  def test_rescues_forbidden_on_timeline_lookup
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repositories/42', body: { id: 42, full_name: 'foo/foo' })
+    stub_github('https://api.github.com/repos/foo/foo', body: { id: 42, full_name: 'foo/foo' })
+    stub_github(
+      'https://api.github.com/repos/foo/foo/issues/44/timeline?per_page=100',
+      status: 403,
+      body: { message: 'Resource not accessible by integration' }
+    )
+    fb = Factbase.new
+    fb.with(_id: 1, what: 'issue-was-opened', repository: 42, issue: 44, where: 'github')
+    load_it('type-was-attached', fb)
+    f = fb.query('(eq issue 44)').each.first
+    refute_nil(f)
+    assert_nil(
+      f['stale'],
+      '403 is transient — fact must NOT be marked stale; next cycle will retry the timeline lookup'
+    )
+  end
+end


### PR DESCRIPTION
Closes #1380.

The outer `begin/rescue Octokit::NotFound` wrapping the inner loop in `judges/type-was-attached/type-was-attached.rb` is replaced with the canonical two-branch rescue pattern already used by `judges/label-was-attached/label-was-attached.rb:35-48` and `judges/issue-was-closed/issue-was-closed.rb:85-95`. `Fbe.octo.issue_timeline` is hoisted out of the loop so the rescue lands on the call that actually raises, `NotFound`/`Deprecated` routes through `Jp.issue_was_lost('github', repository, issue)` and falls through with `next issue` (Integer cursor advance per #1331), and `Forbidden` logs the transient warning and falls through without staling.

After the patch, a 404 on the timeline lookup marks the originating `issue-was-opened` fact with `stale: 'issue'` through the shared helper, and a 403 leaves the fact untouched so the next cycle retries — matching the semantics #1337 established for the rest of the Pattern A judges. The inline `Fbe.fb.query(...).each { |f| f.stale = 'issue' }` stale-marker and the missing `require_relative '../../lib/issue_was_lost'` are corrected.

Verified locally with `bundle exec ruby test/judges/test-type-was-attached.rb` — 2 tests, 3 assertions, 0 failures (one per rescue branch); the sibling `bundle exec ruby test/judges/test-label-was-attached.rb` still passes with 4 tests, 9 assertions. `bundle exec rubocop` reports no offences across the 93 inspected files.
