### PR TITLE
#684: Reuse repository name lookups in issue-was-assigned

### DIFF
--- a/judges/issue-was-assigned/issue-was-assigned.rb
+++ b/judges/issue-was-assigned/issue-was-assigned.rb
@@ -10,6 +10,7 @@ require 'fbe/who'
 require 'tago'
 require_relative '../../lib/issue_was_lost'
 
+repos = {}
 Fbe.iterate do
   as 'assignees_were_scanned'
   sort_by 'issue'
@@ -31,7 +32,7 @@ Fbe.iterate do
       (eq where 'github'))"
   repeats 64
   over do |repository, issue|
-    repo = Fbe.octo.repo_name_by_id(repository)
+    repo = repos[repository] ||= Fbe.octo.repo_name_by_id(repository)
     events =
       begin
         Fbe.octo.issue_events(repo, issue).select { |e| e[:event] == 'assigned' }

--- a/test/judges/test-issue-was-assigned.rb
+++ b/test/judges/test-issue-was-assigned.rb
@@ -4,10 +4,32 @@
 # SPDX-License-Identifier: MIT
 
 require 'factbase'
+require 'fbe/octo'
 require_relative '../test__helper'
 
 class TestIssueWasAssigned < Jp::Test
   using SmartFactbase
+
+  def test_reuses_repository_name_lookup_per_repository
+    calls = Hash.new(0)
+    octo = Object.new
+    octo.define_singleton_method(:repo_name_by_id) do |repository|
+      calls[repository] += 1
+      'foo/foo'
+    end
+    octo.define_singleton_method(:repo_id_by_name) { |_repo| 42 }
+    octo.define_singleton_method(:issue_events) { |_repo, _issue| [] }
+    octo.define_singleton_method(:repository) { |_repo| { id: 42, full_name: 'foo/foo', archived: false } }
+    octo.define_singleton_method(:off_quota?) { |*| false }
+    octo.define_singleton_method(:print_trace!) { nil }
+    fb = Factbase.new
+    fb.with(_id: 1, what: 'issue-was-opened', repository: 42, issue: 44, where: 'github')
+      .with(_id: 2, what: 'issue-was-opened', repository: 42, issue: 45, where: 'github')
+    Fbe.stub(:octo, octo) do
+      load_it('issue-was-assigned', fb)
+    end
+    assert_equal({ 42 => 1 }, calls)
+  end
 
   def test_not_found_issue_events
     WebMock.disable_net_connect!


### PR DESCRIPTION
Fixes #684

Summary:
- Cache repository ID to repository name within one `issue-was-assigned` judge run.
- Avoid repeated `Fbe.octo.repo_name_by_id(repository)` calls when the scan processes multiple issues from the same repository.
- Add a regression test proving two opened issues from one repository perform one repository-name lookup.

Validation:
- `docker run --rm -v "$PWD":/work -v /tmp/judges-action-bundle:/usr/local/bundle -w /work ruby:4.0 bash -lc 'bundle exec rake'`\n- `docker run --rm -v "$PWD":/work -v /tmp/judges-action-bundle:/usr/local/bundle -w /work ruby:4.0 bash -lc 'bundle exec rubocop judges/issue-was-assigned/issue-was-assigned.rb test/judges/test-issue-was-assigned.rb'`\n- `git diff --check`\n- `git diff | gitleaks stdin --no-banner --redact --exit-code 1`\n\nNo secrets or credentials are included.