### PR TITLE
#589: stop QoS search on quota exhaustion

### DIFF
--- a/judges/quality-of-service/quality-of-service.rb
+++ b/judges/quality-of-service/quality-of-service.rb
@@ -8,9 +8,11 @@ require 'fbe/octo'
 require 'fbe/pmp'
 require_relative '../../lib/cover_qo'
 require_relative '../../lib/incremate'
+require_relative '../../lib/qos_search'
 
 days = Fbe.pmp.quality.qos_days
 pause = Fbe.pmp.quality.qos_pause_seconds.value || 0
+Jp.qoreset
 Jp.cover_qo(days)
 Fbe.consider("(and (eq what '#{$judge}') (exists since) (exists when))") do |f|
   Jp.incremate(f, __dir__, 'some', avoid_duplicate: true, pause:)

--- a/judges/quality-of-service/some_backlog_size.rb
+++ b/judges/quality-of-service/some_backlog_size.rb
@@ -5,6 +5,7 @@
 
 require 'fbe/octo'
 require 'fbe/unmask_repos'
+require_relative '../../lib/qos_search'
 
 def some_backlog_size(fact)
   issues = []
@@ -12,10 +13,12 @@ def some_backlog_size(fact)
     (fact.since.utc.to_date..fact.when.utc.to_date).last(7).each do |date|
       return {} if Fbe.octo.off_quota?
       count = 0
-      Fbe.octo.search_issues(
+      found = Jp.qosearch(
         "repo:#{repo} type:issue created:*..#{date.iso8601[0..9]} (closed:>=#{date.iso8601[0..9]} OR state:open)",
         advanced_search: true
-      )[:items].each do |item|
+      )
+      return {} if found.nil?
+      found[:items].each do |item|
         count += 1 if item[:closed_at].nil? || item[:closed_at].utc.to_date >= date
       end
       issues << count

--- a/judges/quality-of-service/some_issue_lifetime.rb
+++ b/judges/quality-of-service/some_issue_lifetime.rb
@@ -5,6 +5,7 @@
 
 require 'fbe/octo'
 require 'fbe/unmask_repos'
+require_relative '../../lib/qos_search'
 
 def some_issue_lifetime(fact)
   ret = {}
@@ -13,8 +14,10 @@ def some_issue_lifetime(fact)
     Fbe.unmask_repos do |repo|
       return {} if Fbe.octo.off_quota?
       q = "repo:#{repo} type:#{type} closed:#{fact.since.utc.iso8601}..#{fact.when.utc.iso8601}"
+      found = Jp.qosearch(q)
+      return {} if found.nil?
       ages +=
-        Fbe.octo.search_issues(q)[:items].map do |json|
+        found[:items].map do |json|
           next if json[:closed_at].nil?
           next if json[:created_at].nil?
           json[:closed_at] - json[:created_at]

--- a/judges/quality-of-service/some_merged_pulls.rb
+++ b/judges/quality-of-service/some_merged_pulls.rb
@@ -5,19 +5,22 @@
 
 require 'fbe/octo'
 require 'fbe/unmask_repos'
+require_relative '../../lib/qos_search'
 
 def some_merged_pulls(fact)
   pulls = []
   rejected = []
   Fbe.unmask_repos do |repo|
     return {} if Fbe.octo.off_quota?
-    pulls << Fbe.octo.search_issues(
-      "repo:#{repo} type:pr is:merged closed:#{fact.since.utc.iso8601}..#{fact.when.utc.iso8601}"
-    )[:total_count]
+    q = "repo:#{repo} type:pr is:merged closed:#{fact.since.utc.iso8601}..#{fact.when.utc.iso8601}"
+    found = Jp.qosearch(q)
+    return {} if found.nil?
+    pulls << found[:total_count]
     return {} if Fbe.octo.off_quota?
-    rejected << Fbe.octo.search_issues(
-      "repo:#{repo} type:pr is:unmerged closed:#{fact.since.utc.iso8601}..#{fact.when.utc.iso8601}"
-    )[:total_count]
+    q = "repo:#{repo} type:pr is:unmerged closed:#{fact.since.utc.iso8601}..#{fact.when.utc.iso8601}"
+    found = Jp.qosearch(q)
+    return {} if found.nil?
+    rejected << found[:total_count]
   end
   {
     some_merged_pulls: pulls,

--- a/judges/quality-of-service/some_pull_hoc_size.rb
+++ b/judges/quality-of-service/some_pull_hoc_size.rb
@@ -5,15 +5,17 @@
 
 require 'fbe/octo'
 require 'fbe/unmask_repos'
+require_relative '../../lib/qos_search'
 
 def some_pull_hoc_size(fact)
   hocs = []
   files = []
   Fbe.unmask_repos do |repo|
     return {} if Fbe.octo.off_quota?
-    Fbe.octo.search_issues(
-      "repo:#{repo} type:pr is:merged closed:#{fact.since.utc.iso8601}..#{fact.when.utc.iso8601}"
-    )[:items].each do |json|
+    q = "repo:#{repo} type:pr is:merged closed:#{fact.since.utc.iso8601}..#{fact.when.utc.iso8601}"
+    found = Jp.qosearch(q)
+    return {} if found.nil?
+    found[:items].each do |json|
       Fbe.octo.pull_request(repo, json[:number]).then do |pull|
         hocs << (pull[:additions] + pull[:deletions])
         files << pull[:changed_files]

--- a/judges/quality-of-service/some_review_time.rb
+++ b/judges/quality-of-service/some_review_time.rb
@@ -6,6 +6,7 @@
 require 'fbe/octo'
 require 'fbe/unmask_repos'
 require 'octokit'
+require_relative '../../lib/qos_search'
 
 def some_review_time(fact)
   times = []
@@ -14,9 +15,10 @@ def some_review_time(fact)
   reviews = []
   Fbe.unmask_repos do |repo|
     return {} if Fbe.octo.off_quota?
-    Fbe.octo.search_issues(
-      "repo:#{repo} type:pr is:merged closed:#{fact.since.utc.iso8601}..#{fact.when.utc.iso8601}"
-    )[:items].each do |pr|
+    q = "repo:#{repo} type:pr is:merged closed:#{fact.since.utc.iso8601}..#{fact.when.utc.iso8601}"
+    found = Jp.qosearch(q)
+    return {} if found.nil?
+    found[:items].each do |pr|
       all, csize =
         begin
           [Fbe.octo.pull_request_reviews(repo, pr[:number]), Fbe.octo.review_comments(repo, pr[:number]).size]

--- a/judges/quality-of-service/some_triage_time.rb
+++ b/judges/quality-of-service/some_triage_time.rb
@@ -7,15 +7,17 @@ require 'fbe/fb'
 require 'fbe/octo'
 require 'fbe/pmp'
 require 'fbe/unmask_repos'
+require_relative '../../lib/qos_search'
 
 def some_triage_time(fact)
   threshold = Fbe.pmp.quality.qos_min_triage_seconds.value || 60
   times = []
   Fbe.unmask_repos do |repo|
     return {} if Fbe.octo.off_quota?
-    Fbe.octo.search_issues(
-      "repo:#{repo} type:issue created:#{fact.since.utc.iso8601}..#{fact.when.utc.iso8601}"
-    )[:items].each do |issue|
+    q = "repo:#{repo} type:issue created:#{fact.since.utc.iso8601}..#{fact.when.utc.iso8601}"
+    found = Jp.qosearch(q)
+    return {} if found.nil?
+    found[:items].each do |issue|
       ff = Fbe.fb.query(
         "
         (and

--- a/lib/qos_search.rb
+++ b/lib/qos_search.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+# SPDX-License-Identifier: MIT
+
+require 'fbe/octo'
+require 'octokit'
+require_relative 'jp'
+
+def Jp.qoreset
+  @offquota = false
+end
+
+def Jp.qosearch(query, **options)
+  return if @offquota || Fbe.octo.off_quota?
+  found = Fbe.octo.search_issues(query, options)
+  left = Fbe.octo.rate_limit.remaining
+  if left.zero?
+    @offquota = true
+    $loog.info('Too much GitHub Search API quota consumed already (0 left)')
+  end
+  found
+rescue Octokit::TooManyRequests => e
+  @offquota = true
+  $loog.warn("[#{$judge}] GitHub Search API quota exhausted, stopping QoS search calls: #{e.message}")
+  nil
+end

--- a/test/judges/test-quality-of-service.rb
+++ b/test/judges/test-quality-of-service.rb
@@ -2305,6 +2305,37 @@ class TestQualityOfService < Jp::Test
     end
   end
 
+  def test_quality_of_service_stops_backlog_searches_after_search_quota_is_consumed
+    WebMock.disable_net_connect!
+    rate_limit_up
+    $global = {}
+    $local = {}
+    $judge = 'quality-of-service'
+    $options = Judges::Options.new({ 'repositories' => 'foo/foo' })
+    $loog = Loog::NULL
+    $epoch = Time.now
+    $kickoff = Time.now
+    stub_github('https://api.github.com/repos/foo/foo', body: { id: 42, full_name: 'foo/foo', archived: false })
+    url =
+      'https://api.github.com/search/issues?advanced_search=true&per_page=100&' \
+      'q=repo:foo/foo%20type:issue%20created:*..2025-08-22%20(closed:%3E=2025-08-22%20OR%20state:open)'
+    stub_github(
+      url,
+      body: { total_count: 0, items: [] },
+      headers: { 'Content-Type': 'application/json', 'X-RateLimit-Remaining' => '0' }
+    )
+    load(File.join(__dir__, '../../judges/quality-of-service/some_backlog_size.rb'))
+    Jp.qoreset
+    fb = Factbase.new
+    fb.insert.then do |f|
+      f.what = 'quality-of-service'
+      f.since = Time.parse('2025-08-21 21:00:00 UTC')
+      f.when = Time.parse('2025-08-28 21:00:00 UTC')
+      assert_equal({}, some_backlog_size(f))
+    end
+    assert_requested(:get, url, times: 1)
+  end
+
   def test_quality_of_service_fix_gap
     WebMock.disable_net_connect!
     rate_limit_up


### PR DESCRIPTION
## Summary
- add a shared QoS search wrapper that stops further search calls after GitHub reports zero search quota or raises `Octokit::TooManyRequests`
- route `quality-of-service` search-based metrics through the wrapper while preserving retry behavior by leaving partial metrics unset
- cover the zero-search-quota path for backlog scans

## Tests
- `bundle exec ruby -Itest -e 'ARGV << "--no-cov"; require "./test/judges/test-quality-of-service"; ARGV.delete("--no-cov")'`
- `bundle exec rubocop lib/qos_search.rb judges/quality-of-service/quality-of-service.rb judges/quality-of-service/some_backlog_size.rb judges/quality-of-service/some_issue_lifetime.rb judges/quality-of-service/some_triage_time.rb judges/quality-of-service/some_merged_pulls.rb judges/quality-of-service/some_pull_hoc_size.rb judges/quality-of-service/some_review_time.rb test/judges/test-quality-of-service.rb`
- `bundle exec rake`
- `git diff --check`
- `gitleaks detect --source . --no-git --redact`
