### PR TITLE
#1448: guard deleted users in reactions

### DIFF
--- a/lib/pull_request.rb
+++ b/lib/pull_request.rb
@@ -31,12 +31,12 @@ def Jp.count_appreciated_comments(pr, issue_comments, code_comments, repo: nil)
   issued =
     issue_comments.sum do |comment|
       Fbe.octo.issue_comment_reactions(repo, comment[:id])
-         .count { |reaction| reaction[:user][:id] != comment[:user][:id] }
+         .count { |reaction| reaction.dig(:user, :id) != comment.dig(:user, :id) }
     end
   coded =
     code_comments.sum do |comment|
       Fbe.octo.pull_request_review_comment_reactions(repo, comment[:id])
-         .count { |reaction| reaction[:user][:id] != comment[:user][:id] }
+         .count { |reaction| reaction.dig(:user, :id) != comment.dig(:user, :id) }
     end
   issued + coded
 end

--- a/test/lib/test_pull_request.rb
+++ b/test/lib/test_pull_request.rb
@@ -52,4 +52,43 @@ class TestPullRequest < Jp::Test
     result = Jp.fetch_workflows(pr)
     assert_equal({ succeeded_builds: 1, failed_builds: 0 }, result)
   end
+
+  def test_counts_reactions_when_reaction_user_is_nil
+    WebMock.disable_net_connect!
+    rate_limit_up
+    $options = Judges::Options.new({})
+    $global = {}
+    $loog = Loog::NULL
+    stub_github(
+      'https://api.github.com/repos/foo/foo/issues/comments/101/reactions',
+      body: [
+        { user: nil },
+        { user: { id: 42 } }
+      ]
+    )
+    count = Jp.count_appreciated_comments(
+      { base: { repo: { full_name: 'foo/foo' } } },
+      [{ id: 101, user: { id: 7 } }],
+      []
+    )
+    assert_equal(2, count)
+  end
+
+  def test_counts_reactions_when_comment_user_is_nil
+    WebMock.disable_net_connect!
+    rate_limit_up
+    $options = Judges::Options.new({})
+    $global = {}
+    $loog = Loog::NULL
+    stub_github(
+      'https://api.github.com/repos/foo/foo/pulls/comments/202/reactions',
+      body: [
+        { user: { id: 42 } },
+        { user: nil }
+      ]
+    )
+    pr = { base: { repo: { full_name: 'foo/foo' } } }
+    count = Jp.count_appreciated_comments(pr, [], [{ id: 202, user: nil }])
+    assert_equal(1, count)
+  end
 end


### PR DESCRIPTION
/claim #1448

Fixes #1448.

Summary:
- use `dig(:user, :id)` when comparing reaction and comment authors in `Jp.count_appreciated_comments`
- add regression coverage for deleted reaction authors and deleted comment authors on issue and review-comment reactions

Validation:
- `bundle install --no-color`
- `bundle exec ruby -Itest test/lib/test_pull_request.rb -- --no-cov` -> 4 tests, 4 assertions, 0 failures, 0 errors
- `bundle exec rubocop lib/pull_request.rb test/lib/test_pull_request.rb` -> 2 files inspected, no offenses
- `bundle exec rake test` -> 225 tests, 616 assertions, 0 failures, 0 errors, 1 skip
- `bundle exec rake` -> completed successfully, including test suite, `judges --verbose test --disable live --no-log --lib lib --option=action_version=0.0.0 judges`, RuboCop, and per-file Ruby checks
- `git diff --check origin/master..HEAD`
- `gitleaks detect --no-banner --redact --source . --log-opts origin/master..HEAD` -> no leaks found

No secrets or generated artifacts are included.