### PR TITLE
#1458: check Search API quota before QoS search

### DIFF
--- a/lib/qos_search.rb
+++ b/lib/qos_search.rb
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: MIT
 
 require 'fbe/octo'
+require 'json'
 require 'octokit'
 require_relative 'jp'
 
@@ -13,13 +14,22 @@ end
 
 def Jp.qosearch(query, **options)
   return if @offquota || Fbe.octo.off_quota?
-  found = Fbe.octo.search_issues(query, options)
-  left = Fbe.octo.rate_limit.remaining
+  octo = Fbe.octo
+  left = nil
+  begin
+    json = octo.get('/rate_limit')
+    json = JSON.parse(json, symbolize_names: true) if json.is_a?(String)
+    left = json.dig(:resources, :search, :remaining)
+  rescue NoMethodError => e
+    raise unless e.name == :get
+  end
+  left ||= octo.rate_limit.remaining
   if left.zero?
     @offquota = true
     $loog.info('Too much GitHub Search API quota consumed already (0 left)')
+    return
   end
-  found
+  Fbe.octo.search_issues(query, options)
 rescue Octokit::TooManyRequests => e
   @offquota = true
   $loog.warn("[#{$judge}] GitHub Search API quota exhausted, stopping QoS search calls: #{e.message}")

--- a/test/judges/test-quality-of-service.rb
+++ b/test/judges/test-quality-of-service.rb
@@ -2307,7 +2307,10 @@ class TestQualityOfService < Jp::Test
 
   def test_quality_of_service_stops_backlog_searches_after_search_quota_is_consumed
     WebMock.disable_net_connect!
-    rate_limit_up
+    stub_request(:get, 'https://api.github.com/rate_limit').to_return(
+      body: { resources: { search: { remaining: 0, limit: 30 } }, rate: { remaining: 1000, limit: 1000 } }.to_json,
+      headers: { 'Content-Type': 'application/json', 'X-RateLimit-Remaining' => '999' }
+    )
     $global = {}
     $local = {}
     $judge = 'quality-of-service'
@@ -2319,11 +2322,6 @@ class TestQualityOfService < Jp::Test
     url =
       'https://api.github.com/search/issues?advanced_search=true&per_page=100&' \
       'q=repo:foo/foo%20type:issue%20created:*..2025-08-22%20(closed:%3E=2025-08-22%20OR%20state:open)'
-    stub_github(
-      url,
-      body: { total_count: 0, items: [] },
-      headers: { 'Content-Type': 'application/json', 'X-RateLimit-Remaining' => '0' }
-    )
     load(File.join(__dir__, '../../judges/quality-of-service/some_backlog_size.rb'))
     Jp.qoreset
     fb = Factbase.new
@@ -2333,7 +2331,7 @@ class TestQualityOfService < Jp::Test
       f.when = Time.parse('2025-08-28 21:00:00 UTC')
       assert_equal({}, some_backlog_size(f))
     end
-    assert_requested(:get, url, times: 1)
+    assert_not_requested(:get, url)
   end
 
   def test_quality_of_service_fix_gap

--- a/test/test__helper.rb
+++ b/test/test__helper.rb
@@ -38,8 +38,8 @@ require_relative 'smart_factbase'
 class Jp::Test < Minitest::Test
   def rate_limit_up
     stub_request(:get, 'https://api.github.com/rate_limit').to_return(
-      body: { rate: { remaining: 1000, limit: 1000 } }.to_json,
-      headers: { 'X-RateLimit-Remaining' => '999' }
+      body: { resources: { search: { remaining: 30, limit: 30 } }, rate: { remaining: 1000, limit: 1000 } }.to_json,
+      headers: { 'Content-Type': 'application/json', 'X-RateLimit-Remaining' => '999' }
     )
   end
 


### PR DESCRIPTION
/claim #1458

`Jp.qosearch` now reads `/rate_limit.resources.search.remaining` before spending a search request, while keeping the existing `rate_limit` fallback for the mocked Fbe client used by judge fixtures. The shared rate-limit stub now includes the Search API bucket, and the regression asserts the backlog search is not requested when the search bucket is already empty.

Validated locally with:
- `bundle check`
- `bundle exec ruby -Itest test/judges/test-quality-of-service.rb -n test_quality_of_service_stops_backlog_searches_after_search_quota_is_consumed -- --no-cov`
- `bundle exec ruby -Itest test/judges/test-quality-of-service.rb -- --no-cov`
- `bundle exec rake test`
- `bundle exec rake rubocop`
- `bundle exec rake judges`
- `git diff --check origin/master..HEAD`
- `gitleaks detect --no-banner --redact --source . --log-opts origin/master..HEAD`