### PR TITLE
#1359 cover Octokit::Deprecated branch on pull_request lookup

### DIFF
--- a/test/judges/test-find-earliest-issue.rb
+++ b/test/judges/test-find-earliest-issue.rb
@@ -186,4 +186,31 @@ class TestFindEarliestIssue < Jp::Test
       'forbidden error must not produce an issue-was-lost tombstone'
     )
   end
+
+  def test_rescues_deprecated_on_pull_request_lookup
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repos/foo/foo', body: { id: 42, name: 'foo', full_name: 'foo/foo' })
+    stub_github('https://api.github.com/repositories/42', body: { id: 42, name: 'foo', full_name: 'foo/foo' })
+    stub_github(
+      'https://api.github.com/repos/foo/foo/issues?direction=asc&page=1&per_page=1&sort=created&state=all',
+      body: [
+        {
+          id: 123, number: 4, title: 'Some title', user: { id: 44, login: 'user' },
+          pull_request: { merged_at: '2025-09-27 07:03:00 UTC' }, created_at: '2025-09-27 06:03:16 UTC'
+        }
+      ]
+    )
+    stub_github(
+      'https://api.github.com/repos/foo/foo/pulls/4',
+      status: 410,
+      body: { message: 'Gone', documentation_url: 'https://docs.github.com/rest/using-the-rest-api' }
+    )
+    fb = Factbase.new
+    load_it('find-earliest-issue', fb)
+    assert(
+      fb.one?(what: 'iterate', earliest_issue_was_found: 4, repository: 42, where: 'github'),
+      'cursor must advance to the issue number after a 410 on Fbe.octo.pull_request'
+    )
+  end
 end

--- a/test/judges/test-find-latest-issue.rb
+++ b/test/judges/test-find-latest-issue.rb
@@ -177,6 +177,33 @@ class TestFindLatestIssue < Jp::Test
     )
   end
 
+  def test_rescues_deprecated_on_pull_request_lookup
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repos/foo/foo', body: { id: 42, name: 'foo', full_name: 'foo/foo' })
+    stub_github('https://api.github.com/repositories/42', body: { id: 42, name: 'foo', full_name: 'foo/foo' })
+    stub_github(
+      'https://api.github.com/repos/foo/foo/issues?direction=desc&page=1&per_page=1&sort=created&state=all',
+      body: [
+        {
+          id: 123, number: 549, title: 'Some title', user: { id: 44, login: 'user' },
+          pull_request: { merged_at: '2025-09-14 20:03:16 UTC' }, created_at: '2025-09-14 20:03:16 UTC'
+        }
+      ]
+    )
+    stub_github(
+      'https://api.github.com/repos/foo/foo/pulls/549',
+      status: 410,
+      body: { message: 'Gone', documentation_url: 'https://docs.github.com/rest/using-the-rest-api' }
+    )
+    fb = Factbase.new
+    load_it('find-latest-issue', fb)
+    assert(
+      fb.one?(what: 'iterate', latest_issue_was_found: 549, repository: 42, where: 'github'),
+      'cursor must advance to the issue number after a 410 on Fbe.octo.pull_request'
+    )
+  end
+
   def test_rescues_forbidden_on_pull_request_lookup
     WebMock.disable_net_connect!
     rate_limit_up


### PR DESCRIPTION
Closes #1359.

Both `find-latest-issue.rb:38-49` and `find-earliest-issue.rb:39-50` rescue `Octokit::NotFound, Octokit::Deprecated => e` on the `Fbe.octo.pull_request(repo, f.issue).dig(:head, :ref)` lookup, but the existing test suite stubs only 404 (`test_rescues_not_found_on_pull_request_lookup`) and 403 (`test_rescues_forbidden_on_pull_request_lookup`); the `Octokit::Deprecated` branch — the 410 response GitHub returns for retired endpoints, paired with `NotFound` everywhere the canonical pattern from #1330 is applied — has no regression coverage in either file.

Adds `test_rescues_deprecated_on_pull_request_lookup` to `test/judges/test-find-latest-issue.rb` and `test/judges/test-find-earliest-issue.rb`. Each new test stubs `pulls/<n>` with status 410, then asserts that the `iterate` fact carries the cursor advance (`latest_issue_was_found` / `earliest_issue_was_found`) — exactly what the rescue's `next i` is meant to produce.

Validation:
- `bundle exec rake test` -> 202 tests, 554 assertions, 0 failures, 0 errors, 1 skip
- `bundle exec rake rubocop` -> 96 files inspected, no offenses detected
