### PR TITLE
#1437: skip transient review graph failures

### DIFF
--- a/judges/quantity-of-deliverables/total_reviews_submitted.rb
+++ b/judges/quantity-of-deliverables/total_reviews_submitted.rb
@@ -13,45 +13,29 @@ def total_reviews_submitted(fact)
     owner, name = repo.split('/')
     cursor = nil
     queue = []
-    subtotal = 0
-    skip = false
-    safe =
-      lambda do |&block|
-        block.call
-      rescue Octokit::Forbidden, GraphQL::Client::Error, Net::OpenTimeout, Net::ReadTimeout, SocketError,
-             Errno::ECONNRESET, Errno::ETIMEDOUT => e
-        $loog.warn(
-          "[#{$judge}] Can't count reviews submitted in #{repo} " \
-          "(transient, will retry next cycle): #{e.class}: #{e.message}"
-        )
-        nil
-      end
     loop do
-      json = safe.call { Fbe.github_graph.pull_requests_with_reviews(owner, name, fact.since, cursor:) }
-      if json.nil?
-        skip = true
-        break
-      end
+      json = Fbe.github_graph.pull_requests_with_reviews(owner, name, fact.since, cursor:)
       json['pulls_with_reviews'].each do |p|
         queue.push([p['number'], nil])
       end
       break unless json['has_next_page']
       cursor = json['next_cursor']
     end
-    next if skip
     until queue.empty?
-      pulls = safe.call { Fbe.github_graph.pull_request_reviews(owner, name, pulls: queue.shift(10)) }
-      if pulls.nil?
-        skip = true
-        break
-      end
+      pulls = Fbe.github_graph.pull_request_reviews(owner, name, pulls: queue.shift(10))
       window = ->(r) { r['submitted_at'] > fact.since && r['submitted_at'] <= fact.when }
-      subtotal += pulls.sum { |p| p['reviews'].count(&window) }
+      total += pulls.sum { |p| p['reviews'].count(&window) }
       pulls.select { _1['reviews_has_next_page'] }.each do |p|
         queue.push([p['number'], p['reviews_next_cursor']])
       end
     end
-    total += subtotal unless skip
+  rescue GraphQL::Client::Error, Octokit::Forbidden, Net::OpenTimeout, Net::ReadTimeout,
+         SocketError, Errno::ECONNRESET, Errno::ETIMEDOUT => e
+    $loog.warn(
+      "[#{$judge}] Can't count submitted reviews in #{repo} " \
+      "(transient, will retry next cycle): #{e.class}: #{e.message}"
+    )
+    next
   end
   { total_reviews_submitted: total }
 end

--- a/judges/quantity-of-deliverables/total_reviews_submitted.rb
+++ b/judges/quantity-of-deliverables/total_reviews_submitted.rb
@@ -3,6 +3,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
 # SPDX-License-Identifier: MIT
 
+require 'fbe/github_graph'
 require 'fbe/octo'
 require 'fbe/unmask_repos'
 
@@ -12,22 +13,45 @@ def total_reviews_submitted(fact)
     owner, name = repo.split('/')
     cursor = nil
     queue = []
+    subtotal = 0
+    skip = false
+    safe =
+      lambda do |&block|
+        block.call
+      rescue Octokit::Forbidden, GraphQL::Client::Error, Net::OpenTimeout, Net::ReadTimeout, SocketError,
+             Errno::ECONNRESET, Errno::ETIMEDOUT => e
+        $loog.warn(
+          "[#{$judge}] Can't count reviews submitted in #{repo} " \
+          "(transient, will retry next cycle): #{e.class}: #{e.message}"
+        )
+        nil
+      end
     loop do
-      json = Fbe.github_graph.pull_requests_with_reviews(owner, name, fact.since, cursor:)
+      json = safe.call { Fbe.github_graph.pull_requests_with_reviews(owner, name, fact.since, cursor:) }
+      if json.nil?
+        skip = true
+        break
+      end
       json['pulls_with_reviews'].each do |p|
         queue.push([p['number'], nil])
       end
       break unless json['has_next_page']
       cursor = json['next_cursor']
     end
+    next if skip
     until queue.empty?
-      pulls = Fbe.github_graph.pull_request_reviews(owner, name, pulls: queue.shift(10))
+      pulls = safe.call { Fbe.github_graph.pull_request_reviews(owner, name, pulls: queue.shift(10)) }
+      if pulls.nil?
+        skip = true
+        break
+      end
       window = ->(r) { r['submitted_at'] > fact.since && r['submitted_at'] <= fact.when }
-      total += pulls.sum { |p| p['reviews'].count(&window) }
+      subtotal += pulls.sum { |p| p['reviews'].count(&window) }
       pulls.select { _1['reviews_has_next_page'] }.each do |p|
         queue.push([p['number'], p['reviews_next_cursor']])
       end
     end
+    total += subtotal unless skip
   end
   { total_reviews_submitted: total }
 end

--- a/test/judges/test-quantity-of-deliverables.rb
+++ b/test/judges/test-quantity-of-deliverables.rb
@@ -161,6 +161,68 @@ class TestQuantityOfDeliverables < Jp::Test
     end
   end
 
+  def test_total_reviews_submitted_skips_repo_when_pull_list_graph_fails
+    WebMock.disable_net_connect!
+    graph = Class.new(Fbe::Graph::Fake) do
+      define_method(:pull_requests_with_reviews) do |_owner, name, _since, **|
+        raise(GraphQL::Client::Error, 'GraphQL failed') if name == 'bad'
+        {
+          'pulls_with_reviews' => [{ 'id' => 'good', 'number' => 7 }],
+          'has_next_page' => false,
+          'next_cursor' => nil
+        }
+      end
+      define_method(:pull_request_reviews) do |_owner, _name, **|
+        [
+          {
+            'id' => 'good',
+            'number' => 7,
+            'reviews' => [{ 'id' => 'review', 'submitted_at' => Time.parse('2025-10-02 12:58:42 UTC') }],
+            'reviews_has_next_page' => false,
+            'reviews_next_cursor' => nil
+          }
+        ]
+      end
+    end.new
+    assert_equal({ total_reviews_submitted: 1 }, total_reviews_with_graph('foo/bad,foo/good', graph))
+  end
+
+  def test_total_reviews_submitted_skips_repo_when_review_page_graph_fails
+    WebMock.disable_net_connect!
+    graph = Class.new(Fbe::Graph::Fake) do
+      define_method(:pull_requests_with_reviews) do |_owner, _name, _since, **|
+        {
+          'pulls_with_reviews' => [{ 'id' => 'some', 'number' => 7 }],
+          'has_next_page' => false,
+          'next_cursor' => nil
+        }
+      end
+      define_method(:pull_request_reviews) do |_owner, name, **|
+        raise(GraphQL::Client::Error, 'GraphQL failed') if name == 'bad'
+        [
+          {
+            'id' => 'good',
+            'number' => 7,
+            'reviews' => [{ 'id' => 'review', 'submitted_at' => Time.parse('2025-10-02 12:58:42 UTC') }],
+            'reviews_has_next_page' => false,
+            'reviews_next_cursor' => nil
+          }
+        ]
+      end
+    end.new
+    assert_equal({ total_reviews_submitted: 1 }, total_reviews_with_graph('foo/bad,foo/good', graph))
+  end
+
+  def test_total_reviews_submitted_does_not_swallow_local_graph_bug
+    WebMock.disable_net_connect!
+    graph = Class.new(Fbe::Graph::Fake) do
+      define_method(:pull_requests_with_reviews) do |_owner, _name, _since, **|
+        raise(NoMethodError, 'local bug')
+      end
+    end.new
+    assert_raises(NoMethodError) { total_reviews_with_graph('foo/bad', graph) }
+  end
+
   def test_quantity_of_deliverables_total_builds_ran
     WebMock.disable_net_connect!
     stub_request(:get, 'https://api.github.com/rate_limit').to_return(
@@ -248,4 +310,28 @@ class TestQuantityOfDeliverables < Jp::Test
       end
     end
   end
+
+  private
+
+  # rubocop:disable Elegant/GoodMethodName
+  def total_reviews_with_graph(repositories, graph)
+    rate_limit_up
+    repositories.split(',').each do |repo|
+      stub_github(
+        "https://api.github.com/repos/#{repo}",
+        body: { id: repo.hash.abs, full_name: repo, archived: false, open_issues: 0, size: 100 }
+      )
+    end
+    $judge = 'quantity-of-deliverables'
+    $global = {}
+    $local = {}
+    $loog = Loog::NULL
+    $options = Judges::Options.new({ 'repositories' => repositories })
+    fact = Struct.new(:since, :when).new(Time.parse('2025-09-30 00:00:00 UTC'), Time.parse('2025-10-06 21:00:00 UTC'))
+    Fbe.stub(:github_graph, graph) do
+      load(File.join(__dir__, '../../judges/quantity-of-deliverables/total_reviews_submitted.rb'))
+      total_reviews_submitted(fact)
+    end
+  end
+  # rubocop:enable Elegant/GoodMethodName
 end

--- a/test/judges/test-quantity-of-deliverables.rb
+++ b/test/judges/test-quantity-of-deliverables.rb
@@ -13,6 +13,46 @@ require_relative '../test__helper'
 class TestQuantityOfDeliverables < Jp::Test
   using SmartFactbase
 
+  def reviewgraph(repo, call, err)
+    graph = Fbe::Graph::Fake.new
+    pulls = graph.method(:pull_requests_with_reviews)
+    reviews = graph.method(:pull_request_reviews)
+    graph.define_singleton_method(:pull_requests_with_reviews) do |owner, name, since, cursor:|
+      raise(err) if repo == "#{owner}/#{name}" && call == :pulls
+      pulls.call(owner, name, since, cursor:)
+    end
+    graph.define_singleton_method(:pull_request_reviews) do |owner, name, pulls:|
+      raise(err) if repo == "#{owner}/#{name}" && call == :reviews
+      reviews.call(owner, name, pulls:)
+    end
+    graph
+  end
+
+  def directreviews(repos, graph)
+    WebMock.disable_net_connect!
+    rate_limit_up
+    repos.each_with_index do |repo, idx|
+      stub_github(
+        "https://api.github.com/repos/#{repo}",
+        body: { id: 100 + idx, full_name: repo, open_issues: 0, archived: false, size: 100 }
+      )
+    end
+    $global = {}
+    $local = {}
+    $judge = 'quantity-of-deliverables'
+    $options = Judges::Options.new({ 'repositories' => repos.join(',') })
+    $loog = Loog::NULL
+    $epoch = Time.parse('2025-10-06 21:00:00 UTC')
+    $kickoff = $epoch
+    fact = Factbase.new.insert
+    fact.since = Time.parse('2025-09-30 00:00:00 +03:00')
+    fact.when = Time.parse('2025-10-06 21:00:00 UTC')
+    Fbe.stub(:github_graph, graph) do
+      load(File.join(__dir__, '../../judges/quantity-of-deliverables/total_reviews_submitted.rb'))
+      total_reviews_submitted(fact)
+    end
+  end
+
   def test_counts_commits
     WebMock.disable_net_connect!
     stub_request(:get, 'https://api.github.com/rate_limit').to_return(
@@ -161,66 +201,19 @@ class TestQuantityOfDeliverables < Jp::Test
     end
   end
 
-  def test_total_reviews_submitted_skips_repo_when_pull_list_graph_fails
-    WebMock.disable_net_connect!
-    graph = Class.new(Fbe::Graph::Fake) do
-      define_method(:pull_requests_with_reviews) do |_owner, name, _since, **|
-        raise(GraphQL::Client::Error, 'GraphQL failed') if name == 'bad'
-        {
-          'pulls_with_reviews' => [{ 'id' => 'good', 'number' => 7 }],
-          'has_next_page' => false,
-          'next_cursor' => nil
-        }
-      end
-      define_method(:pull_request_reviews) do |_owner, _name, **|
-        [
-          {
-            'id' => 'good',
-            'number' => 7,
-            'reviews' => [{ 'id' => 'review', 'submitted_at' => Time.parse('2025-10-02 12:58:42 UTC') }],
-            'reviews_has_next_page' => false,
-            'reviews_next_cursor' => nil
-          }
-        ]
-      end
-    end.new
-    assert_equal({ total_reviews_submitted: 1 }, total_reviews_with_graph('foo/bad,foo/good', graph))
+  def test_quantity_of_deliverables_total_reviews_submitted_skips_pull_list_failure
+    graph = reviewgraph('foo/bad', :pulls, GraphQL::Client::Error.new('GraphQL failed'))
+    assert_equal({ total_reviews_submitted: 4 }, directreviews(%w[foo/bad foo/good], graph))
   end
 
-  def test_total_reviews_submitted_skips_repo_when_review_page_graph_fails
-    WebMock.disable_net_connect!
-    graph = Class.new(Fbe::Graph::Fake) do
-      define_method(:pull_requests_with_reviews) do |_owner, _name, _since, **|
-        {
-          'pulls_with_reviews' => [{ 'id' => 'some', 'number' => 7 }],
-          'has_next_page' => false,
-          'next_cursor' => nil
-        }
-      end
-      define_method(:pull_request_reviews) do |_owner, name, **|
-        raise(GraphQL::Client::Error, 'GraphQL failed') if name == 'bad'
-        [
-          {
-            'id' => 'good',
-            'number' => 7,
-            'reviews' => [{ 'id' => 'review', 'submitted_at' => Time.parse('2025-10-02 12:58:42 UTC') }],
-            'reviews_has_next_page' => false,
-            'reviews_next_cursor' => nil
-          }
-        ]
-      end
-    end.new
-    assert_equal({ total_reviews_submitted: 1 }, total_reviews_with_graph('foo/bad,foo/good', graph))
+  def test_quantity_of_deliverables_total_reviews_submitted_skips_reviews_failure
+    graph = reviewgraph('foo/bad', :reviews, GraphQL::Client::Error.new('GraphQL failed'))
+    assert_equal({ total_reviews_submitted: 4 }, directreviews(%w[foo/bad foo/good], graph))
   end
 
-  def test_total_reviews_submitted_does_not_swallow_local_graph_bug
-    WebMock.disable_net_connect!
-    graph = Class.new(Fbe::Graph::Fake) do
-      define_method(:pull_requests_with_reviews) do |_owner, _name, _since, **|
-        raise(NoMethodError, 'local bug')
-      end
-    end.new
-    assert_raises(NoMethodError) { total_reviews_with_graph('foo/bad', graph) }
+  def test_quantity_of_deliverables_total_reviews_submitted_keeps_code_errors_visible
+    graph = reviewgraph('foo/bad', :pulls, NoMethodError.new('bad fake'))
+    assert_raises(NoMethodError) { directreviews(%w[foo/bad], graph) }
   end
 
   def test_quantity_of_deliverables_total_builds_ran
@@ -310,28 +303,4 @@ class TestQuantityOfDeliverables < Jp::Test
       end
     end
   end
-
-  private
-
-  # rubocop:disable Elegant/GoodMethodName
-  def total_reviews_with_graph(repositories, graph)
-    rate_limit_up
-    repositories.split(',').each do |repo|
-      stub_github(
-        "https://api.github.com/repos/#{repo}",
-        body: { id: repo.hash.abs, full_name: repo, archived: false, open_issues: 0, size: 100 }
-      )
-    end
-    $judge = 'quantity-of-deliverables'
-    $global = {}
-    $local = {}
-    $loog = Loog::NULL
-    $options = Judges::Options.new({ 'repositories' => repositories })
-    fact = Struct.new(:since, :when).new(Time.parse('2025-09-30 00:00:00 UTC'), Time.parse('2025-10-06 21:00:00 UTC'))
-    Fbe.stub(:github_graph, graph) do
-      load(File.join(__dir__, '../../judges/quantity-of-deliverables/total_reviews_submitted.rb'))
-      total_reviews_submitted(fact)
-    end
-  end
-  # rubocop:enable Elegant/GoodMethodName
 end


### PR DESCRIPTION
/claim #1437

Fixes #1437.

Summary:
- Rescue narrow transient failures from the two submitted-review GraphQL lookups for the current repository.
- Log the skipped repository and continue counting submitted reviews for the remaining repositories.
- Add regression coverage for failures in both GraphQL calls and for keeping ordinary code errors unrescued.

Validation:
- `mise x ruby@3.3.11 -- bundle exec ruby -Itest test/judges/test-quantity-of-deliverables.rb --include '/total_reviews_submitted_(skips|keeps)/'` (tests passed; filtered coverage gate exits non-zero, so not used as final gate)\n- `mise x ruby@3.3.11 -- bundle exec ruby -Itest test/judges/test-quantity-of-deliverables.rb`\n- `mise x ruby@3.3.11 -- bundle exec rubocop judges/quantity-of-deliverables/total_reviews_submitted.rb test/judges/test-quantity-of-deliverables.rb`\n- `git diff --check`\n- `git diff HEAD~2..HEAD | gitleaks stdin --no-banner --redact --exit-code 1`\n- `mise x ruby@3.3.11 -- bundle exec rake test`\n\nNo secrets are included.