### PR TITLE
#1451: wire Makefile rubocop target

### DIFF
--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -20,6 +20,5 @@ jobs:
         with:
           ruby-version: 4.0.5
           bundler-cache: true
-      - run: gem install rubocop:1.63.5
       - run: sudo apt-get update && sudo apt-get install -y parallel
       - run: make

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,9 @@ export
 
 all: rubocop test entry rmi verify entries
 
+rubocop:
+	bundle exec rubocop
+
 test: target/docker-image.txt
 	img=$$(cat target/docker-image.txt)
 	docker run --rm --entrypoint '/bin/bash' "$${img}" -c 'judges test --disable live --lib /action/lib /action/judges'

--- a/test/test_makefile.rb
+++ b/test/test_makefile.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+# SPDX-License-Identifier: MIT
+
+require 'open3'
+require_relative 'test__helper'
+
+class TestMakefile < Jp::Test
+  def test_all_runs_rubocop
+    out, status = Open3.capture2e('make', '-n', 'all')
+    assert_predicate(status, :success?, out)
+    assert_includes(out, 'bundle exec rubocop')
+  end
+end


### PR DESCRIPTION
/claim #1451

Fixes #1451.

Summary:
- add a real `rubocop` recipe to `Makefile` that runs `bundle exec rubocop`
- remove the stale standalone `gem install rubocop:1.63.5` step from the `make` workflow so the job uses the bundled RuboCop version
- add a regression test proving `make -n all` includes the RuboCop invocation

Validation:
- `make -n rubocop` -> `bundle exec rubocop`
- `make -n all` -> includes `bundle exec rubocop` before Docker-backed targets
- `BUNDLE_PATH=/tmp/judges-action-1451-bundle bundle check`
- `BUNDLE_PATH=/tmp/judges-action-1451-bundle bundle exec ruby test/test_makefile.rb -- --no-cov` -> 1 test, 4 assertions, 0 failures, 0 errors
- `BUNDLE_PATH=/tmp/judges-action-1451-bundle bundle exec rake test` -> 224 tests, 618 assertions, 0 failures, 0 errors, 1 skip
- `BUNDLE_PATH=/tmp/judges-action-1451-bundle bundle exec rake rubocop` -> 99 files inspected, no offenses
- `BUNDLE_PATH=/tmp/judges-action-1451-bundle make rubocop` -> 99 files inspected, no offenses
- `BUNDLE_PATH=/tmp/judges-action-1451-bundle bundle exec rake judges` -> 28 judges and 59 judge tests passed
- `BUNDLE_PATH=/tmp/judges-action-1451-bundle bundle exec rake` -> completed successfully
- `git diff --check`
- `git diff --cached --no-ext-diff | gitleaks stdin --no-banner --redact --exit-code 1` -> no leaks found

No secrets or generated artifacts are included.