### PR TITLE
#1409 mark fact stale on who when timeline actor is deleted

### DIFF
--- a/judges/issue-was-closed/issue-was-closed.rb
+++ b/judges/issue-was-closed/issue-was-closed.rb
@@ -107,10 +107,16 @@ Fbe.iterate do
           $loog.warn("A label #{badge.inspect} is already attached to #{repo}##{issue}")
           next
         end
-        nn.who = te.dig(:actor, :id)
+        who = te.dig(:actor, :id)
+        if who
+          nn.who = who
+        else
+          nn.stale = 'who'
+        end
         nn.when = te[:created_at]
+        actor = te.dig(:actor, :login)
         nn.details =
-          "Seemingly, the #{nn.label.inspect} label was attached by @#{te.dig(:actor, :login)} " \
+          "Seemingly, the #{nn.label.inspect} label was attached by #{actor ? "@#{actor}" : 'an unknown actor'} " \
           "to the issue #{Fbe.issue(nn)}."
         $loog.info("Label attached to #{Fbe.issue(nn)} found: #{nn.label.inspect}")
       end

--- a/judges/type-was-attached/type-was-attached.rb
+++ b/judges/type-was-attached/type-was-attached.rb
@@ -67,10 +67,16 @@ Fbe.iterate do
             n.where = 'github'
           end
         raise(RuntimeError, "Type already attached to #{repo}##{issue}") if nn.nil?
-        nn.who = tee.dig('actor', 'id')
+        who = tee.dig('actor', 'id')
+        if who
+          nn.who = who
+        else
+          nn.stale = 'who'
+        end
         nn.when = tee['created_at']
+        actor = tee.dig('actor', 'login')
         nn.details =
-          "The #{nn.type.inspect} type was attached by @#{tee.dig('actor', 'login')} " \
+          "The #{nn.type.inspect} type was attached by #{actor ? "@#{actor}" : 'an unknown actor'} " \
           "to the issue #{Fbe.issue(nn)}."
         $loog.info("Type attached to #{Fbe.issue(nn)} found: #{nn.type.inspect}")
       end

--- a/test/judges/test-issue-was-closed.rb
+++ b/test/judges/test-issue-was-closed.rb
@@ -170,6 +170,41 @@ class TestIssueWasClosed < Jp::Test
     assert(fb.one?(what: 'label-was-attached', repository: 42, issue: 52, where: 'github', label: 'bug', who: 421))
   end
 
+  def test_marks_label_stale_on_who_when_timeline_actor_is_nil
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repositories/42', body: { id: 42, full_name: 'foo/foo' })
+    stub_github('https://api.github.com/repos/foo/foo', body: { id: 42, full_name: 'foo/foo' })
+    stub_github(
+      'https://api.github.com/repos/foo/foo/issues/52',
+      body: {
+        number: 52, title: 'some title 52', state: 'closed',
+        closed_at: Time.parse('2025-07-10 10:00:00 UTC'),
+        closed_by: { login: 'user1', id: 222_111 }
+      }
+    )
+    stub_github(
+      'https://api.github.com/repos/foo/foo/issues/52/timeline?per_page=100',
+      body: [
+        {
+          id: 195,
+          actor: nil,
+          event: 'labeled',
+          created_at: '2025-09-30 06:14:38 UTC',
+          label: { name: 'bug', color: 'd73a4a' }
+        }
+      ]
+    )
+    fb = Factbase.new
+    fb.with(_id: 1, what: 'issue-was-opened', repository: 42, issue: 52, where: 'github')
+    load_it('issue-was-closed', fb)
+    f = fb.query("(and (eq what 'label-was-attached') (eq label 'bug'))").each.first
+    refute_nil(f)
+    assert_nil(f['who'], 'who must not be set to nil for a deleted timeline actor')
+    assert_equal(['who'], f['stale'], 'a deleted timeline actor must mark the fact stale on who')
+    assert_match(/an unknown actor/, f['details'].first)
+  end
+
   def test_rescues_forbidden_on_issue_lookup
     WebMock.disable_net_connect!
     rate_limit_up

--- a/test/judges/test-type-was-attached.rb
+++ b/test/judges/test-type-was-attached.rb
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: MIT
 
 require 'factbase'
+require 'fbe/github_graph'
 require_relative '../test__helper'
 
 class TestTypeWasAttached < Jp::Test
@@ -47,5 +48,43 @@ class TestTypeWasAttached < Jp::Test
       f['stale'],
       '403 is transient — fact must NOT be marked stale; next cycle will retry the timeline lookup'
     )
+  end
+
+  def test_marks_stale_when_graphql_actor_is_nil
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repositories/42', body: { id: 42, full_name: 'foo/foo' })
+    stub_github('https://api.github.com/repos/foo/foo', body: { id: 42, full_name: 'foo/foo' })
+    stub_github(
+      'https://api.github.com/repos/foo/foo/issues/44/timeline?per_page=100',
+      body: [
+        {
+          id: 100,
+          event: 'issue_type_added',
+          node_id: 'ITAE_orphan_actor',
+          created_at: '2025-09-30 06:14:38 UTC'
+        }
+      ]
+    )
+    fake = Fbe::Graph::Fake.new
+    fake.define_singleton_method(:issue_type_event) do |_node_id|
+      {
+        'type' => 'IssueTypeAddedEvent',
+        'created_at' => Time.parse('2025-09-30 06:14:38 UTC'),
+        'issue_type' => { 'id' => 'IT_x', 'name' => 'Bug', 'description' => 'd' },
+        'prev_issue_type' => nil,
+        'actor' => { 'login' => nil, 'type' => nil, 'id' => nil, 'name' => nil, 'email' => nil }
+      }
+    end
+    fb = Factbase.new
+    fb.with(_id: 1, what: 'issue-was-opened', repository: 42, issue: 44, where: 'github')
+    Fbe.stub(:github_graph, fake) do
+      load_it('type-was-attached', fb)
+    end
+    f = fb.query("(eq what 'type-was-attached')").each.first
+    refute_nil(f, 'the fact must still be created when the actor is deleted')
+    assert_nil(f['who'], 'who must not be set to nil for a deleted GraphQL actor')
+    assert_equal(['who'], f['stale'], 'a deleted GraphQL actor must mark the fact stale on who')
+    assert_match(/an unknown actor/, f['details'].first)
   end
 end


### PR DESCRIPTION
Closes #1409.

`judges/type-was-attached/type-was-attached.rb:70` set `nn.who = tee.dig('actor', 'id')` and `judges/issue-was-closed/issue-was-closed.rb:110` set `nn.who = te.dig(:actor, :id)` without guarding for the deleted-actor case. When GitHub returns a timeline event whose `actor` payload is `null` — which happens routinely once the user account has been removed — the right-hand side evaluated to `nil` and the fact ended up with `who = nil`, diverging from every sibling judge that touches the same timeline stream (`label-was-attached`, `pull-was-merged`, `who-is-alive`, `who-has-name`, `is-human-or-robot`, `fix-missing-who`, `eliminate-ghosts`) and skipping the `stale = 'who'` signal that downstream judges like `fix-missing-who` and `revive-user` rely on to backfill the actor on a later cycle.

Aligns both judges with the canonical fallback already in `label-was-attached.rb:66-76` (the #1395 fix): capture the actor id into a local, set `nn.who` when truthy, set `nn.stale = 'who'` otherwise, and substitute `'an unknown actor'` for the `@login` interpolation in `nn.details` so the rendered detail does not produce a dangling `@`. No other change.

Verified locally with `bundle exec ruby -e "require 'rake'; load 'Rakefile'; Rake::Task[:test].invoke"` (200 tests, 557 assertions, 0 failures, 0 errors, 1 skip; line coverage 90.23%) and `rubocop` on the four touched files (no offenses). Added one regression test per judge: `test_marks_label_stale_on_who_when_timeline_actor_is_nil` in `test/judges/test-issue-was-closed.rb` stubs `actor: nil` on a `labeled` timeline event and asserts `who` is absent, `stale = ['who']`, and the detail reads `an unknown actor`; `test_marks_stale_when_graphql_actor_is_nil` in `test/judges/test-type-was-attached.rb` stubs the GraphQL `issue_type_event` response with an `actor` whose `id`/`login` are `nil` and makes the same three assertions.
