### PR TITLE
#804: add milestone-was-set judge

### DIFF
--- a/judges/milestone-was-set/milestone-was-set.rb
+++ b/judges/milestone-was-set/milestone-was-set.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+# SPDX-License-Identifier: MIT
+
+require 'fbe/if_absent'
+require 'fbe/iterate'
+require 'fbe/octo'
+require 'fbe/who'
+require 'octokit'
+require 'tago'
+
+Fbe.iterate do
+  as 'milestones_were_scanned'
+  by '(plus 0 $before)'
+  over do |repository, before|
+    repo = Fbe.octo.repo_name_by_id(repository)
+    milestones =
+      begin
+        Fbe.octo.list_milestones(repo, state: :all, sort: :created, direction: :asc)
+      rescue Octokit::NotFound, Octokit::Deprecated => e
+        $loog.info("Milestones are not available in #{repo}: #{e.message}")
+        next before
+      rescue Octokit::Forbidden => e
+        $loog.warn("[#{$judge}] Access forbidden to milestones in #{repo}: #{e.class}: #{e.message}")
+        next before
+      end
+    latest = before
+    milestones.each do |json|
+      number = json[:number]
+      next unless number > before
+      latest = [latest, number].max
+      Fbe.fb.txn do |fbt|
+        n =
+          Fbe.if_absent(fb: fbt) do |f|
+            f.what = $judge
+            f.where = 'github'
+            f.repository = repository
+            f.milestone = number
+          end
+        next if n.nil?
+        n.when = json[:created_at]
+        creator = json.dig(:creator, :id)
+        if creator
+          n.who = creator
+        else
+          n.stale = 'who'
+        end
+        n.deadline = json[:due_on] unless json[:due_on].nil?
+        n.details = "The milestone ##{n.milestone} in #{repo} was set by #{creator ? Fbe.who(n) : 'an unknown user'}."
+        $loog.info("The milestone ##{n.milestone} in #{repo} was set #{n.when.ago} ago")
+      end
+    end
+    latest
+  end
+end
+
+Fbe.octo.print_trace!

--- a/test/judges/test-milestone-was-set.rb
+++ b/test/judges/test-milestone-was-set.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+# SPDX-License-Identifier: MIT
+
+require 'factbase'
+require_relative '../test__helper'
+
+class TestMilestoneWasSet < Jp::Test
+  using SmartFactbase
+
+  def test_finds_milestones
+    WebMock.disable_net_connect!
+    rate_limit_up
+    repo
+    milestones(
+      [
+        {
+          number: 7,
+          title: 'v1.0',
+          creator: { id: 444, login: 'jeff' },
+          created_at: '2026-01-02 03:04:05 UTC',
+          due_on: '2026-02-03 00:00:00 UTC'
+        }
+      ]
+    )
+    stub_github('https://api.github.com/user/444', body: { id: 444, login: 'jeff' })
+    fb = Factbase.new
+    load_it('milestone-was-set', fb)
+    assert(
+      fb.one?(
+        what: 'milestone-was-set',
+        where: 'github',
+        repository: 42,
+        milestone: 7,
+        who: 444,
+        when: Time.parse('2026-01-02 03:04:05 UTC'),
+        deadline: Time.parse('2026-02-03 00:00:00 UTC'),
+        details: 'The milestone #7 in foo/foo was set by @jeff.'
+      )
+    )
+    assert(fb.one?(what: 'iterate', milestones_were_scanned: 7, repository: 42, where: 'github'))
+  end
+
+  def test_skips_existing_milestones_and_advances_cursor
+    WebMock.disable_net_connect!
+    rate_limit_up
+    repo
+    milestones(
+      [
+        { number: 1, creator: { id: 111 }, created_at: '2026-01-01 00:00:00 UTC', due_on: nil },
+        { number: 2, creator: { id: 222 }, created_at: '2026-01-02 00:00:00 UTC', due_on: nil },
+        { number: 3, creator: { id: 333 }, created_at: '2026-01-03 00:00:00 UTC', due_on: nil }
+      ]
+    )
+    stub_github('https://api.github.com/user/333', body: { id: 333, login: 'third' })
+    fb = Factbase.new
+    fb.with(
+      _id: 1,
+      what: 'milestone-was-set',
+      where: 'github',
+      repository: 42,
+      milestone: 2,
+      who: 222,
+      when: Time.parse('2026-01-02 00:00:00 UTC')
+    ).with(_id: 2, what: 'iterate', where: 'github', repository: 42, milestones_were_scanned: 2)
+    load_it('milestone-was-set', fb)
+    assert_equal(2, fb.picks(what: 'milestone-was-set').size)
+    assert(fb.one?(what: 'milestone-was-set', repository: 42, milestone: 3, who: 333))
+    assert(fb.one?(what: 'iterate', milestones_were_scanned: 3, repository: 42, where: 'github'))
+  end
+
+  def test_marks_absent_creator_as_stale
+    WebMock.disable_net_connect!
+    rate_limit_up
+    repo
+    milestones(
+      [
+        {
+          number: 5,
+          title: 'unknown owner',
+          creator: nil,
+          created_at: '2026-01-05 00:00:00 UTC',
+          due_on: nil
+        }
+      ]
+    )
+    fb = Factbase.new
+    load_it('milestone-was-set', fb)
+    assert(fb.one?(what: 'milestone-was-set', repository: 42, milestone: 5, stale: 'who'))
+    assert_nil(fb.pick(what: 'milestone-was-set', milestone: 5)['deadline'])
+  end
+
+  def test_forbidden_milestones_are_transient
+    WebMock.disable_net_connect!
+    rate_limit_up
+    repo
+    stub_github(
+      %r{https://api[.]github[.]com/repos/foo/foo/milestones},
+      status: 403,
+      body: { message: 'Resource not accessible by integration' }
+    )
+    fb = Factbase.new
+    load_it('milestone-was-set', fb)
+    assert_empty(fb.picks(what: 'milestone-was-set'))
+    assert_empty(fb.picks(what: 'iterate'))
+  end
+
+  private
+
+  def repo
+    stub_github('https://api.github.com/repos/foo/foo', body: { id: 42, name: 'foo', full_name: 'foo/foo' })
+    stub_github('https://api.github.com/repositories/42', body: { id: 42, name: 'foo', full_name: 'foo/foo' })
+  end
+
+  def milestones(body)
+    stub_github(%r{https://api[.]github[.]com/repos/foo/foo/milestones}, body: body)
+  end
+end


### PR DESCRIPTION
/claim #804
Closes #804

Summary:
- add a new `milestone-was-set` judge that scans GitHub milestones per repository and records `where`, `repository`, `milestone`, `when`, `who`, and `deadline` when present;
- keep a `milestones_were_scanned` iterate cursor so already-scanned milestone numbers are skipped on later cycles;
- add tests for fact creation, cursor advancement/duplicate avoidance, absent creator handling, and transient forbidden milestone lookup.

Validation:
- `bundle exec ruby -Itest test/judges/test-milestone-was-set.rb -- --no-cov` -> 4 tests, 11 assertions, 0 failures.
- `bundle exec ruby -Itest test/test_pattern_a_coverage.rb -- --no-cov` -> 1 test, 4 assertions, 0 failures.
- `bundle exec rake test` -> 224 tests, 622 assertions, 0 failures, 0 errors, 1 skip.
- `bundle exec rake judges` -> all 29 judges and 59 judge fixture tests passed.
- `bundle exec rubocop judges/milestone-was-set/milestone-was-set.rb test/judges/test-milestone-was-set.rb --format simple` -> no offenses.
- `ruby -c judges/milestone-was-set/milestone-was-set.rb` and `ruby -c test/judges/test-milestone-was-set.rb` -> Syntax OK.
- `git diff --cached --check` -> clean before commit.
- `git diff --cached --no-ext-diff | gitleaks stdin --no-banner --redact --exit-code 1` -> no leaks found.

No secrets or credentials are included.