### PR TITLE
#1347: guard non-Array `Fbe.octo.X(...)` responses before `.each`

### DIFF
--- a/judges/dimensions-of-terrain/total_contributors.rb
+++ b/judges/dimensions-of-terrain/total_contributors.rb
@@ -11,7 +11,9 @@ def total_contributors(_fact)
   Fbe.unmask_repos do |repo|
     json = Fbe.octo.repository(repo)
     next if json[:size].nil? || json[:size].zero?
-    Fbe.octo.contributors(repo).each do |contributor|
+    list = Fbe.octo.contributors(repo)
+    next unless list.is_a?(Array)
+    list.each do |contributor|
       contributors << contributor[:id]
     end
   end

--- a/judges/dimensions-of-terrain/total_releases.rb
+++ b/judges/dimensions-of-terrain/total_releases.rb
@@ -9,7 +9,9 @@ require 'fbe/unmask_repos'
 def total_releases(_fact)
   total = 0
   Fbe.unmask_repos do |repo|
-    Fbe.octo.releases(repo).each do |_|
+    releases = Fbe.octo.releases(repo)
+    next unless releases.is_a?(Array)
+    releases.each do |_|
       total += 1
     end
   end

--- a/judges/github-events/github-events.rb
+++ b/judges/github-events/github-events.rb
@@ -80,7 +80,8 @@ Fbe.iterate do
   end
 
   def self.allcontributors(repo)
-    Fbe.octo.contributors(repo)
+    list = Fbe.octo.contributors(repo)
+    list.is_a?(Array) ? list : []
   rescue Octokit::NotFound, Octokit::Deprecated => e
     $loog.info("Contributors API failed for #{repo}: #{e.message}")
     []

--- a/judges/type-was-attached/type-was-attached.rb
+++ b/judges/type-was-attached/type-was-attached.rb
@@ -47,6 +47,7 @@ Fbe.iterate do
         )
         next issue
       end
+    next issue unless timeline.is_a?(Array)
     timeline.each do |te|
       unless events.include?(te[:event])
         $loog.debug("No #{events.joined} events at #{repo}##{issue}")

--- a/test/judges/test-dimensions-of-terrain.rb
+++ b/test/judges/test-dimensions-of-terrain.rb
@@ -134,6 +134,78 @@ class TestDimensionsOfTerrain < Jp::Test
     end
   end
 
+  def test_total_releases_skips_non_array_response
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github(
+      'https://api.github.com/repos/foo/foo',
+      body: {
+        name: 'foo', full_name: 'foo/foo', private: false,
+        created_at: Time.parse('2024-07-11 20:35:25 UTC'),
+        updated_at: Time.parse('2024-09-23 07:23:36 UTC'),
+        pushed_at: Time.parse('2024-09-23 20:22:51 UTC'),
+        size: 1, stargazers_count: 1, forks: 1, default_branch: 'master'
+      }
+    )
+    stub_github(
+      'https://api.github.com/repos/foo/foo/releases?per_page=100',
+      body: { message: 'Not Found', documentation_url: 'https://docs.github.com/rest' }
+    )
+    stub_github(
+      'https://api.github.com/repos/foo/foo/git/trees/master?recursive=true',
+      body: { sha: 'abc', tree: [], truncated: false }
+    )
+    stub_github('https://api.github.com/repos/foo/foo/contributors?per_page=100', body: [])
+    stub_github(
+      'https://api.github.com/search/commits?per_page=100&q=repo:foo/foo%20author-date:%3E2024-08-30',
+      body: { total_count: 0, incomplete_results: false, items: [] }
+    )
+    fb = Factbase.new
+    Fbe.stub(:github_graph, Fbe::Graph::Fake.new) do
+      Time.stub(:now, Time.parse('2024-09-29 21:00:00 UTC')) do
+        load_it('dimensions-of-terrain', fb)
+        f = fb.query("(eq what 'dimensions-of-terrain')").each.first
+        assert_equal(0, f.total_releases)
+      end
+    end
+  end
+
+  def test_total_contributors_skips_non_array_response
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github(
+      'https://api.github.com/repos/foo/foo',
+      body: {
+        name: 'foo', full_name: 'foo/foo', private: false,
+        created_at: Time.parse('2024-07-11 20:35:25 UTC'),
+        updated_at: Time.parse('2024-09-23 07:23:36 UTC'),
+        pushed_at: Time.parse('2024-09-23 20:22:51 UTC'),
+        size: 1, stargazers_count: 1, forks: 1, default_branch: 'master'
+      }
+    )
+    stub_github('https://api.github.com/repos/foo/foo/releases?per_page=100', body: [])
+    stub_github(
+      'https://api.github.com/repos/foo/foo/git/trees/master?recursive=true',
+      body: { sha: 'abc', tree: [], truncated: false }
+    )
+    stub_github(
+      'https://api.github.com/repos/foo/foo/contributors?per_page=100',
+      body: { message: 'Not Found', documentation_url: 'https://docs.github.com/rest' }
+    )
+    stub_github(
+      'https://api.github.com/search/commits?per_page=100&q=repo:foo/foo%20author-date:%3E2024-08-30',
+      body: { total_count: 0, incomplete_results: false, items: [] }
+    )
+    fb = Factbase.new
+    Fbe.stub(:github_graph, Fbe::Graph::Fake.new) do
+      Time.stub(:now, Time.parse('2024-09-29 21:00:00 UTC')) do
+        load_it('dimensions-of-terrain', fb)
+        f = fb.query("(eq what 'dimensions-of-terrain')").each.first
+        assert_equal(0, f.total_contributors)
+      end
+    end
+  end
+
   def test_total_releases
     WebMock.disable_net_connect!
     stub_request(:get, 'https://api.github.com/rate_limit').to_return(


### PR DESCRIPTION
`#1347` reports that `Fbe.octo.releases`, `contributors`, and `issue_timeline` can return a single `Sawyer::Resource` instead of `Array<Resource>` when GitHub answers with an object-shaped body. Iterating that resource delegates to `Hash#each`, yields `[key, value]` arrays, and either silently produces the rogue hash-key count (`total_releases` returned 2 instead of the real release count, per the issue body) or crashes with `TypeError: no implicit conversion of Symbol into Integer` at `sawyer/resource.rb:128`. This was the original `#1161` crash mode and still survives in four of the five sites the reporter listed (the fifth, `lib/in_window_releases.rb`, no longer exists in `master`).

Each of `judges/dimensions-of-terrain/total_releases.rb`, `judges/dimensions-of-terrain/total_contributors.rb`, `judges/type-was-attached/type-was-attached.rb`, and the `self.allcontributors` helper in `judges/github-events/github-events.rb` now coerces the response with an `is_a?(Array)` check before iterating; a non-Array response is treated as empty (the same fallback `allcontributors` already used on its `rescue` branches). Two regression tests in `test/judges/test-dimensions-of-terrain.rb` exercise the guard by stubbing `releases?per_page=100` and `contributors?per_page=100` with a hash body and asserting the dimension judge writes `0` for the affected metric without raising.

Verified locally with `bundle exec rubocop` on the five touched files (clean), `bundle exec ruby -Ilib -Itest test/judges/test-dimensions-of-terrain.rb` (12 tests, 31 assertions, 0 failures), `bundle exec ruby -Ilib -Itest test/judges/test-type-was-attached.rb` (3 tests, 8 assertions, 0 failures), and `bundle exec ruby -Ilib -Itest test/judges/test-github-events.rb` (47 tests, 148 assertions, 0 failures, 1 skip).

Closes #1347