### PR TITLE
#151: default qos_pause_seconds to 5

### DIFF
--- a/judges/quality-of-service/quality-of-service.rb
+++ b/judges/quality-of-service/quality-of-service.rb
@@ -11,7 +11,7 @@ require_relative '../../lib/incremate'
 require_relative '../../lib/qos_search'
 
 days = Fbe.pmp.quality.qos_days
-pause = Fbe.pmp.quality.qos_pause_seconds.value || 0
+pause = Fbe.pmp.quality.qos_pause_seconds.value || 5
 Jp.qoreset
 Jp.cover_qo(days)
 Fbe.consider("(and (eq what '#{$judge}') (exists since) (exists when))") do |f|

--- a/test/judges/test-quality-of-service.rb
+++ b/test/judges/test-quality-of-service.rb
@@ -359,6 +359,7 @@ class TestQualityOfService < Jp::Test
     f.area = 'quality'
     f.qos_days = 7
     f.qos_interval = 3
+    f.qos_pause_seconds = 0
     Time.stub(:now, Time.parse('2024-08-09 21:00:00 UTC')) do
       load_it('quality-of-service', fb)
       f = fb.query('(eq what "quality-of-service")').each.first
@@ -469,6 +470,7 @@ class TestQualityOfService < Jp::Test
     f.area = 'quality'
     f.qos_days = 7
     f.qos_interval = 3
+    f.qos_pause_seconds = 0
     Time.stub(:now, Time.parse('2024-08-09 21:00:00 UTC')) do
       load_it('quality-of-service', fb)
       f = fb.query('(eq what "quality-of-service")').each.first
@@ -622,6 +624,7 @@ class TestQualityOfService < Jp::Test
     f.area = 'quality'
     f.qos_days = 7
     f.qos_interval = 3
+    f.qos_pause_seconds = 0
     Time.stub(:now, Time.parse('2024-08-09 21:00:00 UTC')) do
       load_it('quality-of-service', fb)
       f = fb.query('(eq what "quality-of-service")').each.first
@@ -714,6 +717,7 @@ class TestQualityOfService < Jp::Test
     f.area = 'quality'
     f.qos_days = 7
     f.qos_interval = 3
+    f.qos_pause_seconds = 0
     Time.stub(:now, Time.parse('2024-08-09 21:00:00 UTC')) do
       load_it('quality-of-service', fb)
       f = fb.query('(eq what "quality-of-service")').each.first
@@ -879,6 +883,7 @@ class TestQualityOfService < Jp::Test
     f.area = 'quality'
     f.qos_days = 7
     f.qos_interval = 3
+    f.qos_pause_seconds = 0
     Time.stub(:now, Time.parse('2024-08-09 21:00:00 UTC')) do
       load_it('quality-of-service', fb)
       f = fb.query('(eq what "quality-of-service")').each.first
@@ -1212,6 +1217,7 @@ class TestQualityOfService < Jp::Test
     f.area = 'quality'
     f.qos_days = 7
     f.qos_interval = 3
+    f.qos_pause_seconds = 0
     Time.stub(:now, Time.parse('2024-08-09 21:00:00 UTC')) do
       load_it('quality-of-service', fb)
       f = fb.query('(eq what "quality-of-service")').each.first
@@ -1339,6 +1345,7 @@ class TestQualityOfService < Jp::Test
     f.area = 'quality'
     f.qos_days = 7
     f.qos_interval = 3
+    f.qos_pause_seconds = 0
     Time.stub(:now, Time.parse('2024-08-09 21:00:00 UTC')) do
       load_it('quality-of-service', fb)
       f = fb.query('(eq what "quality-of-service")').each.first
@@ -1454,6 +1461,7 @@ class TestQualityOfService < Jp::Test
       f.area = 'quality'
       f.qos_days = 7
       f.qos_interval = 3
+      f.qos_pause_seconds = 0
       f.qos_min_triage_seconds = 60
     end
     insert_label_was_attached_fact(
@@ -1562,6 +1570,7 @@ class TestQualityOfService < Jp::Test
       f.area = 'quality'
       f.qos_days = 7
       f.qos_interval = 3
+      f.qos_pause_seconds = 0
       f.qos_min_triage_seconds = 60
     end
     insert_label_was_attached_fact(
@@ -1648,6 +1657,7 @@ class TestQualityOfService < Jp::Test
       f.area = 'quality'
       f.qos_days = 7
       f.qos_interval = 3
+      f.qos_pause_seconds = 0
       f.qos_min_triage_seconds = 7_200
     end
     insert_label_was_attached_fact(
@@ -1741,6 +1751,7 @@ class TestQualityOfService < Jp::Test
       f.area = 'quality'
       f.qos_days = 7
       f.qos_interval = 3
+      f.qos_pause_seconds = 0
     end
     insert_label_was_attached_fact(
       fb, where: 'github', repository: 42, issue: 60, when: Time.parse('2024-08-04 12:00:59 UTC'), label: 'bug'
@@ -1836,6 +1847,7 @@ class TestQualityOfService < Jp::Test
       f.area = 'quality'
       f.qos_days = 7
       f.qos_interval = 3
+      f.qos_pause_seconds = 0
       f.qos_min_triage_seconds = 60
     end
     insert_label_was_attached_fact(
@@ -1938,6 +1950,7 @@ class TestQualityOfService < Jp::Test
       f.area = 'quality'
       f.qos_days = 7
       f.qos_interval = 3
+      f.qos_pause_seconds = 0
     end
     fb.insert.then do |f|
       f._id = 1
@@ -2099,6 +2112,7 @@ class TestQualityOfService < Jp::Test
       f.area = 'quality'
       f.qos_days = 7
       f.qos_interval = 3
+      f.qos_pause_seconds = 0
     end
     fb.insert.then do |f|
       f._id = 1
@@ -2202,6 +2216,7 @@ class TestQualityOfService < Jp::Test
       f.what = 'pmp'
       f.area = 'quality'
       f.qos_interval = 3
+      f.qos_pause_seconds = 0
     end
     fb.insert.then do |f|
       f._id = 1
@@ -2340,6 +2355,7 @@ class TestQualityOfService < Jp::Test
       f.area = 'quality'
       f.qos_days = 7
       f.qos_interval = 3
+      f.qos_pause_seconds = 0
     end
     Time.stub(:now, Time.parse('2025-08-28 21:00:00 UTC')) do
       load_it('quality-of-service', fb)


### PR DESCRIPTION
The quality-of-service judge already has the machinery to pause between successive sub-judge evaluations through the qos_pause_seconds PMP property, but it falls back to zero when nothing sets it. The default zero meant production runs fired every metric back-to-back and routinely tripped GitHub's API rate limit, which is what issue #151 was reporting in 2024.

Default the fallback to five seconds so the existing pacing kicks in for real runs without anyone needing to configure a PMP fact. Five seconds matches the lower bound suggested in the issue. The pause only applies between metric evaluations inside a single quality-of-service iteration, so the existing live runs gain about a minute of breathing room across a normal cycle while leaving everything else untouched. To keep the unit suite fast the affected tests now seed qos_pause_seconds=0 alongside qos_days and qos_interval.

Verified locally with bundle exec ruby -Itest test/judges/test-quality-of-service.rb -- --no-cov (20 tests, 0 failures, runs in about 175s), rake judges (28 judges and 59 tests pass) and rake rubocop (101 files, no offenses). Two pre-existing errors in test/lib/test_qos_search.rb reproduce on master without these changes.

Closes #151