### PR TITLE
#1390 use jq -r so latest release tag is not double-quoted in entry.sh

### DIFF
--- a/entry.sh
+++ b/entry.sh
@@ -12,7 +12,7 @@ echo "The 'judges-action' ${VERSION} is running"
 
 if [ "${SKIP_VERSION_CHECKING}" != 'true' ]; then
     resp=$(curl --silent -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/zerocracy/judges-action/releases/latest)
-    latest=$(echo -n "$resp" | jq -Rs "try (fromjson | .tag_name) catch empty")
+    latest=$(echo -n "$resp" | jq -Rrs "try (fromjson | .tag_name) catch empty")
     if [ -z "${latest}" ]; then
         echo "!!! Could not fetch the latest version from GitHub."
         echo "!!! GitHub returned: "


### PR DESCRIPTION
Resolves #1390. Without `-r`, the `jq` call on `entry.sh:15` returns the tag as a JSON-encoded string, so the comparison on line 22 compares a quoted nine-character value against the unquoted `VERSION` written by `.rultor.yml`. The two values never match, the version-mismatch warning fires on every run, and the printed message embeds the literal quote characters.

Adding `-r` to the first `jq` invocation makes it emit the bare tag string, matching the canonical reading on `entry.sh:266` that already uses `jq -r '.tag_name'`. The comparison on line 22 then evaluates as intended and the warning only fires on a real version drift.

I ran `bash -n entry.sh` to confirm the script still parses, and I verified the behavior of both forms locally with a stubbed payload:

```
$ echo '{"tag_name":"0.17.17"}' | jq -Rs  "try (fromjson | .tag_name) catch empty"
"0.17.17"
$ echo '{"tag_name":"0.17.17"}' | jq -Rrs "try (fromjson | .tag_name) catch empty"
0.17.17
```

Closes #1390
