### PR TITLE
#1454: align cycles default

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ The following options are expected by the plugin
 * `verbose` (optional) makes it print debugging info if set to `true`
 * `timeout` (optional) is how many minutes each judge can spend
 * `lifetime` (optional) is how many minutes the entire update can take
-* `cycles` (optional) is a number of update cycles to run
+* `cycles` (optional) is a number of update cycles to run, default is `2`
 * `sqlite-cache` (optional) is a path of SQLite database file with HTTP cache
 * `bots` (optional) is a comma-separated list of GitHub user logins to mark as bots
 

--- a/action.yml
+++ b/action.yml
@@ -47,8 +47,8 @@ inputs:
     default: 15
   cycles:
     description: 'How many update cycles to run (keep it under 10)'
-    required: true
-    default: 1
+    required: false
+    default: 2
   sqlite-cache:
     description: 'Path of the SQLite file with the cache of HTTP requests'
     required: false

--- a/test/test_action_metadata.rb
+++ b/test/test_action_metadata.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+# SPDX-License-Identifier: MIT
+
+require 'yaml'
+require_relative 'test__helper'
+
+class TestActionMetadata < Jp::Test
+  def test_cycles_default_matches_entrypoint_fallback
+    root = File.expand_path('..', __dir__)
+    action = YAML.load_file(File.join(root, 'action.yml'))
+    cycles = action.fetch('inputs').fetch('cycles')
+    refute(cycles.fetch('required'))
+    assert_equal(2, cycles.fetch('default'))
+    assert_includes(
+      File.read(File.join(root, 'entry.sh')),
+      "cycles=2\n"
+    )
+  end
+end


### PR DESCRIPTION
/claim #1454

Fixes #1454.

Summary:
- make the `cycles` action input optional instead of required
- align the action metadata default with the existing `entry.sh` fallback of `2`
- document the default in the README and add a regression test for the metadata/script alignment

Validation:
- `bundle exec ruby -Itest test/test_action_metadata.rb` -> 1 test, 4 assertions, 0 failures
- `bundle exec ruby -Itest test/test_dockerfile.rb` -> 1 test, 6 assertions, 0 failures
- `bundle exec rubocop test/test_action_metadata.rb` -> no offenses
- `git diff --check` -> clean
- `git diff --no-ext-diff | gitleaks stdin --no-banner --redact --exit-code 1` -> no leaks found

Limitations:
- `bundle exec rake test` still has one failure in `test_quality_of_service_fill_up_abandoned_facts_with_exists_when_and_absent_since`; I reproduced the same focused failure on a clean `origin/master` baseline, so I treated it as unrelated to this metadata/docs change.