### PR TITLE
#1472: capture test/entry exit codes in errexit-safe subshell

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,12 +15,10 @@ rubocop:
 
 test: target/docker-image.txt
 	img=$$(cat target/docker-image.txt)
-	docker run --rm --entrypoint '/bin/bash' "$${img}" -c 'bundle exec judges test --disable live --lib /action/lib /action/judges'
-	echo "$$?" > target/test.exit
+	( set +e; docker run --rm --entrypoint '/bin/bash' "$${img}" -c 'bundle exec judges test --disable live --lib /action/lib /action/judges'; echo "$$?" > target/test.exit )
 
 entry: target/docker-image.txt
-	./test-action.sh "$$(cat $<)"
-	echo "$$?" > target/entry.exit
+	( set +e; ./test-action.sh "$$(cat $<)"; echo "$$?" > target/entry.exit )
 
 rmi: target/docker-image.txt
 	img=$$(cat $<)


### PR DESCRIPTION
The `test` and `entry` recipes in the `Makefile` are written under `.ONESHELL` with `.SHELLFLAGS := -e -o pipefail -c`, so each recipe runs as a single bash script with `errexit`. Their captured-exit pattern is `<command>` followed by `echo "$?" > target/<name>.exit`, but `errexit` aborts the recipe shell on the failing command before the `echo` line runs, leaving the `.exit` files missing or stale. The `verify` recipe and the `all` target then never get to judge the build at the end. See `#1472` for the full walkthrough.

After this change, the captured command runs inside `( set +e; ...; echo "$?" > target/<name>.exit )` so the subshell records the real exit code regardless of success or failure, the outer recipe stays on `errexit`, and the `all` target reaches `rmi` and `verify` as intended. Running `make all` against a deliberately failing `test` step now produces a non-empty `target/test.exit` and lets `verify` report a non-zero status, instead of `make` exiting on the failing recipe with no captured status.

Locally I parsed the Makefile with `make -n test`, `make -n entry`, `make -n verify`, and `make -n all` to confirm the recipes still expand correctly. I also ran a minimal reproducer outside the project (a recipe with the same `.ONESHELL`, `-e`, and `pipefail` flags running `bash -c 'exit 7'`): before the change the recipe aborted and no `.exit` file was written; after the change `target/test.exit` contained `7` and the recipe completed.

Closes #1472
