### PR TITLE
#1412: handle pull merge lookup errors

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -57,6 +57,9 @@ Elegant/GoodMethodName:
     - rate_limit_up
     - load_it
     - stub_github
+    - stub_pull_was_merged_base
+    - stub_pull_was_merged_issue
+    - stub_pull_was_merged_success
 Metrics/MethodLength:
   Enabled: false
 Metrics/AbcSize:

--- a/judges/pull-was-merged/pull-was-merged.rb
+++ b/judges/pull-was-merged/pull-was-merged.rb
@@ -69,6 +69,34 @@ Fbe.iterate do
       $loog.debug("Pull #{repo}##{issue} is not closed: #{json[:state].inspect}")
       next issue
     end
+    actor =
+      begin
+        Fbe.octo.issue(repo, issue)[:closed_by]
+      rescue Octokit::NotFound, Octokit::Deprecated => e
+        $loog.info("The issue ##{issue} doesn't exist in #{repo}: #{e.message}")
+        Jp.issue_was_lost('github', repository, issue)
+        next issue
+      rescue Octokit::Forbidden => e
+        $loog.warn(
+          "[#{$judge}] Access forbidden to issue ##{issue} in #{repo} " \
+          "(transient, will retry next cycle): #{e.class}: #{e.message}"
+        )
+        next issue
+      end
+    reviews =
+      begin
+        Fbe.octo.pull_request_reviews(repo, issue)
+      rescue Octokit::NotFound, Octokit::Deprecated => e
+        $loog.info("The reviews of pull ##{issue} don't exist in #{repo}: #{e.message}")
+        Jp.issue_was_lost('github', repository, issue)
+        next issue
+      rescue Octokit::Forbidden => e
+        $loog.warn(
+          "[#{$judge}] Access forbidden to reviews of pull ##{issue} in #{repo} " \
+          "(transient, will retry next cycle): #{e.class}: #{e.message}"
+        )
+        next issue
+      end
     Fbe.fb.txn do |fbt|
       nn =
         Fbe.if_absent(fb: fbt) do |n|
@@ -83,15 +111,14 @@ Fbe.iterate do
       nn.branch = json[:head][:ref]
       Jp.fill_fact_by_hash(nn, Jp.comments_info(json))
       Jp.fill_fact_by_hash(nn, Jp.fetch_workflows(json))
-      actor = Fbe.octo.issue(repo, issue)[:closed_by]
       if actor
         nn.who = Integer(actor[:id])
       else
         nn.stale = 'who'
       end
-      nn.suggestions = Jp.count_suggestions(repo, issue, json.dig(:user, :id))
+      nn.suggestions = Jp.count_suggestions(repo, issue, json.dig(:user, :id), reviews)
       nn.when = json[:closed_at] ? Time.parse(json[:closed_at].iso8601) : Time.now
-      review = Fbe.octo.pull_request_reviews(repo, issue).first
+      review = reviews.first
       nn.review = review[:submitted_at] if review
       nn.details = "Apparently, #{Fbe.issue(nn)} has been #{nn.what.inspect}."
       $loog.info("The pull #{Fbe.issue(nn)} was #{nn.what.inspect} #{nn.when.ago} ago")

--- a/lib/pull_request.rb
+++ b/lib/pull_request.rb
@@ -60,8 +60,8 @@ def Jp.fetch_workflows(pr, repo: nil)
   { succeeded_builds: succeeded, failed_builds: failed }
 end
 
-def Jp.count_suggestions(repo, issue, author)
-  Fbe.octo.pull_request_reviews(repo, issue).sum do |review|
+def Jp.count_suggestions(repo, issue, author, reviews = nil)
+  (reviews || Fbe.octo.pull_request_reviews(repo, issue)).sum do |review|
     next 0 if review.dig(:user, :id) == author
     Fbe.octo.pull_request_review_comments(repo, issue, review[:id]).sum do |comment|
       next 0 if comment.dig(:user, :id) == author || !comment[:in_reply_to_id].nil?

--- a/test/judges/test-pull-was-merged.rb
+++ b/test/judges/test-pull-was-merged.rb
@@ -356,4 +356,115 @@ class TestPullWasMerged < Jp::Test
     refute_nil(f)
     assert_equal('issue', f.stale, 'Jp.issue_was_lost should mark the fact stale=issue when pull lookup returns 404')
   end
+
+  def test_rescues_forbidden_on_issue_lookup_and_continues
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_pull_was_merged_success(45)
+    stub_pull_was_merged_base(44)
+    stub_github(
+      'https://api.github.com/repos/foo/foo/issues/44',
+      status: 403,
+      body: { message: 'Resource not accessible by integration' }
+    )
+    fb = Factbase.new
+    fb.with(_id: 1, what: 'pull-was-opened', repository: 42, issue: 44, where: 'github')
+      .with(_id: 2, what: 'pull-was-opened', repository: 42, issue: 45, where: 'github')
+    Fbe.stub(:github_graph, Fbe::Graph::Fake.new) do
+      load_it('pull-was-merged', fb)
+      assert_nil(fb.pick(issue: 44, what: 'pull-was-opened')['stale'])
+      assert(fb.none?(issue: 44, what: 'pull-was-merged'))
+      assert(fb.one?(issue: 45, what: 'pull-was-merged', repository: 42, where: 'github', who: 422))
+    end
+  end
+
+  def test_rescues_deprecated_on_issue_lookup
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_pull_was_merged_base(44)
+    stub_github('https://api.github.com/repos/foo/foo/issues/44', status: 410, body: { message: 'Gone' })
+    fb = Factbase.new
+    fb.with(_id: 1, what: 'pull-was-opened', repository: 42, issue: 44, where: 'github')
+    Fbe.stub(:github_graph, Fbe::Graph::Fake.new) { load_it('pull-was-merged', fb) }
+    assert_equal('issue', fb.pick(issue: 44, what: 'pull-was-opened').stale)
+    assert(fb.none?(issue: 44, what: 'pull-was-merged'))
+  end
+
+  def test_rescues_forbidden_on_reviews_lookup_and_continues
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_pull_was_merged_success(45)
+    stub_pull_was_merged_base(44)
+    stub_pull_was_merged_issue(44)
+    stub_github(
+      'https://api.github.com/repos/foo/foo/pulls/44/reviews?per_page=100',
+      status: 403,
+      body: { message: 'Resource not accessible by integration' }
+    )
+    fb = Factbase.new
+    fb.with(_id: 1, what: 'pull-was-opened', repository: 42, issue: 44, where: 'github')
+      .with(_id: 2, what: 'pull-was-opened', repository: 42, issue: 45, where: 'github')
+    Fbe.stub(:github_graph, Fbe::Graph::Fake.new) do
+      load_it('pull-was-merged', fb)
+      assert_nil(fb.pick(issue: 44, what: 'pull-was-opened')['stale'])
+      assert(fb.none?(issue: 44, what: 'pull-was-merged'))
+      assert(fb.one?(issue: 45, what: 'pull-was-merged', repository: 42, where: 'github', who: 422))
+    end
+  end
+
+  def test_rescues_deprecated_on_reviews_lookup
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_pull_was_merged_base(44)
+    stub_pull_was_merged_issue(44)
+    stub_github(
+      'https://api.github.com/repos/foo/foo/pulls/44/reviews?per_page=100',
+      status: 410,
+      body: { message: 'Gone' }
+    )
+    fb = Factbase.new
+    fb.with(_id: 1, what: 'pull-was-opened', repository: 42, issue: 44, where: 'github')
+    Fbe.stub(:github_graph, Fbe::Graph::Fake.new) { load_it('pull-was-merged', fb) }
+    assert_equal('issue', fb.pick(issue: 44, what: 'pull-was-opened').stale)
+    assert(fb.none?(issue: 44, what: 'pull-was-merged'))
+  end
+
+  private
+
+  def stub_pull_was_merged_success(issue)
+    stub_pull_was_merged_base(issue)
+    stub_pull_was_merged_issue(issue)
+    stub_github("https://api.github.com/repos/foo/foo/pulls/#{issue}/reviews?per_page=100", body: [])
+    stub_github("https://api.github.com/repos/foo/foo/pulls/#{issue}/comments?per_page=100", body: [])
+    stub_github("https://api.github.com/repos/foo/foo/issues/#{issue}/comments?per_page=100", body: [])
+    stub_github('https://api.github.com/repos/foo/foo/commits/aa123/check-runs?per_page=100', body: { check_runs: [] })
+  end
+
+  def stub_pull_was_merged_base(issue)
+    stub_github('https://api.github.com/repositories/42', body: { id: 42, full_name: 'foo/foo' })
+    stub_github('https://api.github.com/repos/foo/foo', body: { id: 42, name: 'foo', full_name: 'foo/foo' })
+    stub_github(
+      "https://api.github.com/repos/foo/foo/pulls/#{issue}",
+      body: {
+        id: 50, number: issue, user: { id: 421, login: 'user' }, state: 'closed',
+        merged_at: Time.parse('2025-09-30 18:00:00 UTC'),
+        closed_at: Time.parse('2025-09-30 18:00:00 UTC'),
+        created_at: Time.parse('2025-09-30 15:35:30 UTC'),
+        additions: 12, deletions: 5, changed_files: 1,
+        head: { ref: '40', sha: 'aa123' },
+        base: { repo: { id: 42, full_name: 'foo/foo' } }
+      }
+    )
+  end
+
+  def stub_pull_was_merged_issue(issue)
+    stub_github(
+      "https://api.github.com/repos/foo/foo/issues/#{issue}",
+      body: {
+        number: issue, title: "some title #{issue}", state: 'closed',
+        closed_at: Time.parse('2025-09-30 18:00:00 UTC'),
+        closed_by: { login: 'user2', id: 422 }
+      }
+    )
+  end
 end


### PR DESCRIPTION
Fixes #1412

Summary:
- Rescue `Octokit::NotFound`/`Octokit::Deprecated` and `Octokit::Forbidden` from the inner `issue` and `pull_request_reviews` lookups before the `pull-was-merged` transaction starts writing a result fact.
- Reuse the fetched reviews for `review` and suggestion counting so the judge does not make an unguarded second review-list call.
- Add regressions for permanent `410` and transient `403` responses on both inner lookups, including continuing later candidates after transient failures.

Validation:
- Pre-fix local reproduction: a stubbed `GET /repos/foo/foo/issues/44` `403` raised `Octokit::Forbidden` from `pull-was-merged` after the judge had started inserting the result fact.
- `bundle exec ruby -Itest -e 'ARGV << "--no-cov"; require "./test/judges/test-pull-was-merged"; ARGV.delete("--no-cov")'` -> 11 tests, 19 assertions, 0 failures, 0 errors, 0 skips.
- `bundle exec ruby -Itest -e 'ARGV << "--no-cov"; require "./test/test_pattern_a_coverage"; ARGV.delete("--no-cov")'` -> 1 run, 4 assertions, 0 failures, 0 errors, 0 skips.
- `bundle exec rubocop judges/pull-was-merged/pull-was-merged.rb lib/pull_request.rb test/judges/test-pull-was-merged.rb` -> 3 files inspected, no offenses detected.
- `bundle exec rake` -> unit suite 204 tests, 562 assertions, 0 failures, 0 errors, 1 skip; judge fixtures 28 judges and 59 tests passed; full RuboCop inspected 96 files with no offenses; per-file Ruby checks completed with no failures.
- `git diff --cached --check` -> passed.
- `gitleaks protect --staged --no-banner --redact --verbose` -> no leaks found.

No secrets or live service testing were used.
