### PR TITLE
#589: rolling window budget for Search API quota

### DIFF
--- a/judges/dimensions-of-terrain/total_active_contributors.rb
+++ b/judges/dimensions-of-terrain/total_active_contributors.rb
@@ -13,7 +13,10 @@ def total_active_contributors(fact)
   Fbe.unmask_repos do |repo|
     commits =
       begin
-        Jp.qosearch("repo:#{repo} author-date:>#{(fact.when - (30 * 24 * 60 * 60)).iso8601[0..9]}", kind: :commits)
+        Jp.qosearch(
+          "repo:#{repo} author-date:>#{(fact.when - (30 * 24 * 60 * 60)).iso8601[0..9]}",
+          method: :search_commits
+        )
       rescue Octokit::NotFound, Octokit::Deprecated => e
         $loog.info("Commits not found for #{repo}: #{e.message}")
         next

--- a/judges/dimensions-of-terrain/total_active_contributors.rb
+++ b/judges/dimensions-of-terrain/total_active_contributors.rb
@@ -10,12 +10,12 @@ require_relative '../../lib/qos_search'
 def total_active_contributors(fact)
   seen = Set.new
   Fbe.unmask_repos do |repo|
-    commits = Jp.qosearch(
+    result = Jp.qosearch(
       "repo:#{repo} author-date:>#{(fact.when - (30 * 24 * 60 * 60)).iso8601[0..9]}",
-      kind: :commits
+      method: :search_commits
     )
-    next if commits.nil?
-    commits[:items].each do |commit|
+    next unless result
+    result[:items].each do |commit|
       author = commit.dig(:author, :id)
       seen << author unless author.nil?
     end

--- a/judges/find-all-issues/find-all-issues.rb
+++ b/judges/find-all-issues/find-all-issues.rb
@@ -15,6 +15,7 @@ require 'joined'
 require 'logger'
 require 'time'
 require_relative '../../lib/issue_was_lost'
+require_relative '../../lib/qos_search'
 
 %w[issue pull].each do |type|
   Fbe.iterate do
@@ -50,7 +51,9 @@ require_relative '../../lib/issue_was_lost'
       found = []
       first = issue
       elapsed($loog, level: Logger::INFO) do
-        Fbe.octo.search_issues("repo:#{repo} type:#{type} created:>=#{after.iso8601[0..9]}")[:items].each do |json|
+        result = Jp.qosearch("repo:#{repo} type:#{type} created:>=#{after.iso8601[0..9]}")
+        next unless result
+        result[:items].each do |json|
           next if Fbe.octo.off_quota?
           i = json[:number]
           seen << i

--- a/lib/qos_search.rb
+++ b/lib/qos_search.rb
@@ -6,12 +6,26 @@
 require 'fbe/octo'
 require_relative 'jp'
 
+Jp::SEARCH_WINDOW_SECONDS = 60
+Jp::SEARCH_WINDOW_BUDGET = 25
+
 def Jp.qoreset
   @offquota = false
+  @scount = 0
+  @swstart = nil
 end
 
-def Jp.qosearch(query, kind: :issues, **)
+def Jp.qosearch(query, method: :search_issues, **)
   return if @offquota || Fbe.octo.off_quota?
+  now = Time.now
+  if @swstart.nil? || (now - @swstart) >= Jp::SEARCH_WINDOW_SECONDS
+    @swstart = now
+    @scount = 0
+  end
+  if @scount >= Jp::SEARCH_WINDOW_BUDGET
+    $loog.info("[#{$judge}] Search API per-minute budget exceeded (#{Jp::SEARCH_WINDOW_BUDGET}/#{Jp::SEARCH_WINDOW_SECONDS}s)")
+    return
+  end
   octo = Fbe.octo
   left = nil
   begin
@@ -24,7 +38,7 @@ def Jp.qosearch(query, kind: :issues, **)
   end
   if left.nil?
     @offquota = true
-    $loog.warn("[#{$judge}] GitHub Search API quota info unavailable, stopping QoS search calls")
+    $loog.warn("[#{$judge}] GitHub Search API quota info unavailable, stopping search calls")
     return
   end
   if left.zero?
@@ -32,13 +46,10 @@ def Jp.qosearch(query, kind: :issues, **)
     $loog.info('Too much GitHub Search API quota consumed already (0 left)')
     return
   end
-  case kind
-  when :issues then Fbe.octo.search_issues(query, **)
-  when :commits then Fbe.octo.search_commits(query, **)
-  else raise(ArgumentError, "Unknown search kind: #{kind}")
-  end
+  @scount += 1
+  Fbe.octo.__send__(method, query, **)
 rescue Octokit::TooManyRequests => e
   @offquota = true
-  $loog.warn("[#{$judge}] GitHub Search API quota exhausted, stopping QoS search calls: #{e.message}")
+  $loog.warn("[#{$judge}] GitHub Search API quota exhausted, stopping search calls: #{e.message}")
   nil
 end

--- a/test/judges/test-dimensions-of-terrain.rb
+++ b/test/judges/test-dimensions-of-terrain.rb
@@ -15,7 +15,10 @@ class TestDimensionsOfTerrain < Jp::Test
   def test_total_repositories
     WebMock.disable_net_connect!
     stub_request(:get, 'https://api.github.com/rate_limit').to_return(
-      { body: '{"rate":{"remaining":222}}', headers: { 'X-RateLimit-Remaining' => '222' } }
+      {
+        body: '{"rate":{"remaining":222},"resources":{"search":{"remaining":30,"limit":30}}}',
+        headers: { 'X-RateLimit-Remaining' => '222' }
+      }
     )
     stub_github(
       'https://api.github.com/repos/foo/foo',
@@ -211,7 +214,10 @@ class TestDimensionsOfTerrain < Jp::Test
   def test_total_releases
     WebMock.disable_net_connect!
     stub_request(:get, 'https://api.github.com/rate_limit').to_return(
-      { body: '{"rate":{"remaining":222}}', headers: { 'X-RateLimit-Remaining' => '222' } }
+      {
+        body: '{"rate":{"remaining":222},"resources":{"search":{"remaining":30,"limit":30}}}',
+        headers: { 'X-RateLimit-Remaining' => '222' }
+      }
     )
     stub_github(
       'https://api.github.com/repos/foo/foo',
@@ -265,7 +271,10 @@ class TestDimensionsOfTerrain < Jp::Test
   def test_total_stars_and_forks
     WebMock.disable_net_connect!
     stub_request(:get, 'https://api.github.com/rate_limit').to_return(
-      { body: '{"rate":{"remaining":222}}', headers: { 'X-RateLimit-Remaining' => '222' } }
+      {
+        body: '{"rate":{"remaining":222},"resources":{"search":{"remaining":30,"limit":30}}}',
+        headers: { 'X-RateLimit-Remaining' => '222' }
+      }
     )
     stub_github(
       'https://api.github.com/repos/foo/foo',
@@ -395,7 +404,10 @@ class TestDimensionsOfTerrain < Jp::Test
   def test_total_commits_with_nil_size_repo
     WebMock.disable_net_connect!
     stub_request(:get, 'https://api.github.com/rate_limit').to_return(
-      { body: '{"rate":{"remaining":222}}', headers: { 'X-RateLimit-Remaining' => '222' } }
+      {
+        body: '{"rate":{"remaining":222},"resources":{"search":{"remaining":30,"limit":30}}}',
+        headers: { 'X-RateLimit-Remaining' => '222' }
+      }
     )
     stub_github(
       'https://api.github.com/repos/foo/foo',
@@ -459,7 +471,10 @@ class TestDimensionsOfTerrain < Jp::Test
   def test_total_files
     WebMock.disable_net_connect!
     stub_request(:get, 'https://api.github.com/rate_limit').to_return(
-      { body: '{"rate":{"remaining":222}}', headers: { 'X-RateLimit-Remaining' => '222' } }
+      {
+        body: '{"rate":{"remaining":222},"resources":{"search":{"remaining":30,"limit":30}}}',
+        headers: { 'X-RateLimit-Remaining' => '222' }
+      }
     )
     stub_github(
       'https://api.github.com/repos/foo/foo',
@@ -585,7 +600,10 @@ class TestDimensionsOfTerrain < Jp::Test
   def test_total_contributors
     WebMock.disable_net_connect!
     stub_request(:get, 'https://api.github.com/rate_limit').to_return(
-      { body: '{"rate":{"remaining":222}}', headers: { 'X-RateLimit-Remaining' => '222' } }
+      {
+        body: '{"rate":{"remaining":222},"resources":{"search":{"remaining":30,"limit":30}}}',
+        headers: { 'X-RateLimit-Remaining' => '222' }
+      }
     )
     stub_github(
       'https://api.github.com/repos/foo/foo',
@@ -663,8 +681,10 @@ class TestDimensionsOfTerrain < Jp::Test
     Jp.qoreset
     WebMock.disable_net_connect!
     stub_request(:get, 'https://api.github.com/rate_limit').to_return(
-      body: { resources: { search: { remaining: 30, limit: 30 } }, rate: { remaining: 222, limit: 1000 } }.to_json,
-      headers: { 'Content-Type' => 'application/json', 'X-RateLimit-Remaining' => '222' }
+      {
+        body: '{"rate":{"remaining":222},"resources":{"search":{"remaining":30,"limit":30}}}',
+        headers: { 'X-RateLimit-Remaining' => '222' }
+      }
     )
     stub_github(
       'https://api.github.com/repos/foo/foo',
@@ -820,7 +840,10 @@ class TestDimensionsOfTerrain < Jp::Test
   def test_not_fill_props_if_quota_consumed
     WebMock.disable_net_connect!
     stub_request(:get, 'https://api.github.com/rate_limit').to_return(
-      { body: '{"rate":{"remaining":90}}', headers: { 'X-RateLimit-Remaining' => '90' } }
+      {
+        body: '{"rate":{"remaining":90},"resources":{"search":{"remaining":30,"limit":30}}}',
+        headers: { 'X-RateLimit-Remaining' => '90' }
+      }
     )
     fb = Factbase.new
     Fbe.stub(:github_graph, Fbe::Graph::Fake.new) do

--- a/test/judges/test-find-all-issues.rb
+++ b/test/judges/test-find-all-issues.rb
@@ -92,7 +92,10 @@ class TestFindAllIssues < Jp::Test
     stub_github(
       'https://api.github.com/rate_limit',
       body: {
-        resources: { core: { limit: 60, remaining: 59, reset: 1_728_464_472, used: 1, resource: 'core' } },
+        resources: {
+          core: { limit: 60, remaining: 59, reset: 1_728_464_472, used: 1, resource: 'core' },
+          search: { remaining: 30, limit: 30 }
+        },
         rate: { limit: 60, remaining: 59, reset: 1_728_464_472, used: 1, resource: 'core' }
       }
     )
@@ -134,7 +137,10 @@ class TestFindAllIssues < Jp::Test
     stub_github(
       'https://api.github.com/rate_limit',
       body: {
-        resources: { core: { limit: 999, remaining: 999, reset: 1_728_464_472, used: 1, resource: 'core' } },
+        resources: {
+          core: { limit: 999, remaining: 999, reset: 1_728_464_472, used: 1, resource: 'core' },
+          search: { remaining: 30, limit: 30 }
+        },
         rate: { limit: 999, remaining: 999, reset: 1_728_464_472, used: 1, resource: 'core' }
       }
     )

--- a/test/judges/test-fix-missing-branch.rb
+++ b/test/judges/test-fix-missing-branch.rb
@@ -46,7 +46,7 @@ class TestFixMissingBranch < Jp::Test
     load_it('fix-missing-branch', fb)
     f = fb.query('(eq issue 44)').each.first
     refute_nil(f)
-    assert_nil(f['stale'],
-               '403 is transient — fact must NOT be marked stale; next cycle will retry the pull_request lookup')
+    msg = '403 is transient — fact must NOT be marked stale; next cycle will retry the pull_request lookup'
+    assert_nil(f['stale'], msg)
   end
 end

--- a/test/lib/test_qos_search.rb
+++ b/test/lib/test_qos_search.rb
@@ -101,6 +101,51 @@ class TestQosSearch < Jp::Test
     assert_equal(2, Jp.qosearch('repo:foo/foo type:pr')[:items].first[:number])
   end
 
+  def test_caps_search_calls_per_window
+    rate_limit_up
+    Jp::SEARCH_WINDOW_BUDGET.times do
+      searchstub('repo:foo/foo type:issue', body: { total_count: 1, items: [{ number: 1 }] })
+    end
+    Jp::SEARCH_WINDOW_BUDGET.times do
+      refute_nil(Jp.qosearch('repo:foo/foo type:issue'))
+    end
+    assert_nil(Jp.qosearch('repo:foo/foo type:issue'))
+  end
+
+  def test_resets_budget_after_window_elapses
+    rate_limit_up
+    Jp::SEARCH_WINDOW_BUDGET.times do
+      searchstub('repo:foo/foo type:issue', body: { total_count: 1, items: [{ number: 1 }] })
+    end
+    Jp::SEARCH_WINDOW_BUDGET.times do
+      refute_nil(Jp.qosearch('repo:foo/foo type:issue'))
+    end
+    assert_nil(Jp.qosearch('repo:foo/foo type:issue'))
+    Jp.instance_variable_set(:@swstart, Time.now - Jp::SEARCH_WINDOW_SECONDS - 1)
+    $global[:octo] = nil
+    rate_limit_up
+    searchstub('repo:foo/foo type:issue', body: { total_count: 1, items: [{ number: 2 }] })
+    refute_nil(Jp.qosearch('repo:foo/foo type:issue'))
+  end
+
+  def test_stops_after_too_many_requests_respects_window
+    rate_limit_up
+    searchstub('repo:foo/foo type:issue', body: { message: 'API rate limit exceeded' }, status: 403)
+    assert_nil(Jp.qosearch('repo:foo/foo type:issue'))
+    assert_equal(1, Jp.instance_variable_get(:@scount))
+    assert(Jp.instance_variable_get(:@offquota))
+    Jp.qoreset
+    $global[:octo] = nil
+    rate_limit_up
+    Jp::SEARCH_WINDOW_BUDGET.times do
+      searchstub('repo:foo/foo type:issue', body: { total_count: 1, items: [{ number: 1 }] })
+    end
+    Jp::SEARCH_WINDOW_BUDGET.times do
+      refute_nil(Jp.qosearch('repo:foo/foo type:issue'))
+    end
+    assert_nil(Jp.qosearch('repo:foo/foo type:issue'))
+  end
+
   private
 
   def searchstub(query, body:, remaining: 999, status: 200)


### PR DESCRIPTION
## #589: QoS Search API rate limit — rolling window budget

### Problem

`quality-of-service` judge gets `403 / API rate limit exceeded` from GitHub Search API,
even though `Jp.qosearch` checks `resources.search.remaining` before each call.

**Root cause:** `Fbe::Middleware::RateLimit` caches `/rate_limit` response for 100 requests,
but only decrements `rate.remaining` (core quota). `resources.search.remaining` in the cache
stays stale — it doesn't reflect actual Search API calls made. When the real per-minute budget
(30 req/min) is exhausted, the next `search_issues` gets 403.

### Solution

**Rolling window budget** in `Jp.qosearch` — an independent call counter over a 60-second
window, not relying on cached `/rate_limit`:

- `SEARCH_WINDOW_SECONDS = 60`, `SEARCH_WINDOW_BUDGET = 25` (5 buffer for other calls)
- Before each Search API request, the `@scount` counter is checked. If ≥ budget, return `nil`
  without calling the API.
- `Jp.qoreset` resets the window — called at the start of each `quality-of-service.rb` run.
- Existing `resources.search.remaining` check stays as secondary guard.
- `@offquota` latch remains a hard stop on 403.

### Additionally: `find-all-issues` and `total_active_contributors`

Discovered that these two judges call Search API directly (`Fbe.octo.search_issues` /
`Fbe.octo.search_commits`), bypassing `Jp.qosearch`. They consumed the per-minute budget
independently of QoS, which could lead to 403 inside QoS even with correct rolling window behavior.

**What was done:**

- `Jp.qosearch` extended with `method:` parameter (`:search_issues` by default,
  `:search_commits` for commits)
- `judges/find-all-issues/find-all-issues.rb` — `Fbe.octo.search_issues` → `Jp.qosearch`
- `judges/dimensions-of-terrain/total_active_contributors.rb` — `Fbe.octo.search_commits`
  → `Jp.qosearch(method: :search_commits)`

Now all Search API calls in the project go through a single quota-control mechanism.

### Tests

- Added 3 unit tests for rolling window in `test/lib/test_qos_search.rb`
- Fixed `/rate_limit` stubs in `test/judges/test-dimensions-of-terrain.rb` and
  `test/judges/test-find-all-issues.rb` — added `resources.search.remaining` (without it,
  `Jp.qosearch` saw `nil` and disabled search)

### Verification

- `bundle exec rubocop` — 0 offenses
- `bundle exec rake test` — 248 tests, 0 failures

Closes #589