### PR TITLE
#1442: Skip unpublished releases in QoS metrics

### DIFF
--- a/judges/quality-of-service/some_release_hoc_size.rb
+++ b/judges/quality-of-service/some_release_hoc_size.rb
@@ -12,6 +12,7 @@ def some_release_hoc_size(fact)
   commits = []
   Fbe.unmask_repos do |repo|
     Fbe.octo.releases(repo).each do |json|
+      next if json[:published_at].nil?
       next if json[:published_at] > fact.when
       break if json[:published_at] < fact.since
       (grouped[repo] ||= []) << json

--- a/judges/quality-of-service/some_release_interval.rb
+++ b/judges/quality-of-service/some_release_interval.rb
@@ -10,6 +10,7 @@ def some_release_interval(fact)
   dates = []
   Fbe.unmask_repos do |repo|
     Fbe.octo.releases(repo).each do |json|
+      next if json[:published_at].nil?
       next if json[:published_at] > fact.when
       break if json[:published_at] < fact.since
       dates << json[:published_at]

--- a/test/judges/test-quality-of-service.rb
+++ b/test/judges/test-quality-of-service.rb
@@ -196,6 +196,15 @@ class TestQualityOfService < Jp::Test
           assets: [], body: 'Some description', mentions_count: 4
         },
         {
+          id: 173_465,
+          author: { login: 'yegor256', id: 526_301, type: 'User', site_admin: false },
+          tag_name: '0.0.nil', target_commitish: 'master',
+          name: 'Draft Release', draft: true, prerelease: false,
+          created_at: Time.parse('2024-08-06 00:30:14 UTC'),
+          published_at: nil,
+          assets: [], body: 'Some description', mentions_count: 4
+        },
+        {
           id: 173_460,
           author: { login: 'yegor256', id: 526_301, type: 'User', site_admin: false },
           tag_name: '0.0.4', target_commitish: 'master',
@@ -355,6 +364,7 @@ class TestQualityOfService < Jp::Test
       f = fb.query('(eq what "quality-of-service")').each.first
       assert_equal(Time.parse('2024-08-02 21:00:00 UTC'), f.since)
       assert_equal(Time.parse('2024-08-09 21:00:00 UTC'), f.when)
+      assert_equal([64_800, 21_600, 36_000], f['some_release_interval'])
       assert_equal([52, 24, 99], f['some_release_hoc_size'])
       assert_equal([1, 2, 4], f['some_release_commits_size'])
     end


### PR DESCRIPTION
/claim #1442

Fixes #1442.
Fixes #1445.

This skips releases whose `published_at` is `nil` before the QoS release metrics compare the timestamp with the fact window. The same guard is applied to `some_release_interval` and `some_release_hoc_size`, because both iterate the same release payload and both compare `published_at` with `fact.when` / `fact.since`.

Validation:

- `bundle exec ruby test/judges/test-quality-of-service.rb -n test_quality_of_service_some_release_hocs_size_and_commits_size -- --no-cov` -> 1 test, 5 assertions, 0 failures.
- `bundle exec ruby test/judges/test-quality-of-service.rb -- --no-cov` -> 19 tests, 73 assertions, 0 failures.
- `bundle exec rubocop judges/quality-of-service/some_release_interval.rb judges/quality-of-service/some_release_hoc_size.rb test/judges/test-quality-of-service.rb --format simple` -> 3 files inspected, no offenses.
- `ruby -c judges/quality-of-service/some_release_interval.rb`; `ruby -c judges/quality-of-service/some_release_hoc_size.rb`; `ruby -c test/judges/test-quality-of-service.rb` -> Syntax OK.
- `git diff --check` -> clean.
- `git diff --no-ext-diff origin/master | gitleaks stdin --no-banner --redact --exit-code 1` -> no leaks found.
- `bundle exec rake test -- --no-cov` -> 220 tests, 612 assertions, 0 failures, 1 skip.

No wallet, payout, signing, production mutation, or destructive action was performed.
