### PR TITLE
#1467 drop misfiring version check and action_version metadata

### DIFF
--- a/entry.sh
+++ b/entry.sh
@@ -6,27 +6,7 @@ set -e -o pipefail
 
 start=$(date +%s)
 
-VERSION=0.0.0
-
-echo "The 'judges-action' ${VERSION} is running"
-
-if [ "${SKIP_VERSION_CHECKING}" != 'true' ]; then
-    resp=$(curl --silent -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/zerocracy/judges-action/releases/latest)
-    latest=$(echo -n "$resp" | jq -Rrs "try (fromjson | .tag_name) catch empty")
-    if [ -z "${latest}" ]; then
-        echo "!!! Could not fetch the latest version from GitHub."
-        echo "!!! GitHub returned: "
-        echo "$resp"
-        echo "!!! Disabling version checking for the rest of the script."
-        SKIP_VERSION_CHECKING=true
-    elif [ "${latest}" != "${VERSION}" ]; then
-        echo "!!! The latest version of the judges-action plugin available in"
-        echo "!!! its GitHub repository is ${latest}: https://github.com/zerocracy/judges-action."
-        echo "!!! However, you are using a different version: ${VERSION}."
-        echo "!!! This will most likely lead to runtime issues and maybe even data corruption."
-        echo "!!! It is strongly advised to upgrade."
-    fi
-fi
+echo "The 'judges-action' is running"
 
 # Mask token values in CI logs before enabling bash tracing.
 # Without these workflow commands, "set -x" emits the full command line
@@ -123,7 +103,6 @@ if [ -n "${GITHUB_RUN_ID}" ]; then
     options+=("--option=job_id=${GITHUB_RUN_ID}")
 fi
 
-options+=("--option=action_version=${VERSION}")
 options+=("--option=vitals_url=${VITALS_URL}")
 if [ "$(printenv "INPUT_FAIL-FAST" || echo 'false')" == 'true' ]; then
     options+=("--fail-fast");
@@ -262,17 +241,6 @@ else
     echo "SQLite is not used for HTTP caching because the sqlite-cache option is not set"
 fi
 
-if [ "${SKIP_VERSION_CHECKING}" != 'true' ]; then
-    action_version=$(curl --retry 5 --retry-delay 5 --retry-max-time 40 --connect-timeout 5 -sL https://api.github.com/repos/zerocracy/judges-action/releases/latest | jq -r '.tag_name')
-    if [ "${action_version}" == "${VERSION}" ] || [ "${action_version}" == null ]; then
-        action_version=${VERSION}
-    else
-        action_version="${VERSION}!${action_version}"
-    fi
-else
-    action_version=${VERSION}
-fi
-
 if [ "$(printenv "INPUT_DRY-RUN" || echo 'false')" == 'true' ]; then
     echo "We are in 'dry' mode; skipping 'push'"
 else
@@ -284,7 +252,6 @@ else
         "--meta=churn:$(cat churn.txt)" \
         "--meta=vitals_url:${VITALS_URL}" \
         "--meta=duration:$(($(date +%s) - start))" \
-        "--meta=action_version:${action_version}" \
         "--token=${INPUT_TOKEN}" \
         "${name}" "${fb}"
 fi

--- a/test-action.sh
+++ b/test-action.sh
@@ -22,7 +22,6 @@ if [ -z "${name}" ]; then
 fi
 
 docker run --rm \
-    -e "SKIP_VERSION_CHECKING=true" \
     -e "GITHUB_WORKSPACE=/tmp" \
     -e "GITHUB_REPOSITORY=zerocracy/judges-action" \
     -e "GITHUB_REPOSITORY_OWNER=zerocracy" \


### PR DESCRIPTION
The hard-coded `VERSION=0.0.0` constant in `entry.sh:9` was never rewritten by any build, release, or CI step, so the version-check block at `entry.sh:13-28` always evaluated the upstream tag as different from `VERSION` and printed the four `!!!` upgrade-warning lines on every run, even on the latest image. The same `0.0.0` value also propagated through `--option=action_version=${VERSION}` and the duplicate computation at `entry.sh:265-274` into `--meta=action_version:${action_version}`, contaminating downstream facts with a value that never reflected a real release. Issue #1467 describes the symptom and recommends removing the guard and the `action_version` plumbing together when a release pipeline is out of scope, which is the path taken here.

The version-check block, the duplicate computation, the `--option=action_version` and `--meta=action_version` arguments, the now-dead `VERSION=0.0.0` line, and the matching `SKIP_VERSION_CHECKING=true` env-set in `test-action.sh` are removed. The startup banner is shortened from `judges-action 0.0.0 is running` to `judges-action is running`. No downstream judge or test reads `action_version`, confirmed by `grep -rn action_version judges/ lib/ test/`.

Local checks: `bash -n entry.sh` and `bash -n test-action.sh` both pass. The full lint suite (`actionlint`, `bashate`, `shellcheck`, `hadolint`, `make`, `rake`, `xcop`, `yamllint`, etc.) runs on CI.

Closes #1467
