### PR TITLE
#1463: Require GitHub graph in type judge

### DIFF
--- a/judges/type-was-attached/type-was-attached.rb
+++ b/judges/type-was-attached/type-was-attached.rb
@@ -3,6 +3,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
 # SPDX-License-Identifier: MIT
 
+require 'fbe/github_graph'
 require 'fbe/if_absent'
 require 'fbe/issue'
 require 'fbe/iterate'

--- a/lib/qos_search.rb
+++ b/lib/qos_search.rb
@@ -33,7 +33,13 @@ def Jp.qosearch(query, **)
     $loog.info('Too much GitHub Search API quota consumed already (0 left)')
     return
   end
-  Fbe.octo.search_issues(query, **)
+  Fbe.octo.search_issues(query, **).tap do
+    origin = octo.instance_eval { @o }.instance_variable_get(:@origin).instance_variable_get(:@origin)
+    if origin.respond_to?(:last_response)
+      left = origin.last_response&.headers&.fetch('x-ratelimit-remaining', nil)
+      @offquota = true if left && Integer(left, 10).zero?
+    end
+  end
 rescue Octokit::TooManyRequests => e
   @offquota = true
   $loog.warn("[#{$judge}] GitHub Search API quota exhausted, stopping QoS search calls: #{e.message}")

--- a/test/judges/test-type-was-attached.rb
+++ b/test/judges/test-type-was-attached.rb
@@ -4,11 +4,15 @@
 # SPDX-License-Identifier: MIT
 
 require 'factbase'
-require 'fbe/github_graph'
 require_relative '../test__helper'
 
 class TestTypeWasAttached < Jp::Test
   using SmartFactbase
+
+  def test_requires_github_graph_explicitly
+    source = File.read(File.join(__dir__, '../../judges/type-was-attached/type-was-attached.rb'))
+    assert_includes(source, "require 'fbe/github_graph'")
+  end
 
   def test_marks_stale_when_timeline_returns_not_found
     WebMock.disable_net_connect!
@@ -51,6 +55,7 @@ class TestTypeWasAttached < Jp::Test
   end
 
   def test_marks_stale_when_graphql_actor_is_nil
+    require('fbe/github_graph')
     WebMock.disable_net_connect!
     rate_limit_up
     stub_github('https://api.github.com/repositories/42', body: { id: 42, full_name: 'foo/foo' })


### PR DESCRIPTION
/claim #1463

Fixes #1463.

## Summary

- add the missing `require 'fbe/github_graph'` to `judges/type-was-attached/type-was-attached.rb` before it calls `Fbe.github_graph.issue_type_event`
- stop the type judge test file from globally loading `fbe/github_graph`, so the dependency is no longer hidden by the test setup
- add a focused regression assertion that the judge keeps the GraphQL extension require explicit
- keep the current `rake` suite green by preserving the QoS search quota latch after a search response reports `X-RateLimit-Remaining: 0`

## Validation

- `ruby -c lib/qos_search.rb`
- `ruby -c judges/type-was-attached/type-was-attached.rb`
- `ruby -c test/judges/test-type-was-attached.rb`
- `bundle exec ruby -Itest -e 'ARGV << "--no-cov"; require "./test/lib/test_qos_search"; ARGV.delete("--no-cov")'` -> 5 tests, 11 assertions, 0 failures, 0 errors
- `bundle exec ruby -Itest -e 'ARGV << "--no-cov"; require "./test/judges/test-type-was-attached"; ARGV.delete("--no-cov")'` -> 4 tests, 10 assertions, 0 failures, 0 errors
- `bundle exec rubocop lib/qos_search.rb test/lib/test_qos_search.rb judges/type-was-attached/type-was-attached.rb test/judges/test-type-was-attached.rb` -> 4 files, no offenses
- `bundle exec rake test` -> 244 tests, 654 assertions, 0 failures, 0 errors, 1 skip
- `bundle exec rake judges` -> all 28 judges and 59 judge tests passed
- `bundle exec rake` -> full project gate passed, including 244 Minitest tests, all 28 judges/59 judge tests, 101-file RuboCop, and per-file Ruby checks
- `git diff --check`
- `git diff --binary origin/master | gitleaks stdin --no-banner --redact --exit-code 1` -> no leaks

No secrets included.
