### PR TITLE
#1408: respect Gemfile.lock in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get update \
 WORKDIR /action
 COPY Gemfile /action
 COPY Gemfile.lock /action
-RUN bundle update --gemfile=/action/Gemfile
+RUN bundle config set frozen true && bundle install --gemfile=/action/Gemfile
 
 COPY judges /action/judges
 COPY lib /action/lib

--- a/test/test_dockerfile.rb
+++ b/test/test_dockerfile.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+# SPDX-License-Identifier: MIT
+
+require_relative 'test__helper'
+
+class TestDockerfile < Jp::Test
+  def test_installs_locked_bundle
+    dockerfile = File.read(File.join(__dir__, '..', 'Dockerfile'))
+    refute_includes(dockerfile, 'bundle update')
+    assert_includes(dockerfile, 'bundle config set frozen true')
+    assert_includes(dockerfile, 'bundle install --gemfile=/action/Gemfile')
+  end
+end


### PR DESCRIPTION
Closes #1408.

This changes the Docker image build to set Bundler's frozen mode and install the bundle from the checked-in lockfile instead of re-resolving dependencies with `bundle update`. It also adds a small regression test that fails if `bundle update` comes back or the frozen install setup is removed.

Validation:
- `ruby -c test\test_dockerfile.rb`
- `ruby -e "s = File.read('Dockerfile'); abort('bundle update still present') if s.include?('bundle update'); abort('frozen config missing') unless s.include?('bundle config set frozen true'); abort('bundle install missing') unless s.include?('bundle install --gemfile=/action/Gemfile'); puts 'Dockerfile lock install check passed'"`
- `ruby -Itest -Ilib -e "gem 'minitest-mock', '5.27.0'; load 'test/test_dockerfile.rb'"`
- `rubocop test\test_dockerfile.rb --format simple`
- `git diff --cached --check`
- `gitleaks protect --no-banner --redact --staged`
- `gitleaks dir . --no-banner --redact`

Limitation: full `bundle install` / `bundle exec rake test` is not claimed on this Windows machine because `openssl-4.0.1` fails to build without local OpenSSL headers and the MSYS keyring is not writable. The focused Dockerfile regression passed locally.