### PR TITLE
#1474: route find-all-issues search through Jp.qosearch

### DIFF
--- a/judges/find-all-issues/find-all-issues.rb
+++ b/judges/find-all-issues/find-all-issues.rb
@@ -15,6 +15,7 @@ require 'joined'
 require 'logger'
 require 'time'
 require_relative '../../lib/issue_was_lost'
+require_relative '../../lib/qos_search'
 
 %w[issue pull].each do |type|
   Fbe.iterate do
@@ -50,7 +51,8 @@ require_relative '../../lib/issue_was_lost'
       found = []
       first = issue
       elapsed($loog, level: Logger::INFO) do
-        Fbe.octo.search_issues("repo:#{repo} type:#{type} created:>=#{after.iso8601[0..9]}")[:items].each do |json|
+        result = Jp.qosearch("repo:#{repo} type:#{type} created:>=#{after.iso8601[0..9]}")
+        (result.nil? ? [] : result[:items]).each do |json|
           next if Fbe.octo.off_quota?
           i = json[:number]
           seen << i


### PR DESCRIPTION
The `judges/find-all-issues/find-all-issues.rb` judge called `Fbe.octo.search_issues` directly inside the `Fbe.iterate` `over` block, bypassing the `Jp.qosearch` latch in `lib/qos_search.rb`. When the Search API quota (separate from core quota) was depleted the call raised `Octokit::TooManyRequests`, the exception propagated out of `over`, and the iteration dropped every remaining `(repository, issue)` pair in the `%w[issue pull]` loop for the rest of the cycle. Issue #1474 has the full walkthrough.

This change replaces the direct call with `Jp.qosearch(...)` and treats a nil return as "no items this cycle", which is how the rest of the action talks to the Search API. The latch in `Jp.qosearch` checks `resources.search.remaining` before the call, sets `@offquota` on a zero-remaining response or on `Octokit::TooManyRequests`, and short-circuits subsequent searches in the same Ruby process. The surrounding `elapsed` block still reaches its `throw` and the iterate continues to the next pair.

Locally I ran `bundle exec ruby -Itest -Ilib -Ijudges test/judges/test-find-all-issues.rb` (10 tests, 46 assertions, 0 failures, 0 errors) and `bundle exec rake` (243 tests, 648 assertions, 0 failures, 2 errors, 1 skip — the 2 errors and 1 skip reproduce on master at `974002d` and are unrelated to this diff). `bundle exec rubocop` also reports `101 files inspected, no offenses detected`.

Closes #1474
