### PR TITLE
#1461: Move SPDX headers before requires

### DIFF
--- a/judges/add-review-comments/add-review-comments.rb
+++ b/judges/add-review-comments/add-review-comments.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-require 'fbe/consider'
-require 'fbe/octo'
 # SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
 # SPDX-License-Identifier: MIT
 
+require 'fbe/consider'
+require 'fbe/octo'
 require 'octokit'
 require_relative '../../lib/issue_was_lost'
 

--- a/judges/code-was-reviewed/code-was-reviewed.rb
+++ b/judges/code-was-reviewed/code-was-reviewed.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-require 'fbe/consider'
-require 'fbe/issue'
 # SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
 # SPDX-License-Identifier: MIT
 
+require 'fbe/consider'
+require 'fbe/issue'
 require 'fbe/octo'
 require 'fbe/who'
 require 'octokit'

--- a/judges/dimensions-of-terrain/dimensions-of-terrain.rb
+++ b/judges/dimensions-of-terrain/dimensions-of-terrain.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-require 'fbe/fb'
-require 'fbe/octo'
 # SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
 # SPDX-License-Identifier: MIT
 
+require 'fbe/fb'
+require 'fbe/octo'
 require 'time'
 require_relative '../../lib/incremate'
 

--- a/judges/dimensions-of-terrain/total_commits.rb
+++ b/judges/dimensions-of-terrain/total_commits.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-require 'fbe/github_graph'
 # SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
 # SPDX-License-Identifier: MIT
 
+require 'fbe/github_graph'
 require 'fbe/octo'
 require 'fbe/unmask_repos'
 

--- a/judges/fix-missing-branch/fix-missing-branch.rb
+++ b/judges/fix-missing-branch/fix-missing-branch.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+# SPDX-License-Identifier: MIT
+
 require 'fbe/consider'
 require 'fbe/issue'
 require 'fbe/octo'
 require 'fbe/who'
-# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
-# SPDX-License-Identifier: MIT
-
 require 'octokit'
 require_relative '../../lib/issue_was_lost'
 

--- a/judges/fix-missing-comments/fix-missing-comments.rb
+++ b/judges/fix-missing-comments/fix-missing-comments.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+# SPDX-License-Identifier: MIT
+
 require 'fbe/consider'
 require 'fbe/issue'
 require 'fbe/octo'
 require 'fbe/who'
-# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
-# SPDX-License-Identifier: MIT
-
 require 'octokit'
 require_relative '../../lib/fill_fact'
 require_relative '../../lib/issue_was_lost'

--- a/judges/fix-missing-hoc/fix-missing-hoc.rb
+++ b/judges/fix-missing-hoc/fix-missing-hoc.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+# SPDX-License-Identifier: MIT
+
 require 'fbe/consider'
 require 'fbe/issue'
 require 'fbe/octo'
 require 'fbe/who'
-# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
-# SPDX-License-Identifier: MIT
-
 require 'octokit'
 require_relative '../../lib/issue_was_lost'
 

--- a/judges/fix-missing-who/fix-missing-who.rb
+++ b/judges/fix-missing-who/fix-missing-who.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+# SPDX-License-Identifier: MIT
+
 require 'fbe/consider'
 require 'fbe/issue'
 require 'fbe/octo'
 require 'fbe/who'
-# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
-# SPDX-License-Identifier: MIT
-
 require 'octokit'
 require_relative '../../lib/issue_was_lost'
 

--- a/judges/github-events/github-events.rb
+++ b/judges/github-events/github-events.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+# SPDX-License-Identifier: MIT
+
 require 'fbe/github_graph'
 require 'fbe/if_absent'
 require 'fbe/issue'
@@ -7,9 +10,6 @@ require 'fbe/iterate'
 require 'fbe/octo'
 require 'fbe/tombstone'
 require 'fbe/who'
-# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
-# SPDX-License-Identifier: MIT
-
 require 'tago'
 require_relative '../../lib/fill_fact'
 require_relative '../../lib/pull_request'

--- a/judges/is-human-or-robot/is-human-or-robot.rb
+++ b/judges/is-human-or-robot/is-human-or-robot.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-require 'fbe/consider'
 # SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
 # SPDX-License-Identifier: MIT
 
+require 'fbe/consider'
 require 'fbe/issue'
 require 'fbe/octo'
 

--- a/judges/issue-was-opened/issue-was-opened.rb
+++ b/judges/issue-was-opened/issue-was-opened.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-require 'fbe/conclude'
-require 'fbe/issue'
 # SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
 # SPDX-License-Identifier: MIT
 
+require 'fbe/conclude'
+require 'fbe/issue'
 require 'fbe/octo'
 require 'fbe/tombstone'
 require 'fbe/who'

--- a/judges/label-was-attached/label-was-attached.rb
+++ b/judges/label-was-attached/label-was-attached.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
-require 'fbe/if_absent'
-require 'fbe/issue'
-require 'fbe/iterate'
 # SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
 # SPDX-License-Identifier: MIT
 
+require 'fbe/if_absent'
+require 'fbe/issue'
+require 'fbe/iterate'
 require 'fbe/octo'
 require_relative '../../lib/issue_was_lost'
 

--- a/judges/pull-was-opened/pull-was-opened.rb
+++ b/judges/pull-was-opened/pull-was-opened.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-require 'fbe/conclude'
-require 'fbe/issue'
 # SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
 # SPDX-License-Identifier: MIT
 
+require 'fbe/conclude'
+require 'fbe/issue'
 require 'fbe/octo'
 require 'fbe/who'
 require 'octokit'

--- a/judges/type-was-attached/type-was-attached.rb
+++ b/judges/type-was-attached/type-was-attached.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
-require 'fbe/if_absent'
-require 'fbe/issue'
-require 'fbe/iterate'
 # SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
 # SPDX-License-Identifier: MIT
 
+require 'fbe/if_absent'
+require 'fbe/issue'
+require 'fbe/iterate'
 require 'fbe/octo'
 require 'joined'
 require_relative '../../lib/issue_was_lost'

--- a/lib/pull_request.rb
+++ b/lib/pull_request.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-require 'fbe/github_graph'
 # SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
 # SPDX-License-Identifier: MIT
 
+require 'fbe/github_graph'
 require 'fbe/octo'
 require_relative 'jp'
 


### PR DESCRIPTION
/claim #1461

Moves the leading require statements in the 15 issue-listed files below the SPDX header so they match the established layout used by the rest of the Ruby files. No behavior changes are intended.

Validation:
- bundle check
- ruby -c on all 15 touched Ruby files
- bundle exec rake test: 236 tests, 634 assertions, 0 failures, 0 errors, 1 skip
- bundle exec rake judges: all 28 judges and 59 judge tests passed
- bundle exec rake rubocop: 100 files inspected, no offenses
- focused invariant check: SPDX headers precede the first require in all 15 touched files
- git diff --check master...HEAD
- git diff --no-ext-diff master...HEAD | gitleaks stdin --no-banner --redact --exit-code 1: no leaks found