### PR TITLE
#1446: skip transient commit count failures

### DIFF
--- a/judges/quantity-of-deliverables/total_commits_pushed.rb
+++ b/judges/quantity-of-deliverables/total_commits_pushed.rb
@@ -3,18 +3,43 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
 # SPDX-License-Identifier: MIT
 
+require 'fbe/github_graph'
 require 'fbe/octo'
 require 'fbe/unmask_repos'
+require 'net/http'
+require 'octokit'
 
 def total_commits_pushed(fact)
   commits = 0
   hoc = 0
   Fbe.unmask_repos do |repo|
-    next if Fbe.octo.repository(repo)[:size].zero?
+    repository =
+      begin
+        Fbe.octo.repository(repo)
+      rescue Octokit::NotFound, Octokit::Deprecated => e
+        $loog.info("#{repo} can't be inspected: #{e.class}: #{e.message}")
+        next
+      rescue Octokit::Forbidden => e
+        $loog.warn(
+          "[#{$judge}] Access forbidden to #{repo} " \
+          "(transient, will retry next cycle): #{e.class}: #{e.message}"
+        )
+        next
+      end
+    next if repository[:size].zero?
     owner, name = repo.split('/')
-    Fbe.github_graph.total_commits_pushed(owner, name, fact.since).then do |json|
-      commits += json['commits']
-      hoc += json['hoc']
+    begin
+      Fbe.github_graph.total_commits_pushed(owner, name, fact.since).then do |json|
+        commits += json['commits']
+        hoc += json['hoc']
+      end
+    rescue GraphQL::Client::Error, Octokit::Forbidden, Net::OpenTimeout, Net::ReadTimeout,
+           SocketError, Errno::ECONNRESET, Errno::ETIMEDOUT => e
+      $loog.warn(
+        "[#{$judge}] Can't count pushed commits in #{repo} " \
+        "(transient, will retry next cycle): #{e.class}: #{e.message}"
+      )
+      next
     end
   end
   {

--- a/test/judges/test-quantity-of-deliverables.rb
+++ b/test/judges/test-quantity-of-deliverables.rb
@@ -5,6 +5,7 @@
 
 require 'factbase'
 require 'fbe/github_graph'
+require 'fbe/unmask_repos'
 require 'json'
 require 'judges/options'
 require 'loog'
@@ -61,6 +62,90 @@ class TestQuantityOfDeliverables < Jp::Test
         assert_equal(0, f.first.total_hoc_committed)
         assert_equal(25, f.first.total_issues_created)
         assert_equal(8, f.first.total_pulls_submitted)
+      end
+    end
+  end
+
+  def test_total_commits_pushed_skips_unavailable_repositories
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repos/foo/missing', status: 404, body: { message: 'Not Found' })
+    stub_github('https://api.github.com/repos/foo/blocked', status: 403, body: { message: 'Forbidden' })
+    stub_github(
+      'https://api.github.com/repos/foo/good',
+      body: { id: 42, full_name: 'foo/good', open_issues: 0, size: 100 }
+    )
+    graph = Object.new
+    graph.define_singleton_method(:total_commits_pushed) do |_owner, name, _since|
+      { 'commits' => name.length, 'hoc' => name.length * 100 }
+    end
+    fact = Object.new
+    fact.define_singleton_method(:since) { Time.parse('2025-10-01 00:00:00 UTC') }
+    unmask = proc { |&block| %w[foo/missing foo/blocked foo/good].each { |repo| block.call(repo) } }
+    $global = {}
+    $judge = 'quantity-of-deliverables'
+    $loog = Loog::NULL
+    $options = Judges::Options.new({ 'repositories' => 'foo/foo' })
+    Fbe.stub(:unmask_repos, unmask) do
+      Fbe.stub(:github_graph, graph) do
+        load(File.join(__dir__, '../../judges/quantity-of-deliverables/total_commits_pushed.rb'))
+        assert_equal({ total_commits_pushed: 4, total_hoc_committed: 400 }, total_commits_pushed(fact))
+      end
+    end
+  end
+
+  def test_total_commits_pushed_skips_transient_graph_failures
+    WebMock.disable_net_connect!
+    rate_limit_up
+    %w[bad good].each do |name|
+      stub_github(
+        "https://api.github.com/repos/foo/#{name}",
+        body: { id: 42, full_name: "foo/#{name}", open_issues: 0, size: 100 }
+      )
+    end
+    graph = Object.new
+    graph.define_singleton_method(:total_commits_pushed) do |owner, name, _since|
+      repo = "#{owner}/#{name}"
+      raise(Net::OpenTimeout, 'timeout') if repo == 'foo/bad'
+      { 'commits' => name.length, 'hoc' => name.length * 100 }
+    end
+    fact = Object.new
+    fact.define_singleton_method(:since) { Time.parse('2025-10-01 00:00:00 UTC') }
+    unmask = proc { |&block| %w[foo/bad foo/good].each { |repo| block.call(repo) } }
+    $global = {}
+    $judge = 'quantity-of-deliverables'
+    $loog = Loog::NULL
+    $options = Judges::Options.new({ 'repositories' => 'foo/foo' })
+    Fbe.stub(:unmask_repos, unmask) do
+      Fbe.stub(:github_graph, graph) do
+        load(File.join(__dir__, '../../judges/quantity-of-deliverables/total_commits_pushed.rb'))
+        assert_equal({ total_commits_pushed: 4, total_hoc_committed: 400 }, total_commits_pushed(fact))
+      end
+    end
+  end
+
+  def test_total_commits_pushed_keeps_code_errors_visible
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github(
+      'https://api.github.com/repos/foo/bad',
+      body: { id: 42, full_name: 'foo/bad', open_issues: 0, size: 100 }
+    )
+    graph = Object.new
+    graph.define_singleton_method(:total_commits_pushed) do |_owner, _name, _since|
+      raise(NoMethodError, 'unexpected')
+    end
+    fact = Object.new
+    fact.define_singleton_method(:since) { Time.parse('2025-10-01 00:00:00 UTC') }
+    unmask = proc { |&block| block.call('foo/bad') }
+    $global = {}
+    $judge = 'quantity-of-deliverables'
+    $loog = Loog::NULL
+    $options = Judges::Options.new({ 'repositories' => 'foo/foo' })
+    Fbe.stub(:unmask_repos, unmask) do
+      Fbe.stub(:github_graph, graph) do
+        load(File.join(__dir__, '../../judges/quantity-of-deliverables/total_commits_pushed.rb'))
+        assert_raises(NoMethodError) { total_commits_pushed(fact) }
       end
     end
   end


### PR DESCRIPTION
/claim #1446
Fixes #1446

## Summary
- Wrap the `total_commits_pushed` repository lookup so unavailable/deprecated/forbidden repositories do not abort the whole `quantity-of-deliverables` pass.
- Wrap the commit-count GraphQL call so transient GraphQL/network failures are logged and retried on the next cycle while other repositories still contribute their metrics.
- Add regression coverage for skipped repository lookup failures, skipped transient commit-count failures, and non-transient code errors remaining visible.

## Validation
- `mise exec ruby@3.3.11 -- bundle exec ruby test/judges/test-quantity-of-deliverables.rb -n '/test_total_commits_pushed_(skips_unavailable_repositories|skips_transient_graph_failures|keeps_code_errors_visible)$/' -- --no-cov`
- `mise exec ruby@3.3.11 -- bundle exec ruby test/judges/test-quantity-of-deliverables.rb -- --no-cov`
- `mise exec ruby@3.3.11 -- bundle exec ruby test/test_pattern_a_coverage.rb -- --no-cov`
- `mise exec ruby@3.3.11 -- bundle exec rubocop judges/quantity-of-deliverables/total_commits_pushed.rb test/judges/test-quantity-of-deliverables.rb --format simple`
- `mise exec ruby@3.3.11 -- bundle exec rake test`
- `git diff --check`
- `git diff --no-ext-diff origin/master | gitleaks stdin --no-banner --redact --exit-code 1`

No secrets, credentials, wallet material, or production mutations are included.
