### PR TITLE
fix(label-was-attached): #1395 handle nil timeline payloads

### DIFF
--- a/judges/label-was-attached/label-was-attached.rb
+++ b/judges/label-was-attached/label-was-attached.rb
@@ -48,7 +48,7 @@ Fbe.iterate do
       end
     events.each do |te|
       next unless te[:event] == 'labeled'
-      badge = te[:label][:name]
+      badge = te.dig(:label, :name)
       next unless badges.include?(badge)
       Fbe.fb.txn do |fbt|
         nn =
@@ -63,10 +63,16 @@ Fbe.iterate do
           $loog.warn("A label #{badge.inspect} is already attached to #{repo}##{issue}")
           next
         end
-        nn.who = te[:actor][:id]
+        who = te.dig(:actor, :id)
+        if who
+          nn.who = who
+        else
+          nn.stale = 'who'
+        end
         nn.when = te[:created_at]
+        actor = te.dig(:actor, :login)
         nn.details =
-          "The #{nn.label.inspect} label was attached by @#{te[:actor][:login]} " \
+          "The #{nn.label.inspect} label was attached by #{actor ? "@#{actor}" : 'an unknown actor'} " \
           "to the issue #{Fbe.issue(nn)}."
         $loog.info("Label attached to #{Fbe.issue(nn)} found: #{nn.label.inspect}")
       end

--- a/test/judges/test-label-was-attached.rb
+++ b/test/judges/test-label-was-attached.rb
@@ -116,6 +116,55 @@ class TestLabelWasAttached < Jp::Test
     )
   end
 
+  def test_ignores_labeled_event_without_label_payload
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repositories/42', body: { id: 42, full_name: 'foo/foo' })
+    stub_github('https://api.github.com/repos/foo/foo', body: { id: 42, name: 'foo', full_name: 'foo/foo' })
+    stub_github(
+      'https://api.github.com/repos/foo/foo/issues/44/timeline?per_page=100',
+      body: [
+        {
+          id: 100,
+          actor: { id: 421, login: 'alice' },
+          event: 'labeled',
+          created_at: '2025-09-30 06:00:00 UTC',
+          label: nil
+        }
+      ]
+    )
+    fb = Factbase.new
+    fb.with(_id: 1, what: 'issue-was-opened', repository: 42, issue: 44, where: 'github')
+    load_it('label-was-attached', fb)
+    assert_equal(0, fb.query("(eq what 'label-was-attached')").each.to_a.size)
+  end
+
+  def test_attaches_label_without_actor_payload
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repositories/42', body: { id: 42, full_name: 'foo/foo' })
+    stub_github('https://api.github.com/repos/foo/foo', body: { id: 42, name: 'foo', full_name: 'foo/foo' })
+    stub_github(
+      'https://api.github.com/repos/foo/foo/issues/44/timeline?per_page=100',
+      body: [
+        {
+          id: 100,
+          actor: nil,
+          event: 'labeled',
+          created_at: '2025-09-30 06:00:00 UTC',
+          label: { name: 'bug', color: 'd73a4a' }
+        }
+      ]
+    )
+    fb = Factbase.new
+    fb.with(_id: 1, what: 'issue-was-opened', repository: 42, issue: 44, where: 'github')
+    load_it('label-was-attached', fb)
+    f = fb.query("(and (eq what 'label-was-attached') (eq label 'bug'))").each.first
+    refute_nil(f)
+    assert_nil(f['who'])
+    assert_equal(['who'], f['stale'])
+  end
+
   def test_marks_stale_when_timeline_returns_not_found
     WebMock.disable_net_connect!
     rate_limit_up


### PR DESCRIPTION
Fixes #1395.

## What changed

- Use `dig` for timeline `:label` and `:actor` payloads in `label-was-attached`.
- Skip labeled events with no label name, matching the sibling safe pattern.
- Keep the label fact when the actor payload is missing, but mark it `stale: who` instead of assigning a nil `who` value.
- Add regressions for nil label and nil actor timeline entries.

## Validation

- `PATH=/usr/local/Homebrew/Library/Homebrew/vendor/portable-ruby/current/bin:$PATH BUNDLE_PATH=/private/tmp/judges-action-1395-bundle BUNDLE_FROZEN=true bundle exec ruby test/judges/test-label-was-attached.rb -- --no-cov` passed: 6 tests, 13 assertions.
- `PATH=/usr/local/Homebrew/Library/Homebrew/vendor/portable-ruby/current/bin:$PATH BUNDLE_PATH=/private/tmp/judges-action-1395-bundle BUNDLE_FROZEN=true bundle exec rake test` passed: 190 tests, 524 assertions, 0 failures, 0 errors, 1 skip.
- `PATH=/usr/local/Homebrew/Library/Homebrew/vendor/portable-ruby/current/bin:$PATH BUNDLE_PATH=/private/tmp/judges-action-1395-bundle BUNDLE_FROZEN=true bundle exec rubocop judges/label-was-attached/label-was-attached.rb test/judges/test-label-was-attached.rb` passed: 2 files, no offenses.
- `PATH=/usr/local/Homebrew/Library/Homebrew/vendor/portable-ruby/current/bin:$PATH ruby -c judges/label-was-attached/label-was-attached.rb` passed.
- `PATH=/usr/local/Homebrew/Library/Homebrew/vendor/portable-ruby/current/bin:$PATH ruby -c test/judges/test-label-was-attached.rb` passed.
- `git diff HEAD~1..HEAD --check` passed.
- `git show --format= --patch HEAD | gitleaks stdin --no-banner --redact --timeout 30` passed with no leaks.

I used Homebrew portable Ruby 4.0.4 with the locked bundle installed under `/private/tmp/judges-action-1395-bundle`. The system Ruby on this macOS 12 host is 2.6, and a Homebrew `ruby@3.3` install entered an LLVM source-build path, so I did not complete that install.
