### PR TITLE
#1478: rescue Octokit errors in Jp.fetch_workflows

### DIFF
--- a/lib/pull_request.rb
+++ b/lib/pull_request.rb
@@ -5,6 +5,7 @@
 
 require 'fbe/github_graph'
 require 'fbe/octo'
+require 'octokit'
 require_relative 'jp'
 
 def Jp.comments_info(pr, repo: nil)
@@ -46,9 +47,34 @@ def Jp.fetch_workflows(pr, repo: nil)
   failed = 0
   repo = pr.dig(:base, :repo, :full_name) if repo.nil?
   return {} if repo.nil?
-  Fbe.octo.check_runs_for_ref(repo, pr.dig(:head, :sha))[:check_runs].each do |run|
+  runs = nil
+  begin
+    runs = Fbe.octo.check_runs_for_ref(repo, pr.dig(:head, :sha))[:check_runs]
+  rescue Octokit::NotFound, Octokit::Deprecated => e
+    $loog.info("Can't list check runs for #{repo}@#{pr.dig(:head, :sha)}: #{e.message}")
+    return { succeeded_builds: 0, failed_builds: 0 }
+  rescue Octokit::Forbidden => e
+    $loog.warn(
+      "[#{$judge}] Access forbidden to check runs in #{repo} " \
+      "(transient, will retry next cycle): #{e.class}: #{e.message}"
+    )
+    return { succeeded_builds: 0, failed_builds: 0 }
+  end
+  runs.each do |run|
     next unless run.dig(:app, :slug) == 'github-actions'
-    workflow = Fbe.octo.workflow_run(repo, Fbe.octo.workflow_run_job(repo, run[:id])[:run_id])
+    workflow =
+      begin
+        Fbe.octo.workflow_run(repo, Fbe.octo.workflow_run_job(repo, run[:id])[:run_id])
+      rescue Octokit::NotFound, Octokit::Deprecated => e
+        $loog.info("Workflow run for job ##{run[:id]} not available in #{repo}: #{e.message}")
+        next
+      rescue Octokit::Forbidden => e
+        $loog.warn(
+          "[#{$judge}] Access forbidden to workflow run for job ##{run[:id]} in #{repo} " \
+          "(transient, will retry next cycle): #{e.class}: #{e.message}"
+        )
+        next
+      end
     next unless workflow[:event] == 'pull_request'
     case workflow[:conclusion]
     when 'success'

--- a/test/lib/test_pull_request.rb
+++ b/test/lib/test_pull_request.rb
@@ -53,6 +53,85 @@ class TestPullRequest < Jp::Test
     assert_equal({ succeeded_builds: 1, failed_builds: 0 }, result)
   end
 
+  def test_fetch_workflows_rescues_not_found_on_check_runs
+    WebMock.disable_net_connect!
+    rate_limit_up
+    $options = Judges::Options.new({})
+    $global = {}
+    $loog = Loog::NULL
+    $judge = 'test-pull-request'
+    pr = { number: 66, head: { sha: 'cc789' }, base: { repo: { full_name: 'foo/foo' } } }
+    stub_request(:get, 'https://api.github.com/repos/foo/foo/commits/cc789/check-runs?per_page=100')
+      .to_return(status: 404, body: { message: 'Not Found' }.to_json, headers: { 'Content-Type' => 'application/json' })
+    result = Jp.fetch_workflows(pr)
+    assert_equal({ succeeded_builds: 0, failed_builds: 0 }, result)
+  end
+
+  def test_fetch_workflows_rescues_forbidden_on_check_runs
+    WebMock.disable_net_connect!
+    rate_limit_up
+    $options = Judges::Options.new({})
+    $global = {}
+    $loog = Loog::NULL
+    $judge = 'test-pull-request'
+    pr = { number: 77, head: { sha: 'dd012' }, base: { repo: { full_name: 'foo/foo' } } }
+    stub_request(:get, 'https://api.github.com/repos/foo/foo/commits/dd012/check-runs?per_page=100')
+      .to_return(status: 403, body: { message: 'Forbidden' }.to_json, headers: { 'Content-Type' => 'application/json' })
+    result = Jp.fetch_workflows(pr)
+    assert_equal({ succeeded_builds: 0, failed_builds: 0 }, result)
+  end
+
+  def test_fetch_workflows_skips_run_when_workflow_run_job_not_found
+    WebMock.disable_net_connect!
+    rate_limit_up
+    $options = Judges::Options.new({})
+    $global = {}
+    $loog = Loog::NULL
+    $judge = 'test-pull-request'
+    pr = { number: 88, head: { sha: 'ee345' }, base: { repo: { full_name: 'foo/foo' } } }
+    stub_github(
+      'https://api.github.com/repos/foo/foo/commits/ee345/check-runs?per_page=100',
+      body: {
+        check_runs: [
+          { id: 10, app: { slug: 'github-actions' } },
+          { id: 20, app: { slug: 'github-actions' } }
+        ]
+      }
+    )
+    stub_request(:get, 'https://api.github.com/repos/foo/foo/actions/jobs/10')
+      .to_return(status: 404, body: { message: 'Not Found' }.to_json, headers: { 'Content-Type' => 'application/json' })
+    stub_github('https://api.github.com/repos/foo/foo/actions/jobs/20', body: { id: 20, run_id: 7777 })
+    stub_github(
+      'https://api.github.com/repos/foo/foo/actions/runs/7777',
+      body: { id: 7777, event: 'pull_request', conclusion: 'failure' }
+    )
+    result = Jp.fetch_workflows(pr)
+    assert_equal({ succeeded_builds: 0, failed_builds: 1 }, result)
+  end
+
+  def test_fetch_workflows_skips_run_when_workflow_run_forbidden
+    WebMock.disable_net_connect!
+    rate_limit_up
+    $options = Judges::Options.new({})
+    $global = {}
+    $loog = Loog::NULL
+    $judge = 'test-pull-request'
+    pr = { number: 99, head: { sha: 'ff678' }, base: { repo: { full_name: 'foo/foo' } } }
+    stub_github(
+      'https://api.github.com/repos/foo/foo/commits/ff678/check-runs?per_page=100',
+      body: {
+        check_runs: [
+          { id: 30, app: { slug: 'github-actions' } }
+        ]
+      }
+    )
+    stub_github('https://api.github.com/repos/foo/foo/actions/jobs/30', body: { id: 30, run_id: 5555 })
+    stub_request(:get, 'https://api.github.com/repos/foo/foo/actions/runs/5555')
+      .to_return(status: 403, body: { message: 'Forbidden' }.to_json, headers: { 'Content-Type' => 'application/json' })
+    result = Jp.fetch_workflows(pr)
+    assert_equal({ succeeded_builds: 0, failed_builds: 0 }, result)
+  end
+
   def test_counts_reactions_when_reaction_user_is_nil
     WebMock.disable_net_connect!
     rate_limit_up


### PR DESCRIPTION
Issue #1478 reports that `Jp.fetch_workflows` in `lib/pull_request.rb:44-60` makes three Octokit calls back-to-back with no `begin/rescue`, so any `Octokit::NotFound` on a vanished workflow run, any `Octokit::Deprecated` on a deprecated endpoint, or any transient `Octokit::Forbidden` propagates out of the method, out of `pull-was-merged.rb:113` after the carefully-rescued `pull_request`/`issue`/`pull_request_reviews` block already passed, and out of `github-events.rb:175` mid-event-scan, dropping every remaining `(repository, issue)` pair in the cycle.

This change applies the two-branch rescue shape already used by `judges/pull-was-merged/pull-was-merged.rb:55-99`, `judges/quality-of-service/some_review_time.rb`, `code-was-reviewed.rb`, `erase-repository.rb`, and `fix-missing-comments.rb`. The outer `check_runs_for_ref` call now returns `{ succeeded_builds: 0, failed_builds: 0 }` and logs at info/warn when it raises, so the calling judges continue. The inner `workflow_run_job` + `workflow_run` pair is wrapped in the same shape and uses `next`, so a single missing or transient run contributes zero to the counts and the remaining runs still feed `succeeded` and `failed`.

Local checks on Ruby 3.3.6: `bundle exec ruby -Itest -Ilib -Ijudges test/lib/test_pull_request.rb` reports `8 tests, 8 assertions, 0 failures, 0 errors, 0 skips` (four new cases cover the NotFound/Forbidden branches at the outer call and the NotFound/Forbidden branches inside the per-run loop). `bundle exec rake test` reports `247 tests, 652 assertions, 0 failures, 2 errors, 1 skips`; the two errors and the skip are `TestQosSearch#test_latches_after_zero_remaining_search_quota` and `#test_qoreset_clears_the_latch`, which reproduce on `974002d` (master) and are the subject of open #1458 / PR #1480, unrelated to this diff. `bundle exec rubocop` reports `101 files inspected, no offenses detected`.

Closes #1478
