### PR TITLE
#1427: handle github-events release lookup errors

### DIFF
--- a/judges/github-events/github-events.rb
+++ b/judges/github-events/github-events.rb
@@ -38,12 +38,12 @@ Fbe.iterate do
     since = tag(last, repo)
     list = Set.new
     if since
-      Fbe.octo.compare(repo, since, fact.tag)[:commits].each do |commit|
+      (comparison(repo, since, fact.tag) || {}).fetch(:commits, []).each do |commit|
         author = commit.dig(:author, :id)
         list << author if author
       end
     else
-      Fbe.octo.contributors(repo).each do |contributor|
+      allcontributors(repo).each do |contributor|
         list << contributor[:id]
       end
     end
@@ -56,18 +56,40 @@ Fbe.iterate do
     since = tag(last, repo)
     since ||= earliest(repo)[:sha]
     info = {}
-    begin
-      Fbe.octo.compare(repo, since, fact.tag).then do |json|
-        return info if json.nil?
-        info[:commits] = json[:total_commits]
-        info[:hoc] = json[:files].sum { |f| f[:changes] }
-        info[:last_commit] = json[:commits].first[:sha]
-      end
-    rescue Octokit::NotFound
-      $loog.info("Compare API returned 404 for #{repo} between #{since} and #{fact.tag}")
+    comparison(repo, since, fact.tag).then do |json|
+      return info if json.nil?
+      info[:commits] = json[:total_commits]
+      info[:hoc] = json[:files].sum { |f| f[:changes] }
+      info[:last_commit] = json[:commits].first[:sha]
     end
     $loog.debug("The repository ##{fact.repository} has this: #{info.inspect}")
     info
+  end
+
+  def self.comparison(repo, since, tag)
+    Fbe.octo.compare(repo, since, tag)
+  rescue Octokit::NotFound, Octokit::Deprecated => e
+    $loog.info("Compare API failed for #{repo} between #{since} and #{tag}: #{e.message}")
+    nil
+  rescue Octokit::Forbidden => e
+    $loog.warn(
+      "[#{$judge}] Access forbidden to compare #{repo} between #{since} and #{tag} " \
+      "(transient, will retry next cycle): #{e.class}: #{e.message}"
+    )
+    nil
+  end
+
+  def self.allcontributors(repo)
+    Fbe.octo.contributors(repo)
+  rescue Octokit::NotFound, Octokit::Deprecated => e
+    $loog.info("Contributors API failed for #{repo}: #{e.message}")
+    []
+  rescue Octokit::Forbidden => e
+    $loog.warn(
+      "[#{$judge}] Access forbidden to contributors in #{repo} " \
+      "(transient, will retry next cycle): #{e.class}: #{e.message}"
+    )
+    []
   end
 
   def self.earliest(repo)

--- a/test/judges/test-github-events.rb
+++ b/test/judges/test-github-events.rb
@@ -2413,6 +2413,128 @@ class TestGithubEvents < Jp::Test
     assert_equal([526_301], f.first[:contributors])
   end
 
+  def test_release_event_rescues_forbidden_contributors_and_compare
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_event(
+      {
+        id: '101',
+        type: 'ReleaseEvent',
+        actor: {
+          id: 8_086_956,
+          login: 'rultor',
+          display_login: 'rultor'
+        },
+        repo: {
+          id: 42,
+          name: 'foo/foo',
+          url: 'https://api.github.com/repos/foo/foo'
+        },
+        payload: {
+          action: 'published',
+          release: {
+            id: 999_001,
+            author: {
+              login: 'rultor',
+              id: 8_086_956,
+              type: 'User',
+              site_admin: false
+            },
+            tag_name: '1.0.0',
+            name: 'v1.0.0',
+            created_at: Time.parse('2024-11-30T00:51:39Z'),
+            published_at: Time.parse('2024-11-30T00:52:07Z')
+          }
+        },
+        public: true,
+        created_at: Time.parse('2024-11-30T00:52:08Z')
+      }
+    )
+    stub_github(
+      'https://api.github.com/repos/foo/foo/contributors?per_page=100',
+      status: 403,
+      body: { message: 'Resource not accessible by integration' }
+    )
+    stub_github('https://api.github.com/repos/foo/foo/commits?per_page=100', body: [{ sha: 'abc123def456' }])
+    stub_github(
+      'https://api.github.com/repos/foo/foo/compare/abc123def456...1.0.0?per_page=100',
+      status: 403,
+      body: { message: 'Resource not accessible by integration' }
+    )
+    stub_github('https://api.github.com/user/8086956', body: { login: 'rultor', id: 8_086_956 })
+    fb = Factbase.new
+    load_it('github-events', fb)
+    f = fb.query('(and (eq repository 42) (eq what "release-published"))').each.to_a
+    assert_equal(1, f.count)
+    refute_includes(f.first.all_properties, 'contributors')
+    refute_includes(f.first.all_properties, 'commits')
+    refute_includes(f.first.all_properties, 'hoc')
+  end
+
+  def test_release_event_rescues_deprecated_release_compare
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_event(
+      {
+        id: '102',
+        type: 'ReleaseEvent',
+        actor: {
+          id: 8_086_956,
+          login: 'rultor',
+          display_login: 'rultor'
+        },
+        repo: {
+          id: 42,
+          name: 'foo/foo',
+          url: 'https://api.github.com/repos/foo/foo'
+        },
+        payload: {
+          action: 'published',
+          release: {
+            id: 999_002,
+            author: {
+              login: 'rultor',
+              id: 8_086_956,
+              type: 'User',
+              site_admin: false
+            },
+            tag_name: '1.1.0',
+            name: 'v1.1.0',
+            created_at: Time.parse('2024-12-01T00:51:39Z'),
+            published_at: Time.parse('2024-12-01T00:52:07Z')
+          }
+        },
+        public: true,
+        created_at: Time.parse('2024-12-01T00:52:08Z')
+      }
+    )
+    stub_github(
+      'https://api.github.com/repos/foo/foo/compare/0.9.0...1.1.0?per_page=100',
+      status: 410,
+      body: { message: 'Git Repository is empty.' }
+    )
+    stub_github('https://api.github.com/user/8086956', body: { login: 'rultor', id: 8_086_956 })
+    fb = Factbase.new
+    fb.insert.then do |f|
+      f.details = 'A previous release was published in this repo.'
+      f.event_id = 100
+      f.event_type = 'ReleaseEvent'
+      f.repository = 42
+      f.tag = '0.9.0'
+      f.what = 'release-published'
+      f.when = Time.parse('2024-11-29 00:52:08 UTC')
+      f.where = 'github'
+      f.who = 526_301
+    end
+    load_it('github-events', fb)
+    f = fb.query('(and (eq repository 42) (eq what "release-published"))').each.to_a
+    assert_equal(2, f.count)
+    assert_equal('1.1.0', f.last.tag)
+    refute_includes(f.last.all_properties, 'contributors')
+    refute_includes(f.last.all_properties, 'commits')
+    refute_includes(f.last.all_properties, 'hoc')
+  end
+
   def test_write_supervision_log_if_raise_error
     WebMock.disable_net_connect!
     rate_limit_up


### PR DESCRIPTION
Closes #1427.

- Routes release compare calls through a helper that handles `Octokit::NotFound`/`Octokit::Deprecated` and logs `Octokit::Forbidden` as a transient miss.
- Applies the same rescue handling to release contributors lookup so that contributors API misses do not abort the events scan.
- Adds `ReleaseEvent` regressions for 403 contributor/compare responses and 410 compare responses.

Validation:
- `env BUNDLE_PATH=/private/tmp/bundle-judges-action-1427 mise x ruby@3.3.11 -- bundle exec ruby -Itest -e "ARGV << \"--no-cov\"; require \"./test/judges/test-github-events\"; ARGV.delete(\"--no-cov\")" -- --quiet` -> 44 tests, 142 assertions, 0 failures, 0 errors, 1 skips
- `env BUNDLE_PATH=/private/tmp/bundle-judges-action-1427 mise x ruby@3.3.11 -- bundle exec ruby -Itest -e "ARGV << \"--no-cov\"; require \"./test/test_pattern_a_coverage\"; ARGV.delete(\"--no-cov\")"` -> 1 run, 4 assertions, 0 failures, 0 errors
- `env BUNDLE_PATH=/private/tmp/bundle-judges-action-1427 mise x ruby@3.3.11 -- bundle exec rubocop judges/github-events/github-events.rb test/judges/test-github-events.rb` -> 2 files inspected, no offenses detected
- `git diff --check HEAD~1..HEAD` -> clean
- `git show --format= --no-ext-diff HEAD | gitleaks stdin --no-banner --redact --exit-code 1` -> no leaks found

Limitation:
- Docker-backed `make` was not run locally; the focused Ruby test file and style checks above were run with `mise` Ruby 3.3.11.