### PR TITLE
#1425: handle github-events pull lookup errors

### DIFF
--- a/judges/github-events/github-events.rb
+++ b/judges/github-events/github-events.rb
@@ -134,8 +134,14 @@ Fbe.iterate do
         pl =
           begin
             Fbe.octo.pull_request(rname, fact.issue)
-          rescue Octokit::NotFound
-            $loog.warn("The pull request ##{fact.issue} doesn't exist in #{rname}")
+          rescue Octokit::NotFound, Octokit::Deprecated => e
+            $loog.warn("The pull request ##{fact.issue} doesn't exist in #{rname}: #{e.message}")
+            nil
+          rescue Octokit::Forbidden => e
+            $loog.warn(
+              "[#{$judge}] Access forbidden to pull ##{fact.issue} in #{rname} " \
+              "(transient, will retry next cycle): #{e.class}: #{e.message}"
+            )
             nil
           end
         skip(json) if pl.nil?
@@ -148,8 +154,14 @@ Fbe.iterate do
         review =
           begin
             Fbe.octo.pull_request_reviews(rname, fact.issue).first
-          rescue Octokit::NotFound
-            $loog.warn("The pull request ##{fact.issue} doesn't exist in #{rname}")
+          rescue Octokit::NotFound, Octokit::Deprecated => e
+            $loog.warn("The pull request ##{fact.issue} doesn't exist in #{rname}: #{e.message}")
+            nil
+          rescue Octokit::Forbidden => e
+            $loog.warn(
+              "[#{$judge}] Access forbidden to reviews for pull ##{fact.issue} in #{rname} " \
+              "(transient, will retry next cycle): #{e.class}: #{e.message}"
+            )
             nil
           end
         fact.review = review[:submitted_at] if review

--- a/test/judges/test-github-events.rb
+++ b/test/judges/test-github-events.rb
@@ -2211,6 +2211,33 @@ class TestGithubEvents < Jp::Test
     assert(fb.one?(what: 'iterate', repository: 42, events_were_scanned: 11_127))
   end
 
+  def test_rescues_deprecated_on_closed_pull_request_lookup
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_event(
+      {
+        id: '11130',
+        type: 'PullRequestEvent',
+        actor: { id: 45, login: 'user' },
+        repo: { id: 42, name: 'foo/foo' },
+        payload: {
+          action: 'closed',
+          pull_request: { number: 123, head: { ref: 'feature-branch', sha: 'abc123' } }
+        },
+        created_at: '2025-06-27 19:00:05 UTC'
+      }
+    )
+    stub_github(
+      'https://api.github.com/repos/foo/foo/pulls/123',
+      status: 410,
+      body: { message: 'Gone', documentation_url: 'https://docs.github.com/rest/using-the-rest-api' }
+    )
+    fb = Factbase.new
+    load_it('github-events', fb)
+    assert_equal(1, fb.all.size)
+    assert(fb.one?(what: 'iterate', repository: 42, events_were_scanned: 11_130))
+  end
+
   def test_rescues_forbidden_on_closed_pull_request_reviews_lookup
     WebMock.disable_net_connect!
     rate_limit_up

--- a/test/judges/test-github-events.rb
+++ b/test/judges/test-github-events.rb
@@ -2184,6 +2184,83 @@ class TestGithubEvents < Jp::Test
     assert_equal(15, f.hoc)
   end
 
+  def test_rescues_forbidden_on_closed_pull_request_lookup
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_event(
+      {
+        id: '11127',
+        type: 'PullRequestEvent',
+        actor: { id: 45, login: 'user' },
+        repo: { id: 42, name: 'foo/foo' },
+        payload: {
+          action: 'closed',
+          pull_request: { number: 123, head: { ref: 'feature-branch', sha: 'abc123' } }
+        },
+        created_at: '2025-06-27 19:00:05 UTC'
+      }
+    )
+    stub_github(
+      'https://api.github.com/repos/foo/foo/pulls/123',
+      status: 403,
+      body: { message: 'Resource not accessible by integration' }
+    )
+    fb = Factbase.new
+    load_it('github-events', fb)
+    assert_equal(1, fb.all.size)
+    assert(fb.one?(what: 'iterate', repository: 42, events_were_scanned: 11_127))
+  end
+
+  def test_rescues_forbidden_on_closed_pull_request_reviews_lookup
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_event(
+      {
+        id: '11128',
+        type: 'PullRequestEvent',
+        actor: { id: 45, login: 'user' },
+        repo: { id: 42, name: 'foo/foo' },
+        payload: {
+          action: 'closed',
+          pull_request: { number: 123, head: { ref: 'feature-branch', sha: 'abc123' } }
+        },
+        created_at: '2025-06-27 19:00:05 UTC'
+      }
+    )
+    stub_github(
+      'https://api.github.com/repos/foo/foo/pulls/123',
+      body: {
+        id: 50, number: 123, user: { id: 46, login: 'user2' },
+        head: { ref: 'feature-branch', sha: 'abc123' },
+        merged: true, state: 'closed', merged_at: Time.parse('2025-06-27 19:00:05 UTC'),
+        additions: 10, deletions: 5
+      }
+    )
+    stub_github('https://api.github.com/user/45', body: { id: 45, login: 'user' })
+    stub_github('https://api.github.com/repos/foo/foo/pulls/123/comments?per_page=100', body: [])
+    stub_github('https://api.github.com/repos/foo/foo/issues/123/comments?per_page=100', body: [])
+    stub_github('https://api.github.com/repos/foo/foo/commits/abc123/check-runs?per_page=100', body: { check_runs: [] })
+    stub_request(:get, 'https://api.github.com/repos/foo/foo/pulls/123/reviews?per_page=100')
+      .to_return(
+        {
+          status: 403,
+          body: { message: 'Resource not accessible by integration' }.to_json,
+          headers: { 'Content-Type': 'application/json', 'X-RateLimit-Remaining' => '999' }
+        },
+        {
+          body: [].to_json,
+          headers: { 'Content-Type': 'application/json', 'X-RateLimit-Remaining' => '999' }
+        }
+      )
+    fb = Factbase.new
+    Fbe.stub(:github_graph, Fbe::Graph::Fake.new) do
+      load_it('github-events', fb)
+    end
+    f = fb.query('(eq what "pull-was-merged")').each.first
+    refute_nil(f)
+    assert_nil(f['review'])
+  end
+
   def test_closed_pull_request_event_with_nil_additions_or_deletions
     WebMock.disable_net_connect!
     rate_limit_up


### PR DESCRIPTION
Closes #1425.

- Handles `Octokit::Deprecated` with `Octokit::NotFound` for the closed `PullRequestEvent` pull lookup.
- Logs `Octokit::Forbidden` as a transient miss at the pull and review lookup sites instead of letting the scan crash.
- Adds regression coverage for 403 responses at both scoped lookup sites.

I left the sibling release compare/contributor calls mentioned in the issue untouched.

Validation:
- `mise exec ruby@3.3.11 -- bundle exec ruby -Itest -e 'ARGV << "--no-cov"; require "./test/judges/test-github-events"; ARGV.delete("--no-cov")' -- --quiet` -> 44 tests, 131 assertions, 0 failures, 0 errors, 1 skips
- `mise exec ruby@3.3.11 -- bundle exec ruby -Itest -e 'ARGV << "--no-cov"; require "./test/test_pattern_a_coverage"; ARGV.delete("--no-cov")'` -> 1 run, 4 assertions, 0 failures, 0 errors
- `mise exec ruby@3.3.11 -- bundle exec rubocop judges/github-events/github-events.rb test/judges/test-github-events.rb` -> 2 files inspected, no offenses detected
- `git diff --check` -> clean
- `git diff | gitleaks stdin --no-banner --redact` -> no leaks found
