### PR TITLE
#1414: handle code review lookup errors

### DIFF
--- a/judges/code-was-reviewed/code-was-reviewed.rb
+++ b/judges/code-was-reviewed/code-was-reviewed.rb
@@ -7,6 +7,7 @@ require 'fbe/issue'
 
 require 'fbe/octo'
 require 'fbe/who'
+require 'octokit'
 require_relative '../../lib/issue_was_lost'
 
 Fbe.consider(
@@ -46,9 +47,15 @@ Fbe.consider(
   reviews =
     begin
       Fbe.octo.pull_request_reviews(repo, f.issue)
-    rescue Octokit::NotFound
-      $loog.info("The pull request ##{f.issue} doesn't exist in #{repo}")
+    rescue Octokit::NotFound, Octokit::Deprecated => e
+      $loog.info("The pull request ##{f.issue} doesn't exist in #{repo}: #{e.message}")
       Jp.issue_was_lost(f.where, f.repository, f.issue)
+      next
+    rescue Octokit::Forbidden => e
+      $loog.warn(
+        "[#{$judge}] Access forbidden to reviews for pull ##{f.issue} in #{repo} " \
+        "(transient, will retry next cycle): #{e.class}: #{e.message}"
+      )
       next
     end
   reviews.each do |review|

--- a/test/judges/test-code-was-reviewed.rb
+++ b/test/judges/test-code-was-reviewed.rb
@@ -108,4 +108,76 @@ class TestCodeWasReviewed < Jp::Test
       'forbidden error must leave the original fact untouched'
     )
   end
+
+  def test_rescues_deprecated_on_reviews_lookup
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repositories/42', body: { id: 42, full_name: 'foo/foo' })
+    stub_github(
+      'https://api.github.com/repos/foo/foo/pulls/99',
+      body: {
+        id: 99, number: 99, user: { id: 421, login: 'user' },
+        created_at: Time.parse('2025-09-01 15:35:30 UTC'), additions: 1, deletions: 2
+      }
+    )
+    stub_github(
+      'https://api.github.com/repos/foo/foo/pulls/99/reviews?per_page=100',
+      status: 410,
+      body: { message: 'Gone' }
+    )
+    fb = Factbase.new
+    fb.with(_id: 1, what: 'pull-was-closed', repository: 42, issue: 99, where: 'github')
+    load_it('code-was-reviewed', fb)
+    assert(
+      fb.one?(what: 'pull-was-closed', repository: 42, issue: 99, stale: 'issue'),
+      'deprecated reviews lookup must mark the sibling pull fact stale through Jp.issue_was_lost'
+    )
+  end
+
+  def test_rescues_forbidden_on_reviews_lookup_and_continues
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repositories/42', body: { id: 42, full_name: 'foo/foo' })
+    stub_github(
+      'https://api.github.com/repos/foo/foo/pulls/99',
+      body: {
+        id: 99, number: 99, user: { id: 421, login: 'user' },
+        created_at: Time.parse('2025-09-01 15:35:30 UTC'), additions: 1, deletions: 2
+      }
+    )
+    stub_github(
+      'https://api.github.com/repos/foo/foo/pulls/99/reviews?per_page=100',
+      status: 403,
+      body: { message: 'Resource not accessible by integration' }
+    )
+    stub_github(
+      'https://api.github.com/repos/foo/foo/pulls/100',
+      body: {
+        id: 100, number: 100, user: { id: 421, login: 'user' },
+        created_at: Time.parse('2025-09-01 15:35:30 UTC'), additions: 3, deletions: 4
+      }
+    )
+    stub_github(
+      'https://api.github.com/repos/foo/foo/pulls/100/reviews?per_page=100',
+      body: [
+        { id: 50_100, user: { id: 422, login: 'user2' }, submitted_at: Time.parse('2025-09-02 10:39:20 UTC') }
+      ]
+    )
+    stub_github('https://api.github.com/repos/foo/foo/issues/100/comments?per_page=100', body: [])
+    stub_github('https://api.github.com/repos/foo/foo/pulls/100/reviews/50100/comments?per_page=100', body: [])
+    stub_github('https://api.github.com/user/421', body: {  id: 421, login: 'user1' })
+    stub_github('https://api.github.com/user/422', body: {  id: 422, login: 'user2' })
+    fb = Factbase.new
+    fb.with(_id: 1, what: 'pull-was-closed', repository: 42, issue: 99, where: 'github')
+      .with(_id: 2, what: 'pull-was-closed', repository: 42, issue: 100, where: 'github')
+    load_it('code-was-reviewed', fb)
+    refute(
+      fb.one?(what: 'pull-was-closed', repository: 42, issue: 99, stale: 'issue'),
+      'forbidden reviews lookup must leave the original pull fact untouched'
+    )
+    assert(
+      fb.one?(what: 'code-was-reviewed', repository: 42, issue: 100, who: 422, hoc: 7, author: 421),
+      'forbidden reviews lookup must not abort later candidates in the same judge batch'
+    )
+  end
 end


### PR DESCRIPTION
Summary:
- Treat `Octokit::Deprecated` the same as `NotFound` when `code-was-reviewed` fetches pull request reviews.
- Treat `Octokit::Forbidden` on review lookup as transient, leaving the original fact untouched and continuing the batch.
- Add regressions for 410/Deprecated and 403/Forbidden review-list lookups.

Closes #1414

Validation:
- Pre-fix probe: `pull_request_reviews` HTTP 410 raised `Octokit::Deprecated`; HTTP 403 raised `Octokit::Forbidden` out of `code-was-reviewed`.
- `bundle exec ruby -Itest -e "ARGV << \"--no-cov\"; require \"./test/judges/test-code-was-reviewed\"; ARGV.delete(\"--no-cov\")"` -> 5 tests, 8 assertions, 0 failures, 0 errors, 0 skips.
- `bundle exec ruby -Itest -e "ARGV << \"--no-cov\"; require \"./test/test_pattern_a_coverage\"; ARGV.delete(\"--no-cov\")"` -> 1 run, 4 assertions, 0 failures, 0 errors, 0 skips.
- `bundle exec rake` -> unit suite 202 tests, 555 assertions, 0 failures, 0 errors, 1 skip; judge fixtures 28 judges and 59 tests passed; RuboCop inspected 96 files with no offenses; per-file Ruby checks completed with no failures.
- `git diff --check` -> passed.
- `gitleaks protect --staged --no-banner --redact --verbose` -> no leaks found.

No secrets were added.