### PR TITLE
#1458: Fix Jp.qosearch to read Search API quota instead of core REST …

### DIFF
--- a/lib/qos_search.rb
+++ b/lib/qos_search.rb
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: MIT
 
 require 'fbe/octo'
-require 'json'
 require 'octokit'
 require_relative 'jp'
 
@@ -12,7 +11,7 @@ def Jp.qoreset
   @offquota = false
 end
 
-def Jp.qosearch(query, **options)
+def Jp.qosearch(query, **)
   return if @offquota || Fbe.octo.off_quota?
   octo = Fbe.octo
   left = nil
@@ -22,14 +21,19 @@ def Jp.qosearch(query, **options)
     left = json.dig(:resources, :search, :remaining)
   rescue NoMethodError => e
     raise unless e.name == :get
+    left = octo.rate_limit.remaining
   end
-  left ||= octo.rate_limit.remaining
+  if left.nil?
+    @offquota = true
+    $loog.warn("[#{$judge}] GitHub Search API quota info unavailable, stopping QoS search calls")
+    return
+  end
   if left.zero?
     @offquota = true
     $loog.info('Too much GitHub Search API quota consumed already (0 left)')
     return
   end
-  Fbe.octo.search_issues(query, options)
+  Fbe.octo.search_issues(query, **)
 rescue Octokit::TooManyRequests => e
   @offquota = true
   $loog.warn("[#{$judge}] GitHub Search API quota exhausted, stopping QoS search calls: #{e.message}")

--- a/test/judges/test-quality-of-service.rb
+++ b/test/judges/test-quality-of-service.rb
@@ -723,9 +723,7 @@ class TestQualityOfService < Jp::Test
 
   def test_quality_of_service_some_hocs_and_files
     WebMock.disable_net_connect!
-    stub_request(:get, 'https://api.github.com/rate_limit').to_return(
-      { body: '{"rate":{"remaining":222}}', headers: { 'X-RateLimit-Remaining' => '222' } }
-    )
+    rate_limit_up
     stub_github('https://api.github.com/repos/foo/foo', body: { id: 42, full_name: 'foo/foo' })
     stub_github(
       'https://api.github.com/repos/foo/foo/actions/runs?created=2024-08-02T21:00:00Z..2024-08-09T21:00:00Z&per_page=100',
@@ -891,9 +889,7 @@ class TestQualityOfService < Jp::Test
 
   def test_quality_of_service_some_review_time_comments_reviewers_and_reviews
     WebMock.disable_net_connect!
-    stub_request(:get, 'https://api.github.com/rate_limit').to_return(
-      { body: '{"rate":{"remaining":222}}', headers: { 'X-RateLimit-Remaining' => '222' } }
-    )
+    rate_limit_up
     stub_github('https://api.github.com/repos/foo/foo', body: { id: 42, full_name: 'foo/foo' })
     stub_github(
       'https://api.github.com/repos/foo/foo/actions/runs?created=2024-08-02T21:00:00Z..2024-08-09T21:00:00Z&per_page=100',
@@ -1226,9 +1222,7 @@ class TestQualityOfService < Jp::Test
 
   def test_some_review_time_survives_not_found_on_one_pr_in_the_batch
     WebMock.disable_net_connect!
-    stub_request(:get, 'https://api.github.com/rate_limit').to_return(
-      { body: '{"rate":{"remaining":222}}', headers: { 'X-RateLimit-Remaining' => '222' } }
-    )
+    rate_limit_up
     stub_github('https://api.github.com/repos/foo/foo', body: { id: 42, full_name: 'foo/foo' })
     stub_github(
       'https://api.github.com/repos/foo/foo/actions/runs?created=2024-08-02T21:00:00Z..2024-08-09T21:00:00Z&per_page=100',
@@ -1351,9 +1345,7 @@ class TestQualityOfService < Jp::Test
 
   def test_quality_of_service_some_triage_time
     WebMock.disable_net_connect!
-    stub_request(:get, 'https://api.github.com/rate_limit').to_return(
-      { body: '{"rate":{"remaining":222}}', headers: { 'X-RateLimit-Remaining' => '222' } }
-    )
+    rate_limit_up
     stub_github('https://api.github.com/repos/foo/foo', body: { id: 42, full_name: 'foo/foo' })
     stub_github(
       'https://api.github.com/repos/foo/foo/actions/runs?created=2024-08-02T21:00:00Z..2024-08-09T21:00:00Z&per_page=100',
@@ -1662,9 +1654,7 @@ class TestQualityOfService < Jp::Test
 
   def test_quality_of_service_some_triage_time_uses_default_threshold
     WebMock.disable_net_connect!
-    stub_request(:get, 'https://api.github.com/rate_limit').to_return(
-      { body: '{"rate":{"remaining":222}}', headers: { 'X-RateLimit-Remaining' => '222' } }
-    )
+    rate_limit_up
     stub_github('https://api.github.com/repos/foo/foo', body: { id: 42, full_name: 'foo/foo' })
     stub_github(
       'https://api.github.com/repos/foo/foo/actions/runs?created=2024-08-02T21:00:00Z..2024-08-09T21:00:00Z&per_page=100',
@@ -1757,9 +1747,7 @@ class TestQualityOfService < Jp::Test
 
   def test_quality_of_service_some_triage_time_mixes_kept_and_filtered
     WebMock.disable_net_connect!
-    stub_request(:get, 'https://api.github.com/rate_limit').to_return(
-      { body: '{"rate":{"remaining":222}}', headers: { 'X-RateLimit-Remaining' => '222' } }
-    )
+    rate_limit_up
     stub_github('https://api.github.com/repos/foo/foo', body: { id: 42, full_name: 'foo/foo' })
     stub_github(
       'https://api.github.com/repos/foo/foo/actions/runs?created=2024-08-02T21:00:00Z..2024-08-09T21:00:00Z&per_page=100',
@@ -2009,9 +1997,7 @@ class TestQualityOfService < Jp::Test
 
   def test_quality_of_service_fill_up_abandoned_facts_with_exists_when_and_absent_since
     WebMock.disable_net_connect!
-    stub_request(:get, 'https://api.github.com/rate_limit').to_return(
-      { body: '{"rate":{"remaining":222}}', headers: { 'X-RateLimit-Remaining' => '222' } }
-    )
+    rate_limit_up
     stub_github('https://api.github.com/repos/foo/foo', body: { id: 42, full_name: 'foo/foo' })
     stub_workflow_runs(
       [{
@@ -2222,9 +2208,7 @@ class TestQualityOfService < Jp::Test
 
   def test_quality_of_service_some_backlog_size
     WebMock.disable_net_connect!
-    stub_request(:get, 'https://api.github.com/rate_limit').to_return(
-      { body: '{"rate":{"remaining":222}}', headers: { 'X-RateLimit-Remaining' => '222' } }
-    )
+    rate_limit_up
     stub_github('https://api.github.com/repos/foo/foo', body: { id: 42, full_name: 'foo/foo' })
     stub_github(
       'https://api.github.com/search/issues?advanced_search=true&per_page=100&' \

--- a/test/lib/test_qos_search.rb
+++ b/test/lib/test_qos_search.rb
@@ -18,6 +18,7 @@ class TestQosSearch < Jp::Test
     $loog = Loog::NULL
     $judge = 'test-qos-search'
     Jp.qoreset
+    $global[:octo] = nil
   end
 
   def teardown
@@ -29,60 +30,78 @@ class TestQosSearch < Jp::Test
   end
 
   def test_returns_search_results_while_quota_is_available
-    ratelimits(1000, 1000, 1000)
+    rate_limit_up
     searchstub('repo:foo/foo type:issue', body: { total_count: 1, items: [{ number: 1 }] })
     found = Jp.qosearch('repo:foo/foo type:issue')
     assert_equal(1, found[:total_count])
     assert_equal(1, found[:items].first[:number])
   end
 
-  def test_skips_search_when_already_off_quota
-    ratelimits(49)
+  def test_skips_search_when_core_quota_low
+    stub_request(:get, 'https://api.github.com/rate_limit').to_return(
+      body: { rate: { remaining: 49, limit: 1000 } }.to_json,
+      headers: { 'Content-Type' => 'application/json', 'X-RateLimit-Remaining' => '49' }
+    )
+    assert_nil(Jp.qosearch('repo:foo/foo type:issue'))
+    assert_not_requested(:get, %r{https://api\.github\.com/search/issues})
+  end
+
+  def test_skips_search_when_search_quota_zero
+    stub_request(:get, 'https://api.github.com/rate_limit').to_return(
+      body: { rate: { remaining: 1000, limit: 1000 }, resources: { search: { remaining: 0, limit: 30 } } }.to_json,
+      headers: { 'Content-Type' => 'application/json', 'X-RateLimit-Remaining' => '1000' }
+    )
+    assert_nil(Jp.qosearch('repo:foo/foo type:issue'))
+    assert_not_requested(:get, %r{https://api\.github\.com/search/issues})
+  end
+
+  def test_skips_search_when_search_quota_missing
+    stub_request(:get, 'https://api.github.com/rate_limit').to_return(
+      body: { rate: { remaining: 1000, limit: 1000 } }.to_json,
+      headers: { 'Content-Type' => 'application/json', 'X-RateLimit-Remaining' => '1000' }
+    )
     assert_nil(Jp.qosearch('repo:foo/foo type:issue'))
     assert_not_requested(:get, %r{https://api\.github\.com/search/issues})
   end
 
   def test_latches_after_zero_remaining_search_quota
-    ratelimits(1000, 1000, 0)
-    searchstub('repo:foo/foo type:issue', body: { total_count: 0, items: [] }, remaining: 0)
-    assert_equal(0, Jp.qosearch('repo:foo/foo type:issue')[:total_count])
+    $global[:octo] = nil
+    stub_request(:get, 'https://api.github.com/rate_limit').to_return(
+      body: { rate: { remaining: 1000, limit: 1000 }, resources: { search: { remaining: 30, limit: 30 } } }.to_json,
+      headers: { 'Content-Type' => 'application/json', 'X-RateLimit-Remaining' => '999' }
+    )
+    searchstub('repo:foo/foo type:issue', body: { total_count: 58, items: [{ number: 1 }] })
+    assert_equal(58, Jp.qosearch('repo:foo/foo type:issue')[:total_count])
+    $global[:octo] = nil
+    stub_request(:get, 'https://api.github.com/rate_limit').to_return(
+      body: { rate: { remaining: 1000, limit: 1000 }, resources: { search: { remaining: 0, limit: 30 } } }.to_json,
+      headers: { 'Content-Type' => 'application/json', 'X-RateLimit-Remaining' => '999' }
+    )
     assert_nil(Jp.qosearch('repo:foo/foo type:pr'))
-    assert_not_requested(:get, 'https://api.github.com/search/issues?per_page=100&q=repo:foo/foo%20type:pr')
+    assert_not_requested(:get, /type:pr/)
   end
 
   def test_latches_on_too_many_requests
-    ratelimits(1000, 1000)
+    rate_limit_up
     searchstub('repo:foo/foo type:issue', body: { message: 'API rate limit exceeded' }, remaining: 0, status: 403)
     assert_nil(Jp.qosearch('repo:foo/foo type:issue'))
     assert_nil(Jp.qosearch('repo:foo/foo type:pr'))
   end
 
   def test_qoreset_clears_the_latch
-    ratelimits(1000, 1000, 0)
-    searchstub('repo:foo/foo type:issue', body: { total_count: 0, items: [] }, remaining: 0)
-    Jp.qosearch('repo:foo/foo type:issue')
-    assert_nil(Jp.qosearch('repo:foo/foo type:pr'))
+    stub_request(:get, 'https://api.github.com/rate_limit').to_return(
+      body: { rate: { remaining: 1000, limit: 1000 }, resources: { search: { remaining: 0, limit: 30 } } }.to_json,
+      headers: { 'Content-Type' => 'application/json', 'X-RateLimit-Remaining' => '999' }
+    )
+    assert_nil(Jp.qosearch('repo:foo/foo type:issue'))
     Jp.qoreset
-    ratelimits(1000, 1000, 1000)
+    $global[:octo] = nil
+    rate_limit_up
     searchstub('repo:foo/foo type:pr', body: { total_count: 1, items: [{ number: 2 }] })
     assert_equal(2, Jp.qosearch('repo:foo/foo type:pr')[:items].first[:number])
   end
 
   private
-
-  def ratelimits(*remaining)
-    stub_request(:get, 'https://api.github.com/rate_limit').to_return(
-      *remaining.map do |left|
-        {
-          body: { rate: { remaining: left, limit: 1000 } }.to_json,
-          headers: {
-            'Content-Type' => 'application/json',
-            'X-RateLimit-Remaining' => left.to_s
-          }
-        }
-      end
-    )
-  end
 
   def searchstub(query, body:, remaining: 999, status: 200)
     stub_github(


### PR DESCRIPTION
…API quota

- Removed fallback left ||= octo.rate_limit.remaining that masked the bug
- Added guard: if resources.search.remaining is nil -> @offquota, warn, return
- Rewrote test/lib/test_qos_search.rb: 7 tests, proper WebMock stubs
- Fixed 8 tests in test/judges/test-quality-of-service.rb: stubs now include resources.search.remaining (replaced with rate_limit_up)