### PR TITLE
#1476: rescue Octokit errors in Jp.count_appreciated_comments

### DIFF
--- a/lib/pull_request.rb
+++ b/lib/pull_request.rb
@@ -32,11 +32,29 @@ def Jp.count_appreciated_comments(pr, issue_comments, code_comments, repo: nil)
     issue_comments.sum do |comment|
       Fbe.octo.issue_comment_reactions(repo, comment[:id])
          .count { |reaction| reaction.dig(:user, :id) != comment.dig(:user, :id) }
+    rescue Octokit::NotFound, Octokit::Deprecated => e
+      $loog.info("Issue comment ##{comment[:id]} reactions don't exist in #{repo}: #{e.message}")
+      0
+    rescue Octokit::Forbidden => e
+      $loog.warn(
+        "Access forbidden to issue comment ##{comment[:id]} reactions in #{repo} " \
+        "(transient, will retry next cycle): #{e.class}: #{e.message}"
+      )
+      0
     end
   coded =
     code_comments.sum do |comment|
       Fbe.octo.pull_request_review_comment_reactions(repo, comment[:id])
          .count { |reaction| reaction.dig(:user, :id) != comment.dig(:user, :id) }
+    rescue Octokit::NotFound, Octokit::Deprecated => e
+      $loog.info("Code comment ##{comment[:id]} reactions don't exist in #{repo}: #{e.message}")
+      0
+    rescue Octokit::Forbidden => e
+      $loog.warn(
+        "Access forbidden to code comment ##{comment[:id]} reactions in #{repo} " \
+        "(transient, will retry next cycle): #{e.class}: #{e.message}"
+      )
+      0
     end
   issued + coded
 end

--- a/test/lib/test_pull_request.rb
+++ b/test/lib/test_pull_request.rb
@@ -91,4 +91,58 @@ class TestPullRequest < Jp::Test
     count = Jp.count_appreciated_comments(pr, [], [{ id: 202, user: nil }])
     assert_equal(1, count)
   end
+
+  def test_count_appreciated_comments_skips_issue_comment_on_octokit_not_found
+    WebMock.disable_net_connect!
+    rate_limit_up
+    $options = Judges::Options.new({})
+    $global = {}
+    $loog = Loog::NULL
+    stub_request(:get, 'https://api.github.com/repos/foo/foo/issues/comments/301/reactions')
+      .to_return(status: 404, headers: { 'Content-Type' => 'application/json' }, body: '{}')
+    stub_github('https://api.github.com/repos/foo/foo/issues/comments/302/reactions', body: [{ user: { id: 99 } }])
+    pr = { base: { repo: { full_name: 'foo/foo' } } }
+    count = Jp.count_appreciated_comments(pr, [{ id: 301, user: { id: 1 } }, { id: 302, user: { id: 1 } }], [])
+    assert_equal(1, count)
+  end
+
+  def test_count_appreciated_comments_skips_issue_comment_on_octokit_forbidden
+    WebMock.disable_net_connect!
+    rate_limit_up
+    $options = Judges::Options.new({})
+    $global = {}
+    $loog = Loog::NULL
+    stub_request(:get, 'https://api.github.com/repos/foo/foo/issues/comments/401/reactions')
+      .to_return(status: 403, headers: { 'Content-Type' => 'application/json' }, body: '{}')
+    pr = { base: { repo: { full_name: 'foo/foo' } } }
+    count = Jp.count_appreciated_comments(pr, [{ id: 401, user: { id: 1 } }], [])
+    assert_equal(0, count)
+  end
+
+  def test_count_appreciated_comments_skips_code_comment_on_octokit_not_found
+    WebMock.disable_net_connect!
+    rate_limit_up
+    $options = Judges::Options.new({})
+    $global = {}
+    $loog = Loog::NULL
+    stub_request(:get, 'https://api.github.com/repos/foo/foo/pulls/comments/501/reactions')
+      .to_return(status: 404, headers: { 'Content-Type' => 'application/json' }, body: '{}')
+    stub_github('https://api.github.com/repos/foo/foo/pulls/comments/502/reactions', body: [{ user: { id: 88 } }])
+    pr = { base: { repo: { full_name: 'foo/foo' } } }
+    count = Jp.count_appreciated_comments(pr, [], [{ id: 501, user: { id: 1 } }, { id: 502, user: { id: 1 } }])
+    assert_equal(1, count)
+  end
+
+  def test_count_appreciated_comments_skips_code_comment_on_octokit_forbidden
+    WebMock.disable_net_connect!
+    rate_limit_up
+    $options = Judges::Options.new({})
+    $global = {}
+    $loog = Loog::NULL
+    stub_request(:get, 'https://api.github.com/repos/foo/foo/pulls/comments/601/reactions')
+      .to_return(status: 403, headers: { 'Content-Type' => 'application/json' }, body: '{}')
+    pr = { base: { repo: { full_name: 'foo/foo' } } }
+    count = Jp.count_appreciated_comments(pr, [], [{ id: 601, user: { id: 1 } }])
+    assert_equal(0, count)
+  end
 end


### PR DESCRIPTION
Closes #1476.

`lib/pull_request.rb` calls `Fbe.octo.issue_comment_reactions` and `Fbe.octo.pull_request_review_comment_reactions` inside the two `.sum` blocks of `Jp.count_appreciated_comments`. Either lookup can raise `Octokit::NotFound`, `Octokit::Deprecated`, or `Octokit::Forbidden` on a single comment id and abort the whole judge (`pull-was-merged`, `github-events` via `Jp.comments_info`, `fix-missing-comments`), dropping every remaining `(repository, issue)` pair in the cycle.

This change wraps each reaction lookup in the two-branch rescue already used in `judges/pull-was-merged/pull-was-merged.rb:55-99`, `judges/code-was-reviewed/code-was-reviewed.rb` (#1414), and `judges/erase-repository/erase-repository.rb` (#1416): `NotFound`/`Deprecated` log info and contribute 0; `Forbidden` logs a transient warning and contributes 0. The surrounding `.sum` keeps counting the rest of the comments.

Checks run locally on the head commit:
- `bundle exec rake test TEST=test/lib/test_pull_request.rb` — 8 tests, 8 assertions, 0 failures, 0 errors.
- `bundle exec rubocop` — 101 files, 0 offenses.

Four new tests in `test/lib/test_pull_request.rb` lock the four new branches (issue/code × `NotFound`/`Forbidden`).