### PR TITLE
#1115 pin third-party actions to commit SHAs

### DIFF
--- a/.github/workflows/checkmake.yml
+++ b/.github/workflows/checkmake.yml
@@ -15,4 +15,4 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: Uno-Takashi/checkmake-action@v2
+      - uses: Uno-Takashi/checkmake-action@bc11ee86274ceaf5710dbcd80871d7cd7ecc78ce # v2

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # v1.310.0
         with:
           ruby-version: 4.0.4
           bundler-cache: true

--- a/.github/workflows/rake.yml
+++ b/.github/workflows/rake.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # v1.310.0
         with:
           ruby-version: 4.0.4
           bundler-cache: true

--- a/.github/workflows/titles.yml
+++ b/.github/workflows/titles.yml
@@ -13,7 +13,7 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-24.04
     steps:
-      - uses: horw/issue-title-ai@v0.1.7b
+      - uses: horw/issue-title-ai@e7deb68172571a7afe7784100d2b6548a45a5243 # v0.1.7b
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}


### PR DESCRIPTION
Closes #1115.

Four workflow refs still floated on a tag — `ruby/setup-ruby@v1` on `make.yml:19` and `rake.yml:19`, `Uno-Takashi/checkmake-action@v2` on `checkmake.yml:18`, and `horw/issue-title-ai@v0.1.7b` on `titles.yml:16`. Each one is pinned here to the current commit SHA with a trailing `# v…` comment, matching the shape of every other third-party `uses:` in `.github/workflows/`. Renovate already extends `config:best-practices` and `minimumReleaseAge: 7 days`, so future bumps land in the same SHA-with-comment form.

Test plan: `yamllint .github/workflows/checkmake.yml .github/workflows/make.yml .github/workflows/rake.yml .github/workflows/titles.yml` passes locally; the four edits change only the `uses:` ref and the trailing version comment, leaving every other key, indent, and run step byte-identical.
