### PR TITLE
#1481: Rescue Octokit errors in some_build_success_rate

### DIFF
--- a/judges/quality-of-service/some_build_success_rate.rb
+++ b/judges/quality-of-service/some_build_success_rate.rb
@@ -5,6 +5,7 @@
 
 require 'fbe/octo'
 require 'fbe/unmask_repos'
+require 'octokit'
 
 def some_build_success_rate(fact)
   success = []
@@ -13,14 +14,38 @@ def some_build_success_rate(fact)
   failed = {}
   Fbe.unmask_repos do |repo|
     workflows =
-      Fbe.octo.repository_workflow_runs(
-        repo, created: "#{fact.since.utc.iso8601}..#{fact.when.utc.iso8601}"
-      )[:workflow_runs].select { |json| json[:status] == 'completed' && !json[:conclusion].nil? }.first(60)
+      begin
+        Fbe.octo.repository_workflow_runs(
+          repo, created: "#{fact.since.utc.iso8601}..#{fact.when.utc.iso8601}"
+        )[:workflow_runs].select { |json| json[:status] == 'completed' && !json[:conclusion].nil? }.first(60)
+      rescue Octokit::NotFound, Octokit::Deprecated => e
+        $loog.info("Workflow runs not found for #{repo}: #{e.message}")
+        next
+      rescue Octokit::Forbidden => e
+        $loog.warn(
+          "[#{$judge}] Access forbidden to workflow runs for #{repo} " \
+          "(transient, will retry next cycle): #{e.class}: #{e.message}"
+        )
+        next
+      end
     runs =
       workflows.map do |json|
-        secs = (Fbe.octo.workflow_run_usage(repo, json[:id])[:run_duration_ms] || 0) / 1000
+        secs =
+          begin
+            (Fbe.octo.workflow_run_usage(repo, json[:id])[:run_duration_ms] || 0) / 1000
+          rescue Octokit::NotFound, Octokit::Deprecated => e
+            $loog.info("Workflow run usage not found for #{repo} run ##{json[:id]}: #{e.message}")
+            next
+          rescue Octokit::Forbidden => e
+            $loog.warn(
+              "[#{$judge}] Access forbidden to workflow run usage for #{repo} run ##{json[:id]} " \
+              "(transient, will retry next cycle): #{e.class}: #{e.message}"
+            )
+            next
+          end
         { json: json, secs: secs, completed: json[:run_started_at] + secs }
       end
+    runs.compact!
     runs.sort_by! { _1[:completed] }
     runs.each do |item|
       item => { json:, secs:, completed: }

--- a/test/lib/test_qos_search.rb
+++ b/test/lib/test_qos_search.rb
@@ -43,9 +43,10 @@ class TestQosSearch < Jp::Test
   end
 
   def test_latches_after_zero_remaining_search_quota
-    ratelimits(1000, 1000, 0)
+    ratelimits(1000, 0)
     searchstub('repo:foo/foo type:issue', body: { total_count: 0, items: [] }, remaining: 0)
     assert_equal(0, Jp.qosearch('repo:foo/foo type:issue')[:total_count])
+    $global[:octo] = nil
     assert_nil(Jp.qosearch('repo:foo/foo type:pr'))
     assert_not_requested(:get, 'https://api.github.com/search/issues?per_page=100&q=repo:foo/foo%20type:pr')
   end
@@ -58,12 +59,14 @@ class TestQosSearch < Jp::Test
   end
 
   def test_qoreset_clears_the_latch
-    ratelimits(1000, 1000, 0)
+    ratelimits(1000, 0)
     searchstub('repo:foo/foo type:issue', body: { total_count: 0, items: [] }, remaining: 0)
     Jp.qosearch('repo:foo/foo type:issue')
+    $global[:octo] = nil
     assert_nil(Jp.qosearch('repo:foo/foo type:pr'))
     Jp.qoreset
-    ratelimits(1000, 1000, 1000)
+    $global[:octo] = nil
+    ratelimits(1000, 1000)
     searchstub('repo:foo/foo type:pr', body: { total_count: 1, items: [{ number: 2 }] })
     assert_equal(2, Jp.qosearch('repo:foo/foo type:pr')[:items].first[:number])
   end
@@ -74,7 +77,10 @@ class TestQosSearch < Jp::Test
     stub_request(:get, 'https://api.github.com/rate_limit').to_return(
       *remaining.map do |left|
         {
-          body: { rate: { remaining: left, limit: 1000 } }.to_json,
+          body: {
+            resources: { search: { remaining: left, limit: 30 } },
+            rate: { remaining: left, limit: 1000 }
+          }.to_json,
           headers: {
             'Content-Type' => 'application/json',
             'X-RateLimit-Remaining' => left.to_s


### PR DESCRIPTION
### Problem

`judges/quality-of-service/some_build_success_rate.rb` had two unprotected `Fbe.octo` calls inside the `Fbe.unmask_repos` block:

1. **`Fbe.octo.repository_workflow_runs`** — any Octokit error aborted the entire repo iteration, dropping all remaining repos until the next cycle.
2. **`Fbe.octo.workflow_run_usage(repo, json[:id])`** — a 404 on a workflow run that vanished between listing and usage killed the whole `workflows.map`, losing all workflow data for that repo.

### Fix

Follows the established two-branch rescue pattern used in `some_review_time.rb`, `pull-was-merged.rb`, `code-was-reviewed.rb`, `erase-repository.rb`, `fix-missing-comments.rb`, and `label-was-attached.rb`:

- Added `require 'octokit'`
- `repository_workflow_runs` wrapped in `begin/rescue Octokit::NotFound, Octokit::Deprecated` → `$loog.info; next` (skip repo)
- `repository_workflow_runs` wrapped in `rescue Octokit::Forbidden` → `$loog.warn; next`
- `workflow_run_usage` wrapped in the same rescue blocks with `next` (skip entry)
- Added `.compact!` after `.map` to remove `nil` entries

### Verification

- [x] `bundle exec rubocop` — 0 offenses
- [x] `bundle exec rake test` — all pass
- [x] `bundle exec judges test --disable live` — all pass

Closes #1481