### PR TITLE
#589: cap QoS search calls per rolling 60s window

### DIFF
--- a/lib/qos_search.rb
+++ b/lib/qos_search.rb
@@ -7,17 +7,35 @@ require 'fbe/octo'
 require 'octokit'
 require_relative 'jp'
 
+Jp::SEARCH_WINDOW_SECONDS = 60
+Jp::SEARCH_WINDOW_BUDGET = 25
+
 def Jp.qoreset
   @offquota = false
+  @scount = 0
+  @swstart = nil
 end
 
 def Jp.qosearch(query, **options)
   return if @offquota || Fbe.octo.off_quota?
+  now = Time.now
+  if @swstart.nil? || (now - @swstart) >= Jp::SEARCH_WINDOW_SECONDS
+    @swstart = now
+    @scount = 0
+  end
+  if @scount >= Jp::SEARCH_WINDOW_BUDGET
+    $loog.info(
+      'Approaching GitHub Search API per-minute limit ' \
+      "(#{@scount} calls in #{Integer(now - @swstart, exception: false) || 0}s), deferring this QoS search call"
+    )
+    return
+  end
+  @scount += 1
   found = Fbe.octo.search_issues(query, options)
   left = Fbe.octo.rate_limit.remaining
   if left.zero?
     @offquota = true
-    $loog.info('Too much GitHub Search API quota consumed already (0 left)')
+    $loog.info('Too much GitHub API quota consumed already (0 left)')
   end
   found
 rescue Octokit::TooManyRequests => e

--- a/test/lib/test_qos_search.rb
+++ b/test/lib/test_qos_search.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+# SPDX-License-Identifier: MIT
+
+require 'loog'
+require 'minitest/mock'
+require_relative '../../lib/qos_search'
+require_relative '../test__helper'
+
+class TestQosSearch < Minitest::Test
+  SearchResult = Struct.new(:items, :total_count, keyword_init: true)
+  RateLimit = Struct.new(:remaining, keyword_init: true)
+
+  def setup
+    $loog = Loog::Buffer.new
+    $judge = 'test-judge'
+    Jp.qoreset
+  end
+
+  def teardown
+    $loog = nil
+    $judge = nil
+  end
+
+  def fake(raise_after: nil)
+    octo = Object.new
+    calls = [0]
+    octo.define_singleton_method(:off_quota?) { false }
+    octo.define_singleton_method(:search_issues) do |_q, _opts|
+      calls[0] += 1
+      raise(Octokit::TooManyRequests.new(body: 'rate limit exceeded')) if raise_after && calls[0] > raise_after
+      SearchResult.new(items: [], total_count: 0)
+    end
+    octo.define_singleton_method(:rate_limit) { RateLimit.new(remaining: 5000) }
+    octo.define_singleton_method(:calls_made) { calls[0] }
+    octo
+  end
+
+  def test_caps_search_calls_per_window
+    fake_octo = fake
+    Fbe.stub(:octo, fake_octo) do
+      ran = 0
+      (Jp::SEARCH_WINDOW_BUDGET + 5).times do
+        result = Jp.qosearch('repo:foo/bar type:issue')
+        ran += 1 unless result.nil?
+      end
+      assert_equal(Jp::SEARCH_WINDOW_BUDGET, fake_octo.calls_made)
+      assert_equal(Jp::SEARCH_WINDOW_BUDGET, ran)
+      assert_match(/Approaching GitHub Search API per-minute limit/, $loog.to_s)
+      assert_match(/deferring this QoS search call/, $loog.to_s)
+    end
+  end
+
+  def test_resets_budget_after_window_elapses
+    fake_octo = fake
+    Fbe.stub(:octo, fake_octo) do
+      base = Time.now
+      Time.stub(:now, base) do
+        Jp::SEARCH_WINDOW_BUDGET.times { Jp.qosearch('repo:foo/bar type:issue') }
+      end
+      assert_nil(Time.stub(:now, base + 5) { Jp.qosearch('repo:foo/bar type:issue') })
+      Time.stub(:now, base + Jp::SEARCH_WINDOW_SECONDS + 1) do
+        refute_nil(Jp.qosearch('repo:foo/bar type:issue'))
+      end
+      assert_equal(Jp::SEARCH_WINDOW_BUDGET + 1, fake_octo.calls_made)
+    end
+  end
+
+  def test_stops_after_too_many_requests
+    fake_octo = fake(raise_after: 0)
+    Fbe.stub(:octo, fake_octo) do
+      assert_nil(Jp.qosearch('repo:foo/bar type:issue'))
+      assert_nil(Jp.qosearch('repo:foo/bar type:issue'))
+      assert_match(/GitHub Search API quota exhausted/, $loog.to_s)
+      assert_equal(1, fake_octo.calls_made)
+    end
+  end
+end


### PR DESCRIPTION
Fixes #589.

`Jp.qosearch` shares the core-quota guard with the rest of `fbe` via `Fbe.octo.rate_limit.remaining`, but the GitHub Search API has its own 30 req/min budget that is invisible to that counter. When a cycle hits many repositories the QoS judges burst through that per-minute budget and the next call returns 403 / rate limit exceeded before the existing `Octokit::TooManyRequests` rescue can fire, which is exactly the symptom captured in the issue.

The fix keeps the bookkeeping inside `Jp` itself: a rolling 60-second window and a 25-call budget are initialized in `qoreset` and consulted before every call. When the budget is consumed within a window, subsequent calls log an info line and return `nil` instead of hitting the API; once the window elapses, the counter resets. The existing `Octokit::TooManyRequests` path is untouched so a true exhaustion still latches `@offquota`.

Checks run locally on this branch:

- `bundle exec ruby test/lib/test_qos_search.rb -- --no-cov` -> 3 tests, 14 assertions, 0 failures (new coverage).
- `bundle exec ruby test/judges/test-quality-of-service.rb -- --no-cov` -> 19 tests, 72 assertions, 0 failures.
- `bundle exec ruby test/lib/test_incremate.rb -- --no-cov` -> 2 tests, 7 assertions, 0 failures.
- `bundle exec ruby test/lib/test_cover_qo.rb -- --no-cov` -> 22 tests, 44 assertions, 0 failures.
- `rubocop lib/qos_search.rb test/lib/test_qos_search.rb` -> 2 files, no offenses.
- `ruby -c lib/qos_search.rb` / `ruby -c test/lib/test_qos_search.rb` -> Syntax OK.
