### PR TITLE
#1435: skip failed graph total issues

### DIFF
--- a/judges/dimensions-of-terrain/total_issues.rb
+++ b/judges/dimensions-of-terrain/total_issues.rb
@@ -10,7 +10,16 @@ def total_issues(_fact)
   issues = 0
   pulls = 0
   Fbe.unmask_repos do |repo|
-    json = Fbe.github_graph.total_issues_and_pulls(*repo.split('/'))
+    json =
+      begin
+        Fbe.github_graph.total_issues_and_pulls(*repo.split('/'))
+      rescue StandardError => e
+        $loog.warn(
+          "[#{$judge}] Can't count issues and pulls in #{repo} " \
+          "(transient, will retry next cycle): #{e.class}: #{e.message}"
+        )
+        next
+      end
     issues += json['issues']
     pulls += json['pulls']
   end

--- a/judges/dimensions-of-terrain/total_issues.rb
+++ b/judges/dimensions-of-terrain/total_issues.rb
@@ -13,7 +13,8 @@ def total_issues(_fact)
     json =
       begin
         Fbe.github_graph.total_issues_and_pulls(*repo.split('/'))
-      rescue StandardError => e
+      rescue GraphQL::Client::Error, Net::OpenTimeout, Net::ReadTimeout, SocketError,
+             Errno::ECONNRESET, Errno::ETIMEDOUT => e
         $loog.warn(
           "[#{$judge}] Can't count issues and pulls in #{repo} " \
           "(transient, will retry next cycle): #{e.class}: #{e.message}"

--- a/test/judges/test-dimensions-of-terrain.rb
+++ b/test/judges/test-dimensions-of-terrain.rb
@@ -277,13 +277,33 @@ class TestDimensionsOfTerrain < Jp::Test
     $options = Judges::Options.new({ 'repositories' => 'foo/bad,foo/good' })
     graph = Class.new(Fbe::Graph::Fake) do
       define_method(:total_issues_and_pulls) do |_owner, name|
-        raise(RuntimeError, 'GraphQL failed') if name == 'bad'
+        raise(GraphQL::Client::Error, 'GraphQL failed') if name == 'bad'
         { 'issues' => 7, 'pulls' => 5 }
       end
     end.new
     Fbe.stub(:github_graph, graph) do
       load(File.join(__dir__, '../../judges/dimensions-of-terrain/total_issues.rb'))
       assert_equal({ total_issues: 7, total_pulls: 5 }, total_issues(nil))
+    end
+  end
+
+  def test_total_issues_does_not_swallow_local_graph_bug
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repos/foo/bad', body: { full_name: 'foo/bad', archived: false })
+    $judge = 'dimensions-of-terrain'
+    $global = {}
+    $local = {}
+    $loog = Loog::NULL
+    $options = Judges::Options.new({ 'repositories' => 'foo/bad' })
+    graph = Class.new(Fbe::Graph::Fake) do
+      define_method(:total_issues_and_pulls) do |_owner, _name|
+        raise(NoMethodError, 'local bug')
+      end
+    end.new
+    Fbe.stub(:github_graph, graph) do
+      load(File.join(__dir__, '../../judges/dimensions-of-terrain/total_issues.rb'))
+      assert_raises(NoMethodError) { total_issues(nil) }
     end
   end
 

--- a/test/judges/test-dimensions-of-terrain.rb
+++ b/test/judges/test-dimensions-of-terrain.rb
@@ -264,6 +264,29 @@ class TestDimensionsOfTerrain < Jp::Test
     assert_equal(19, f.total_pulls)
   end
 
+  def test_total_issues_skips_failing_graph_repo
+    WebMock.disable_net_connect!
+    rate_limit_up
+    %w[bad good].each do |name|
+      stub_github("https://api.github.com/repos/foo/#{name}", body: { full_name: "foo/#{name}", archived: false })
+    end
+    $judge = 'dimensions-of-terrain'
+    $global = {}
+    $local = {}
+    $loog = Loog::NULL
+    $options = Judges::Options.new({ 'repositories' => 'foo/bad,foo/good' })
+    graph = Class.new(Fbe::Graph::Fake) do
+      define_method(:total_issues_and_pulls) do |_owner, name|
+        raise(RuntimeError, 'GraphQL failed') if name == 'bad'
+        { 'issues' => 7, 'pulls' => 5 }
+      end
+    end.new
+    Fbe.stub(:github_graph, graph) do
+      load(File.join(__dir__, '../../judges/dimensions-of-terrain/total_issues.rb'))
+      assert_equal({ total_issues: 7, total_pulls: 5 }, total_issues(nil))
+    end
+  end
+
   def test_total_commits
     WebMock.disable_net_connect!
     fb = Factbase.new


### PR DESCRIPTION
/claim #1435

Fixes #1435.

Summary:
- Wrap each `Fbe.github_graph.total_issues_and_pulls` call in `dimensions-of-terrain/total_issues.rb` so one GraphQL failure logs the affected repository and continues with the remaining repositories.
- Add a regression where `foo/bad` raises from GraphQL while `foo/good` is still counted.

Validation:
- `mise x ruby@3.3.11 -- bundle exec ruby test/judges/test-dimensions-of-terrain.rb -n test_total_issues_skips_failing_graph_repo -- --no-cov`
- `mise x ruby@3.3.11 -- bundle exec ruby test/judges/test-dimensions-of-terrain.rb -n test_total_issues_and_pull_requests -- --no-cov`
- `mise x ruby@3.3.11 -- bundle exec ruby test/judges/test-dimensions-of-terrain.rb -- --no-cov` -> 11 tests, 30 assertions, 0 failures, 0 errors
- `mise x ruby@3.3.11 -- bundle exec rubocop judges/dimensions-of-terrain/total_issues.rb test/judges/test-dimensions-of-terrain.rb`
- `mise x ruby@3.3.11 -- bundle exec rake test` -> 221 tests, 612 assertions, 0 failures, 0 errors, 1 skip
- `git diff --check`
- `git show --format= --patch HEAD | gitleaks stdin --no-banner --redact --log-level warn`

No secrets or generated private files are included.