### PR TITLE
#1489: read merged_by from pulls endpoint in fix-missing-who

### DIFF
--- a/judges/fix-missing-who/fix-missing-who.rb
+++ b/judges/fix-missing-who/fix-missing-who.rb
@@ -11,12 +11,12 @@ require 'octokit'
 require_relative '../../lib/issue_was_lost'
 
 {
-  'issue-was-opened' => :user,
-  'pull-was-opened' => :user,
-  'issue-was-closed' => :closed_by,
-  'pull-was-closed' => :closed_by,
-  'pull-was-merged' => :merged_by
-}.each do |w, a|
+  'issue-was-opened' => %i[issue user],
+  'pull-was-opened' => %i[issue user],
+  'issue-was-closed' => %i[issue closed_by],
+  'pull-was-closed' => %i[issue closed_by],
+  'pull-was-merged' => %i[pull_request merged_by]
+}.each do |w, (api, a)|
   Fbe.consider(
     "(and
       (absent who)
@@ -31,7 +31,7 @@ require_relative '../../lib/issue_was_lost'
     repo = Fbe.octo.repo_name_by_id(f.repository)
     json =
       begin
-        Fbe.octo.issue(repo, f.issue)
+        Fbe.octo.public_send(api, repo, f.issue)
       rescue Octokit::NotFound, Octokit::Deprecated => e
         $loog.info("#{Fbe.issue(f)} doesn't exist in #{repo}: #{e.message}")
         Jp.issue_was_lost(f.where, f.repository, f.issue)

--- a/test/judges/test-fix-missing-who.rb
+++ b/test/judges/test-fix-missing-who.rb
@@ -45,4 +45,22 @@ class TestFixMissingWho < Jp::Test
     refute_nil(f)
     assert_equal('issue', f['stale'].first, '410 is permanent — fact must be marked stale via Jp.issue_was_lost')
   end
+
+  def test_reads_merged_by_from_pull_endpoint
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repos/foo/foo', body: { id: 42, full_name: 'foo/foo' })
+    stub_github('https://api.github.com/repositories/42', body: { id: 42, full_name: 'foo/foo' })
+    stub_github(
+      'https://api.github.com/repos/foo/foo/pulls/66',
+      body: { number: 66, merged_by: { id: 7, login: 'merger' } }
+    )
+    fb = Factbase.new
+    fb.with(_id: 1, what: 'pull-was-merged', repository: 42, issue: 66, where: 'github')
+    load_it('fix-missing-who', fb)
+    f = fb.query('(eq issue 66)').each.first
+    refute_nil(f)
+    assert_equal(7, f['who'].first, 'merged_by.id from pulls endpoint must be assigned to who')
+    assert_nil(f['stale'], 'fact must not be marked stale when merged_by is present on the pull payload')
+  end
 end


### PR DESCRIPTION
The dispatch table in `fix-missing-who.rb:13-19` mapped `pull-was-merged` to `:merged_by` but routed every lookup through `Fbe.octo.issue`. The REST issues endpoint does not return `merged_by`, so `json.dig(:merged_by, :id)` was always nil for `pull-was-merged` facts and line 47 set `f.stale = 'who'` unconditionally, locking those facts out of payout attribution. The dispatch table is now a `(api, attribute)` pair and the `pull-was-merged` row routes through `Fbe.octo.pull_request`, which is the endpoint that exposes `merged_by`. The other four rows keep the issues endpoint they already used.

For a `pull-was-merged` fact backed by a pull payload with `merged_by: { id: 7 }`, `f.who` now lands on `7` instead of leaving the fact stale; the existing `issue-was-opened`, `pull-was-opened`, `issue-was-closed`, and `pull-was-closed` paths keep their current call to the issues endpoint, so behavior on those four event types is unchanged. The transient and permanent error branches (`Octokit::Forbidden`, `Octokit::NotFound`, `Octokit::Deprecated`) keep their current dispositions.

Ran `bundle exec ruby -Ilib -Itest test/judges/test-fix-missing-who.rb` (3 tests, 8 assertions, 0 failures including the new `test_reads_merged_by_from_pull_endpoint`), `bundle exec rake test` against the full suite (246 tests, 659 assertions, 0 failures, 1 pre-existing skip), and `rubocop` against the two touched files (0 offenses).

Closes #1489
