### PR TITLE
test: #1342 pin catch/throw exit in github-events scan

### DIFF
--- a/test/judges/test-github-events.rb
+++ b/test/judges/test-github-events.rb
@@ -1955,6 +1955,63 @@ class TestGithubEvents < Jp::Test
     assert(fb.none?(what: 'tag-was-created', where: 'github', event_type: 'CreateEvent', repository: 42, event_id: 13))
   end
 
+  def test_max_events_guard_fires_once
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github(
+      'https://api.github.com/repos/foo/foo',
+      body: { id: 42, name: 'foo', full_name: 'foo/foo', default_branch: 'master' }
+    )
+    stub_github(
+      'https://api.github.com/repositories/42',
+      body: { id: 42, name: 'foo', full_name: 'foo/foo', default_branch: 'master' }
+    )
+    stub_github('https://api.github.com/user/42', body: { id: 42, login: 'torvalds' })
+    stub_github(
+      'https://api.github.com/repositories/42/events?per_page=100',
+      body: 6.downto(1).map do |id|
+        {
+          id:, created_at: Time.now.to_s, actor: { id: 42 },
+          type: 'CreateEvent', repo: { id: 42 },
+          payload: { ref_type: 'tag', ref: 'foo' }
+        }
+      end
+    )
+    fb = Factbase.new
+    loog = Loog::Buffer.new
+    load_it('github-events', fb, Judges::Options.new({ 'repositories' => 'foo/foo', 'max_events' => 2 }), loog:)
+    assert_equal(1, loog.to_s.scan('Already scanned').size)
+  end
+
+  def test_latest_id_guard_fires_once
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github(
+      'https://api.github.com/repos/foo/foo',
+      body: { id: 42, name: 'foo', full_name: 'foo/foo', default_branch: 'master' }
+    )
+    stub_github(
+      'https://api.github.com/repositories/42',
+      body: { id: 42, name: 'foo', full_name: 'foo/foo', default_branch: 'master' }
+    )
+    stub_github('https://api.github.com/user/42', body: { id: 42, login: 'torvalds' })
+    stub_github(
+      'https://api.github.com/repositories/42/events?per_page=100',
+      body: 15.downto(10).map do |id|
+        {
+          id:, created_at: Time.now.to_s, actor: { id: 42 },
+          type: 'CreateEvent', repo: { id: 42 },
+          payload: { ref_type: 'tag', ref: 'foo' }
+        }
+      end
+    )
+    fb = Factbase.new
+    fb.with(_id: 1, _time: Time.now.utc, where: 'github', repository: 42, events_were_scanned: 13, what: 'iterate')
+    loog = Loog::Buffer.new
+    load_it('github-events', fb, loog:)
+    assert_equal(1, loog.to_s.scan('good stop').size)
+  end
+
   def test_skip_fill_up_if_event_exists_in_factbase
     WebMock.disable_net_connect!
     rate_limit_up


### PR DESCRIPTION
PR #1393 replaced the two `break` statements inside `Jp.supervision { ... }` in `judges/github-events/github-events.rb` with `throw :done` for #1342, but no test pins the new exit path. The pre-existing `test_stop_scanning_if_number_event_greater_than_max_events` and `test_stop_scanning_if_event_id_less_or_eq_than_latest` tests assert factbase content only, which stays identical whether the supervision block runs once (`throw :done`) or N times (`break`) — both paths skip the body, so neither test catches a silent regression back to `break`.

This change adds two regression tests that load `github-events` with a `Loog::Buffer` logger, then count the `Already scanned ...` and `good stop in ...` debug lines emitted by the two guards. Each must appear exactly once on the catch/throw path; with `break` in place, they fire once per remaining event.

Verified locally with `bundle exec ruby -Ilib -Itest test/judges/test-github-events.rb -n "/max_events_guard_fires_once|latest_id_guard_fires_once/" -- --no-cov` — both new tests pass on master and both fail with `Expected: 1, Actual: 4` when the production code is temporarily reverted to `break`. The full file (`49 tests, 152 assertions, 0 failures, 0 errors, 1 skip`) is green, and `bin/rubocop test/judges/test-github-events.rb` is clean.

Closes #1342.