### PR TITLE
#1454: align cycles action default

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ The following options are expected by the plugin
 * `verbose` (optional) makes it print debugging info if set to `true`
 * `timeout` (optional) is how many minutes each judge can spend
 * `lifetime` (optional) is how many minutes the entire update can take
-* `cycles` (optional) is a number of update cycles to run
+* `cycles` (optional) is a number of update cycles to run, defaulting to `2`
 * `sqlite-cache` (optional) is a path of SQLite database file with HTTP cache
 * `bots` (optional) is a comma-separated list of GitHub user logins to mark as bots
 

--- a/action.yml
+++ b/action.yml
@@ -47,8 +47,8 @@ inputs:
     default: 15
   cycles:
     description: 'How many update cycles to run (keep it under 10)'
-    required: true
-    default: 1
+    required: false
+    default: 2
   sqlite-cache:
     description: 'Path of the SQLite file with the cache of HTTP requests'
     required: false

--- a/test/test_action_contract.rb
+++ b/test/test_action_contract.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+# SPDX-License-Identifier: MIT
+
+require 'yaml'
+require_relative 'test__helper'
+
+class TestActionContract < Jp::Test
+  def test_cycles_default_is_consistent
+    root = File.expand_path('..', __dir__)
+    meta = YAML.safe_load_file(File.join(root, 'action.yml'))
+    cycles = meta.fetch('inputs').fetch('cycles')
+    refute(cycles.fetch('required'))
+    assert_equal(2, cycles.fetch('default'))
+    assert_includes(File.read(File.join(root, 'entry.sh')), "cycles=2\n")
+    assert_includes(
+      File.read(File.join(root, 'README.md')),
+      '`cycles` (optional) is a number of update cycles to run, defaulting to `2`'
+    )
+  end
+end


### PR DESCRIPTION
/claim #1454

This aligns the `cycles` action input contract across `action.yml`, `entry.sh`, and README. The action metadata now makes `cycles` optional and defaults it to the same `2` value used by the shell fallback; README documents that default.

Validation:
- `bundle check`
- `bundle exec ruby -Itest test/test_action_contract.rb -- --no-cov`
- `bundle exec rake test`
- `bundle exec rake rubocop`
- `bundle exec rake judges`
- `bundle exec rake`
- `git diff --check origin/master..HEAD`
- `gitleaks detect --no-banner --redact --source . --log-opts origin/master..HEAD`