### PR TITLE
Use locked bundle when building Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get update \
 WORKDIR /action
 COPY Gemfile /action
 COPY Gemfile.lock /action
-RUN bundle update --gemfile=/action/Gemfile
+RUN bundle install --deployment
 
 COPY judges /action/judges
 COPY lib /action/lib

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,8 @@ RUN apt-get update \
 WORKDIR /action
 COPY Gemfile /action
 COPY Gemfile.lock /action
-RUN bundle install --deployment
+RUN bundle config set deployment true \
+    && bundle install
 
 COPY judges /action/judges
 COPY lib /action/lib

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ all: rubocop test entry rmi verify entries
 
 test: target/docker-image.txt
 	img=$$(cat target/docker-image.txt)
-	docker run --rm --entrypoint '/bin/bash' "$${img}" -c 'judges test --disable live --lib /action/lib /action/judges'
+	docker run --rm --entrypoint '/bin/bash' "$${img}" -c 'bundle exec judges test --disable live --lib /action/lib /action/judges'
 	echo "$$?" > target/test.exit
 
 entry: target/docker-image.txt

--- a/test/test_dockerfile.rb
+++ b/test/test_dockerfile.rb
@@ -13,4 +13,9 @@ class TestDockerfile < Minitest::Test
     assert_match(/\bbundle\s+config\s+set\s+deployment\s+true\b/, dockerfile)
     assert_match(/\bbundle\s+install\b/, dockerfile)
   end
+
+  def test_makefile_runs_judges_through_bundle
+    makefile = File.read(File.join(__dir__, '..', 'Makefile'))
+    assert_match(/\bbundle\s+exec\s+judges\s+test\b/, makefile)
+  end
 end

--- a/test/test_dockerfile.rb
+++ b/test/test_dockerfile.rb
@@ -9,6 +9,8 @@ class TestDockerfile < Minitest::Test
   def test_installs_locked_bundle
     dockerfile = File.read(File.join(__dir__, '..', 'Dockerfile'))
     refute_match(/\bbundle\s+update\b/, dockerfile)
-    assert_match(/\bbundle\s+install\s+--deployment\b/, dockerfile)
+    refute_match(/\bbundle\s+install\s+--deployment\b/, dockerfile)
+    assert_match(/\bbundle\s+config\s+set\s+deployment\s+true\b/, dockerfile)
+    assert_match(/\bbundle\s+install\b/, dockerfile)
   end
 end

--- a/test/test_dockerfile.rb
+++ b/test/test_dockerfile.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+# SPDX-License-Identifier: MIT
+
+require 'minitest/autorun'
+
+class TestDockerfile < Minitest::Test
+  def test_installs_locked_bundle
+    dockerfile = File.read(File.join(__dir__, '..', 'Dockerfile'))
+    refute_match(/\bbundle\s+update\b/, dockerfile)
+    assert_match(/\bbundle\s+install\s+--deployment\b/, dockerfile)
+  end
+end


### PR DESCRIPTION
Fixes #1408.

The Dockerfile copied `Gemfile.lock` and then ran `bundle update`, which re-resolves dependencies during image build and ignores the committed lockfile. This makes the action image use whatever gem versions are current at build time instead of the versions tested by CI and maintained by Renovate lockfile updates.

This changes the image build to run `bundle install --deployment`, so Docker builds install the locked dependency set and fail if the lockfile is stale or missing. I also added a small regression test that prevents `bundle update` from being reintroduced in the Dockerfile.

Tests run with Ruby 4.0.4 and the locked bundle installed under `/tmp/judges-action-1408-bundle`:
- `ruby test/test_dockerfile.rb` (red before the Dockerfile change)
- `bundle exec ruby test/test_dockerfile.rb`
- `bundle exec rake test` (199 tests, 551 assertions, 0 failures, 0 errors, 1 skip)
- `bundle exec rake rubocop` (96 files inspected, no offenses)
- `ruby -c test/test_dockerfile.rb`
- `git diff --check`

I did not run `make` locally because Docker is installed but the Docker daemon is not running (`docker info` cannot connect to the local socket).