### PR TITLE
#1398 rescue transient comment lookup failures

### DIFF
--- a/judges/fix-missing-comments/fix-missing-comments.rb
+++ b/judges/fix-missing-comments/fix-missing-comments.rb
@@ -27,9 +27,15 @@ Fbe.consider(
   json =
     begin
       Fbe.octo.pull_request(repo, f.issue)
-    rescue Octokit::NotFound
-      $loog.info("#{Fbe.issue(f)} doesn't exist in #{repo}")
+    rescue Octokit::NotFound, Octokit::Deprecated => e
+      $loog.info("#{Fbe.issue(f)} doesn't exist in #{repo}: #{e.message}")
       Jp.issue_was_lost(f.where, f.repository, f.issue)
+      next
+    rescue Octokit::Forbidden => e
+      $loog.warn(
+        "[#{$judge}] Access forbidden to #{Fbe.issue(f)} in #{repo} " \
+        "(transient, will retry next cycle): #{e.class}: #{e.message}"
+      )
       next
     end
   Jp.fill_fact_by_hash(f, Jp.comments_info(json, repo:))

--- a/test/judges/test-fix-missing-comments.rb
+++ b/test/judges/test-fix-missing-comments.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+# SPDX-License-Identifier: MIT
+
+require 'factbase'
+require_relative '../test__helper'
+
+class TestFixMissingComments < Jp::Test
+  using SmartFactbase
+
+  def test_rescues_forbidden_on_pull_lookup
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repos/foo/foo', body: { id: 42, full_name: 'foo/foo' })
+    stub_github('https://api.github.com/repositories/42', body: { id: 42, full_name: 'foo/foo' })
+    stub_github(
+      'https://api.github.com/repos/foo/foo/pulls/44',
+      status: 403,
+      body: { message: 'Resource not accessible by integration' }
+    )
+    fb = Factbase.new
+    fb.with(_id: 1, what: 'pull-was-merged', repository: 42, issue: 44, where: 'github')
+    load_it('fix-missing-comments', fb)
+    f = fb.query('(eq issue 44)').each.first
+    refute_nil(f)
+    assert_nil(f['stale'], '403 must retry without marking stale')
+    assert_nil(f['comments'], '403 must leave comments absent until retry')
+  end
+end


### PR DESCRIPTION
Fixes #1398.

Changes:
- Treat `Octokit::Deprecated` like `NotFound` for the pull lookup and mark the issue as lost.
- Treat `Octokit::Forbidden` as transient, log a warning, and retry on the next cycle instead of aborting the batch.
- Add a focused regression test for the 403 path in `fix-missing-comments`.

Validation:
- `git diff --check`
- Focused Ruby tests were blocked locally because this machine only has system Ruby 2.6 and the bundle is not installed; the repository already uses newer Ruby syntax such as keyword argument forwarding (`repo:`), so local Ruby cannot parse the current tree.