### PR TITLE
#1403 rescue Octokit::Deprecated and Forbidden in fix-missing-who

### DIFF
--- a/judges/fix-missing-who/fix-missing-who.rb
+++ b/judges/fix-missing-who/fix-missing-who.rb
@@ -8,6 +8,7 @@ require 'fbe/who'
 # SPDX-License-Identifier: MIT
 
 require 'octokit'
+require_relative '../../lib/issue_was_lost'
 
 {
   'issue-was-opened' => :user,
@@ -31,10 +32,15 @@ require 'octokit'
     json =
       begin
         Fbe.octo.issue(repo, f.issue)
-      rescue Octokit::NotFound
-        $loog.info("#{Fbe.issue(f)} doesn't exist in #{repo}")
-        f.stale = 'issue'
-        $loog.info("#{Fbe.issue(f)} is lost")
+      rescue Octokit::NotFound, Octokit::Deprecated => e
+        $loog.info("#{Fbe.issue(f)} doesn't exist in #{repo}: #{e.message}")
+        Jp.issue_was_lost(f.where, f.repository, f.issue)
+        next
+      rescue Octokit::Forbidden => e
+        $loog.warn(
+          "[#{$judge}] Access forbidden to #{Fbe.issue(f)} in #{repo} " \
+          "(transient, will retry next cycle): #{e.class}: #{e.message}"
+        )
         next
       end
     who = json.dig(a, :id)

--- a/test/judges/test-fix-missing-who.rb
+++ b/test/judges/test-fix-missing-who.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+# SPDX-License-Identifier: MIT
+
+require 'factbase'
+require_relative '../test__helper'
+
+class TestFixMissingWho < Jp::Test
+  using SmartFactbase
+
+  def test_rescues_forbidden_on_issue_lookup
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repos/foo/foo', body: { id: 42, full_name: 'foo/foo' })
+    stub_github('https://api.github.com/repositories/42', body: { id: 42, full_name: 'foo/foo' })
+    stub_github(
+      'https://api.github.com/repos/foo/foo/issues/44',
+      status: 403,
+      body: { message: 'Resource not accessible by integration' }
+    )
+    fb = Factbase.new
+    fb.with(_id: 1, what: 'pull-was-opened', repository: 42, issue: 44, where: 'github')
+    load_it('fix-missing-who', fb)
+    f = fb.query('(eq issue 44)').each.first
+    refute_nil(f)
+    assert_nil(f['stale'], '403 is transient — fact must NOT be marked stale; next cycle will retry the issue lookup')
+    assert_nil(f['who'], 'who must remain absent so the next cycle re-runs the lookup')
+  end
+
+  def test_rescues_deprecated_on_issue_lookup
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repos/foo/foo', body: { id: 42, full_name: 'foo/foo' })
+    stub_github('https://api.github.com/repositories/42', body: { id: 42, full_name: 'foo/foo' })
+    stub_github(
+      'https://api.github.com/repos/foo/foo/issues/55',
+      status: 410,
+      body: { message: 'Issues are disabled for this repo' }
+    )
+    fb = Factbase.new
+    fb.with(_id: 1, what: 'issue-was-opened', repository: 42, issue: 55, where: 'github')
+    load_it('fix-missing-who', fb)
+    f = fb.query('(eq issue 55)').each.first
+    refute_nil(f)
+    assert_equal('issue', f['stale'].first, '410 is permanent — fact must be marked stale via Jp.issue_was_lost')
+  end
+end


### PR DESCRIPTION
Closes #1403.

`judges/fix-missing-who/fix-missing-who.rb` rescued only `Octokit::NotFound` around `Fbe.octo.issue(repo, f.issue)`, so any `Octokit::Deprecated` (the marker paired with `NotFound` everywhere else for retired endpoints) or `Octokit::Forbidden` (the transient 403 GitHub returns on rate-limit hits, SSO scope changes, or revoked tokens) propagated out of `Fbe.consider` and aborted the entire `fix-missing-who` pass for the rest of the cycle. The block iterates five `what` values (`issue-was-opened`, `pull-was-opened`, `issue-was-closed`, `pull-was-closed`, `pull-was-merged`), so one bad row also killed the `who` backfill for every later kind in the same cycle.

The rescue now follows the two-branch shape established by `judges/fix-missing-branch/fix-missing-branch.rb` and recently applied to `pull-was-opened` (#1396), `fix-missing-comments` (#1407), and `fix-missing-hoc` (#1406): the permanent case rescues `Octokit::NotFound, Octokit::Deprecated`, routes through the shared `Jp.issue_was_lost` helper (replacing the inline `f.stale = 'issue'` assignment), and `next`s; the transient case rescues `Octokit::Forbidden`, logs the `[#{$judge}]` warning, and `next`s without staling, so the next cycle retries the lookup.

Verified locally with `bundle exec rake test` (200 tests, 552 assertions, 0 failures, 0 errors, 1 skip; line coverage 89.79%) and `rubocop` (96 files, no offenses). Added `test/judges/test-fix-missing-who.rb` with two cases mirroring `test-fix-missing-branch.rb`: a 403 stub asserts the fact is not marked stale (transient retry path), and a 410 stub asserts `Jp.issue_was_lost` stales the fact (permanent path).