### PR TITLE
#1382 rescue per-PR review lookups in some_review_time

### DIFF
--- a/judges/quality-of-service/some_review_time.rb
+++ b/judges/quality-of-service/some_review_time.rb
@@ -5,6 +5,7 @@
 
 require 'fbe/octo'
 require 'fbe/unmask_repos'
+require 'octokit'
 
 def some_review_time(fact)
   times = []
@@ -15,10 +16,22 @@ def some_review_time(fact)
     Fbe.octo.search_issues(
       "repo:#{repo} type:pr is:merged closed:#{fact.since.utc.iso8601}..#{fact.when.utc.iso8601}"
     )[:items].each do |pr|
-      all = Fbe.octo.pull_request_reviews(repo, pr[:number])
+      all, csize =
+        begin
+          [Fbe.octo.pull_request_reviews(repo, pr[:number]), Fbe.octo.review_comments(repo, pr[:number]).size]
+        rescue Octokit::NotFound, Octokit::Deprecated => e
+          $loog.info("The pull ##{pr[:number]} doesn't exist in #{repo}: #{e.message}")
+          next
+        rescue Octokit::Forbidden => e
+          $loog.warn(
+            "[#{$judge}] Access forbidden to pull ##{pr[:number]} in #{repo} " \
+            "(transient, will retry next cycle): #{e.class}: #{e.message}"
+          )
+          next
+        end
       first = all.select { |r| r[:submitted_at] }.min_by { |r| r[:submitted_at] }
       times << Integer(pr[:pull_request][:merged_at] - first[:submitted_at]) if first
-      sizes << Fbe.octo.review_comments(repo, pr[:number]).size
+      sizes << csize
       users = all.map { |r| r.dig(:user, :id) }
       users.uniq!
       reviewers << users.size

--- a/test/judges/test-quality-of-service.rb
+++ b/test/judges/test-quality-of-service.rb
@@ -1181,6 +1181,131 @@ class TestQualityOfService < Jp::Test
     end
   end
 
+  def test_some_review_time_survives_not_found_on_one_pr_in_the_batch
+    WebMock.disable_net_connect!
+    stub_request(:get, 'https://api.github.com/rate_limit').to_return(
+      { body: '{"rate":{"remaining":222}}', headers: { 'X-RateLimit-Remaining' => '222' } }
+    )
+    stub_github('https://api.github.com/repos/foo/foo', body: { id: 42, full_name: 'foo/foo' })
+    stub_github(
+      'https://api.github.com/repos/foo/foo/actions/runs?created=2024-08-02T21:00:00Z..2024-08-09T21:00:00Z&per_page=100',
+      body: { total_count: 0, workflow_runs: [] }
+    )
+    stub_github('https://api.github.com/repos/foo/foo/releases?per_page=100', body: [])
+    stub_github(
+      'https://api.github.com/search/issues?per_page=100&' \
+      'q=repo:foo/foo%20type:issue%20closed:2024-08-02T21:00:00Z..2024-08-09T21:00:00Z',
+      body: {
+        total_count: 1, incomplete_results: false, items: [{ number: 42, labels: [{ name: 'bug' }] }]
+      }
+    )
+    stub_github(
+      'https://api.github.com/search/issues?per_page=100&q=repo:foo/foo%20type:pr%20closed:%3E2024-08-02',
+      body: {
+        total_count: 2, incomplete_results: false,
+        items: [{ id: 42, number: 10, title: 'Awesome 10' }, { id: 43, number: 11, title: 'Awesome 11' }]
+      }
+    )
+    stub_github(
+      'https://api.github.com/search/issues?per_page=100&' \
+      'q=repo:foo/foo%20type:pr%20closed:2024-08-02T21:00:00Z..2024-08-09T21:00:00Z',
+      body: {
+        total_count: 2, incomplete_results: false,
+        items: [{ id: 42, number: 10, title: 'Awesome 10' }, { id: 43, number: 11, title: 'Awesome 11' }]
+      }
+    )
+    (Date.parse('2024-08-02')..Date.parse('2024-08-09')).each do |date|
+      stub_github(
+        'https://api.github.com/search/issues?advanced_search=true&per_page=100&' \
+        "q=repo:foo/foo%20type:issue%20created:*..#{date}%20(closed:%3E=#{date}%20OR%20state:open)",
+        body: { total_count: 0, items: [] }
+      )
+    end
+    stub_github(
+      'https://api.github.com/search/issues?per_page=100&' \
+      'q=repo:foo/foo%20type:pr%20is:unmerged%20closed:2024-08-02T21:00:00Z..2024-08-09T21:00:00Z',
+      body: {
+        total_count: 1, incomplete_results: false, items: [{ id: 42, number: 10, title: 'Awesome 10' }]
+      }
+    )
+    stub_github(
+      'https://api.github.com/search/issues?per_page=100&' \
+      'q=repo:foo/foo%20type:pr%20is:merged%20closed:2024-08-02T21:00:00Z..2024-08-09T21:00:00Z',
+      body: {
+        total_count: 3, incomplete_results: false,
+        items: [
+          {
+            id: 50, number: 12, title: 'Awesome 12',
+            created_at: Time.parse('2024-08-20 22:00:00 UTC'),
+            pull_request: { merged_at: Time.parse('2024-08-27 18:30:00 UTC') }
+          },
+          {
+            id: 51, number: 14, title: 'Awesome 14',
+            created_at: Time.parse('2024-08-23 12:00:00 UTC'),
+            pull_request: { merged_at: Time.parse('2024-08-27 18:30:00 UTC') }
+          },
+          {
+            id: 52, number: 16, title: 'Awesome 16',
+            created_at: Time.parse('2024-08-25 12:00:00 UTC'),
+            pull_request: { merged_at: Time.parse('2024-08-27 18:30:00 UTC') }
+          }
+        ]
+      }
+    )
+    stub_github(
+      'https://api.github.com/repos/foo/foo/pulls/12',
+      body: { id: 50, number: 12, additions: 10, deletions: 5, changed_files: 1 }
+    )
+    stub_github(
+      'https://api.github.com/repos/foo/foo/pulls/14',
+      body: { id: 51, number: 14, additions: 10, deletions: 5, changed_files: 1 }
+    )
+    stub_github(
+      'https://api.github.com/repos/foo/foo/pulls/16',
+      body: { id: 52, number: 16, additions: 10, deletions: 5, changed_files: 1 }
+    )
+    stub_github(
+      'https://api.github.com/repos/foo/foo/pulls/12/reviews?per_page=100',
+      body: [
+        {
+          id: 22_449_326,
+          body: 'Some text 1',
+          user: { login: 'yegor257', id: 526_302, type: 'User' },
+          state: 'CHANGES_REQUESTED',
+          author_association: 'CONTRIBUTOR',
+          submitted_at: Time.parse('2024-08-21 22:00:00 UTC')
+        }
+      ]
+    )
+    stub_request(:get, 'https://api.github.com/repos/foo/foo/pulls/14/reviews?per_page=100').to_return(
+      status: 404,
+      body: { message: 'Not Found' }.to_json,
+      headers: { 'Content-Type': 'application/json', 'X-RateLimit-Remaining' => '999' }
+    )
+    stub_github('https://api.github.com/repos/foo/foo/pulls/16/reviews?per_page=100', body: [])
+    stub_github('https://api.github.com/repos/foo/foo/pulls/12/comments?per_page=100', body: [])
+    stub_github('https://api.github.com/repos/foo/foo/pulls/16/comments?per_page=100', body: [])
+    stub_github(
+      'https://api.github.com/search/issues?per_page=100&' \
+      'q=repo:foo/foo%20type:issue%20created:2024-08-02T21:00:00Z..2024-08-09T21:00:00Z',
+      body: { total_count: 0, incomplete_results: false, items: [] }
+    )
+    fb = Factbase.new
+    f = fb.insert
+    f.what = 'pmp'
+    f.area = 'quality'
+    f.qos_days = 7
+    f.qos_interval = 3
+    Time.stub(:now, Time.parse('2024-08-09 21:00:00 UTC')) do
+      load_it('quality-of-service', fb)
+      f = fb.query('(eq what "quality-of-service")').each.first
+      assert_equal([505_800], f['some_review_time'])
+      assert_equal([0, 0], f['some_review_size'])
+      assert_equal([1, 0], f['some_reviewers_per_pull'])
+      assert_equal([1, 0], f['some_reviews_per_pull'])
+    end
+  end
+
   def test_quality_of_service_some_triage_time
     WebMock.disable_net_connect!
     stub_request(:get, 'https://api.github.com/rate_limit').to_return(


### PR DESCRIPTION
Closes #1382.

`judges/quality-of-service/some_review_time.rb:18-21` was the last Pattern A site in this judge with unprotected per-PR GitHub calls. Both `Fbe.octo.pull_request_reviews(repo, pr[:number])` and `Fbe.octo.review_comments(repo, pr[:number]).size` ran inside the `search_issues[:items].each` loop with no rescue, so a single deleted, transferred, or 403'd merged PR in the batch caused `Octokit::NotFound`, `Octokit::Forbidden`, or `Octokit::Deprecated` to propagate out of the `.each` and through `Fbe.unmask_repos`, truncating the four-metric arrays (`some_review_time`, `some_review_size`, `some_reviewers_per_pull`, `some_reviews_per_pull`) and silently dropping every PR after the bad one — with no log line or tombstone marking the loss.

Both calls now sit inside one combined `begin/rescue` that returns the pair of values on success and `next`s on either failure mode: `Octokit::NotFound, Octokit::Deprecated => e` logs an info line and skips the PR (the permanent case), and `Octokit::Forbidden => e` logs the transient warning with the `[#{$judge}]` prefix and skips the PR (the next cycle retries the lookup). The pattern matches the canonical form already in `judges/fix-missing-branch/fix-missing-branch.rb:25-38` and the recently-landed #1396 fix in `pull-was-opened.rb`. The rescue intentionally covers both lookups together because either failure on the same PR makes the metric pair meaningless, and one rescue keeps the control flow flat.

Verified with `bundle exec ruby test/judges/test-quality-of-service.rb -n test_some_review_time_survives_not_found_on_one_pr_in_the_batch` (1 test, 4 assertions, 0 failures), the existing `test_quality_of_service_some_review_time_comments_reviewers_and_reviews` still green (1 test, 6 assertions), the full `bundle exec ruby test/judges/test-quality-of-service.rb` (18 tests, 70 assertions, 0 failures), `bundle exec rake test` across the whole repo (189 tests, 524 assertions, 0 failures, 1 skip), and `bundle exec rake rubocop` (92 files inspected, no offenses).
