### PR TITLE
#1392 test absoluteness of sqlite cache path, not INPUT_FACTBASE

### DIFF
--- a/entry.sh
+++ b/entry.sh
@@ -206,7 +206,7 @@ fi
 
 sqlite=$(printenv "INPUT_SQLITE-CACHE" || true)
 if [ -n "${sqlite}" ]; then
-    sqlite=$(realpath "$( [[ ${INPUT_FACTBASE} = /* ]] && echo "${sqlite}" || echo "${GITHUB_WORKSPACE}/${sqlite}" )")
+    sqlite=$(realpath "$( [[ ${sqlite} = /* ]] && echo "${sqlite}" || echo "${GITHUB_WORKSPACE}/${sqlite}" )")
     options+=("--option=sqlite_cache=${sqlite}");
     echo "Using SQLite for HTTP caching: ${sqlite}"
     ${JUDGES} "${gopts[@]}" download \


### PR DESCRIPTION
Closes #1392.

`entry.sh:209` was the sqlite cache path normalisation line. The conditional `[[ ${INPUT_FACTBASE} = /* ]]` inspected the factbase path for a leading slash but then used `${sqlite}` in both branches, so the absoluteness of the cache path was being decided by an unrelated input. With `INPUT_FACTBASE` absolute and `INPUT_SQLITE-CACHE` relative, the bare relative path was fed to `realpath` and resolved against the install directory rather than `${GITHUB_WORKSPACE}`; with `INPUT_FACTBASE` relative and `INPUT_SQLITE-CACHE` absolute, `${GITHUB_WORKSPACE}/` was prepended to an already-absolute path, producing a double-slash path that `realpath` collapsed to the wrong file. The same pattern at line 70 normalises `INPUT_FACTBASE` and correctly tests `INPUT_FACTBASE`; line 209 copied the pattern without retargeting the test.

The fix swaps `${INPUT_FACTBASE}` for `${sqlite}` in the test on line 209, so the absoluteness check matches the value being normalised. The two branches and the surrounding `realpath` wrapper are unchanged.

Ran `shellcheck entry.sh` (clean) and `bashate entry.sh` (no new warnings; the line-too-long warning on line 209 pre-existed). The change is shell-only and does not touch any Ruby code, so the rake suite is unaffected; CI will run the full make/rake/actionlint/bashate/checkmake/copyrights/hadolint/pdd/reuse/shellcheck/typos/xcop/yamllint matrix on the push.