### PR TITLE
#1416: handle erase repository octokit errors

### DIFF
--- a/judges/erase-repository/erase-repository.rb
+++ b/judges/erase-repository/erase-repository.rb
@@ -7,6 +7,7 @@ require 'elapsed'
 require 'fbe/consider'
 require 'fbe/octo'
 require 'logger'
+require 'octokit'
 
 good = {}
 
@@ -18,9 +19,14 @@ Fbe.fb.query('(and (eq where "github") (exists repository) (absent stale))').eac
     json = Fbe.octo.repository(r)
     good[r] = true
     throw(:"GitHub repository ##{r} is found: #{json[:full_name]}")
-  rescue Octokit::NotFound
+  rescue Octokit::NotFound, Octokit::Deprecated => e
     good[r] = false
-    throw(:"GitHub repository ##{r} is not found")
+    throw(:"GitHub repository ##{r} is not found: #{e.message}")
+  rescue Octokit::Forbidden => e
+    $loog.warn(
+      "[#{$judge}] Access forbidden to GitHub repository ##{r} " \
+      "(transient, will retry next cycle): #{e.class}: #{e.message}"
+    )
   end
 end
 

--- a/test/judges/test-erase-repository.rb
+++ b/test/judges/test-erase-repository.rb
@@ -59,4 +59,38 @@ class TestEraseRepository < Jp::Test
     assert_equal(1, fb.query('(and (eq where "gitlab") (exists repository))').each.to_a.size)
     assert_equal(1, fb.query('(and (eq where "gitlab") (absent repository))').each.to_a.size)
   end
+
+  def test_erase_deprecated_repository
+    WebMock.disable_net_connect!
+    stub_request(:get, 'https://api.github.com/rate_limit').to_return(
+      { body: '{"rate":{"remaining":222}}', headers: { 'X-RateLimit-Remaining' => '222' } }
+    )
+    stub_github('https://api.github.com/repositories/410123', body: '', status: 410)
+    fb = Factbase.new
+    fb.insert.then do |f|
+      f._id = 1
+      f.where = 'github'
+      f.repository = 410_123
+    end
+    load_it('erase-repository', fb)
+    assert_equal(1, fb.query('(exists stale)').each.to_a.size)
+    assert_equal('repository', fb.query('(exists stale)').each.to_a.first.stale)
+  end
+
+  def test_forbidden_repository_is_not_erased
+    WebMock.disable_net_connect!
+    stub_request(:get, 'https://api.github.com/rate_limit').to_return(
+      { body: '{"rate":{"remaining":222}}', headers: { 'X-RateLimit-Remaining' => '222' } }
+    )
+    stub_github('https://api.github.com/repositories/403123', body: '', status: 403)
+    fb = Factbase.new
+    fb.insert.then do |f|
+      f._id = 1
+      f.where = 'github'
+      f.repository = 403_123
+    end
+    load_it('erase-repository', fb)
+    assert_equal(0, fb.query('(exists stale)').each.to_a.size)
+    assert_equal(1, fb.query('(and (eq where "github") (exists repository) (absent stale))').each.to_a.size)
+  end
 end


### PR DESCRIPTION
Summary:
- Treat `Octokit::Deprecated` the same as `NotFound` when `erase-repository` checks repository existence.
- Treat `Octokit::Forbidden` as transient: warn and leave the repository fact unstaled for a later retry.
- Add regressions for 410/Deprecated and 403/Forbidden repository lookups.

Closes #1416

Validation:
- Pre-fix probe: repository HTTP 410 raised `Octokit::Deprecated`; repository HTTP 403 raised `Octokit::Forbidden` out of `erase-repository`.
- `bundle exec ruby -Itest -e "ARGV << \"--no-cov\"; require \"./test/judges/test-erase-repository\"; ARGV.delete(\"--no-cov\")"` -> 3 tests, 11 assertions, 0 failures, 0 errors, 0 skips.
- `bundle exec ruby -Itest -e "ARGV << \"--no-cov\"; require \"./test/test_pattern_a_coverage\"; ARGV.delete(\"--no-cov\")"` -> 1 run, 4 assertions, 0 failures, 0 errors, 0 skips.
- `bundle exec rake` -> unit suite 202 tests, 556 assertions, 0 failures, 0 errors, 1 skip; judge fixtures 28 judges and 59 tests passed; RuboCop inspected 96 files with no offenses; per-file Ruby checks completed with no failures.
- `git diff --check` -> passed.
- `gitleaks protect --staged --no-banner --redact --verbose` -> no leaks found.

No secrets were added.