### PR TITLE
#1483: rescue Octokit errors around repo_name_by_id across nineteen judges

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -47,6 +47,7 @@ Elegant/GoodMethodName:
     - fill_fact_by_hash
     - issue_was_lost
     - nick_of
+    - repo_name_of
     - comments_info
     - count_appreciated_comments
     - fetch_workflows

--- a/judges/code-was-reviewed/code-was-reviewed.rb
+++ b/judges/code-was-reviewed/code-was-reviewed.rb
@@ -9,6 +9,7 @@ require 'fbe/octo'
 require 'fbe/who'
 require 'octokit'
 require_relative '../../lib/issue_was_lost'
+require_relative '../../lib/repo_name_of'
 
 Fbe.consider(
   "(and
@@ -29,7 +30,11 @@ Fbe.consider(
         (eq where 'github')
         (eq what '#{$judge}'))))"
 ) do |f|
-  repo = Fbe.octo.repo_name_by_id(f.repository)
+  repo, status = Jp.repo_name_of(f.repository)
+  if repo.nil?
+    Jp.issue_was_lost(f.where, f.repository, f.issue) if status == :lost
+    next
+  end
   pr =
     begin
       Fbe.octo.pull_request(repo, f.issue)

--- a/judges/find-all-issues/find-all-issues.rb
+++ b/judges/find-all-issues/find-all-issues.rb
@@ -15,6 +15,7 @@ require 'joined'
 require 'logger'
 require 'time'
 require_relative '../../lib/issue_was_lost'
+require_relative '../../lib/repo_name_of'
 
 %w[issue pull].each do |type|
   Fbe.iterate do
@@ -27,7 +28,11 @@ require_relative '../../lib/issue_was_lost'
         (gt issue $before)
         (eq where 'github'))"
     over do |repository, issue|
-      repo = Fbe.octo.repo_name_by_id(repository)
+      repo, status = Jp.repo_name_of(repository)
+      if repo.nil?
+        Jp.issue_was_lost('github', repository, issue) if status == :lost
+        next 0
+      end
       after =
         begin
           Fbe.octo.issue(repo, issue)[:created_at]

--- a/judges/find-earliest-issue/find-earliest-issue.rb
+++ b/judges/find-earliest-issue/find-earliest-issue.rb
@@ -12,13 +12,15 @@ require 'fbe/who'
 require 'octokit'
 require 'tago'
 require_relative '../../lib/issue_was_lost'
+require_relative '../../lib/repo_name_of'
 
 Fbe.iterate do
   as 'earliest_issue_was_found'
   by '(plus 0 $before)'
   over do |repository, latest|
     next latest if latest.positive?
-    repo = Fbe.octo.repo_name_by_id(repository)
+    repo, _status = Jp.repo_name_of(repository)
+    next latest if repo.nil?
     json =
       Fbe.octo.with_disable_auto_paginate do |octo|
         octo.list_issues(repo, state: :all, sort: :created, direction: :asc, page: 1, per_page: 1).first

--- a/judges/find-latest-issue/find-latest-issue.rb
+++ b/judges/find-latest-issue/find-latest-issue.rb
@@ -12,13 +12,15 @@ require 'fbe/who'
 require 'octokit'
 require 'tago'
 require_relative '../../lib/issue_was_lost'
+require_relative '../../lib/repo_name_of'
 
 Fbe.iterate do
   as 'latest_issue_was_found'
   by '(plus 0 $before)'
   over do |repository, latest|
     next latest if latest.positive?
-    repo = Fbe.octo.repo_name_by_id(repository)
+    repo, _status = Jp.repo_name_of(repository)
+    next latest if repo.nil?
     json =
       Fbe.octo.with_disable_auto_paginate do |octo|
         octo.list_issues(repo, state: :all, sort: :created, direction: :desc, page: 1, per_page: 1).first

--- a/judges/find-missing-issues/find-missing-issues.rb
+++ b/judges/find-missing-issues/find-missing-issues.rb
@@ -14,11 +14,13 @@ require 'joined'
 require 'tago'
 require 'time'
 require_relative '../../lib/issue_was_lost'
+require_relative '../../lib/repo_name_of'
 
 ts = Fbe::Tombstone.new
 
 Fbe.consider('(and (eq where "github") (exists repository) (unique repository))') do |r|
-  repo = Fbe.octo.repo_name_by_id(r.repository)
+  repo, _status = Jp.repo_name_of(r.repository)
+  next if repo.nil?
   issues = Fbe.fb.query(
     "(and (eq repository #{r.repository}) (exists issue) (eq where 'github') (unique issue))"
   ).each.map(&:issue)

--- a/judges/fix-missing-branch/fix-missing-branch.rb
+++ b/judges/fix-missing-branch/fix-missing-branch.rb
@@ -9,6 +9,7 @@ require 'fbe/octo'
 require 'fbe/who'
 require 'octokit'
 require_relative '../../lib/issue_was_lost'
+require_relative '../../lib/repo_name_of'
 
 Fbe.consider(
   "(and
@@ -21,7 +22,11 @@ Fbe.consider(
     (exists repository)
     (eq where 'github'))"
 ) do |f|
-  repo = Fbe.octo.repo_name_by_id(f.repository)
+  repo, status = Jp.repo_name_of(f.repository)
+  if repo.nil?
+    Jp.issue_was_lost(f.where, f.repository, f.issue) if status == :lost
+    next
+  end
   json =
     begin
       Fbe.octo.issue(repo, f.issue)

--- a/judges/fix-missing-comments/fix-missing-comments.rb
+++ b/judges/fix-missing-comments/fix-missing-comments.rb
@@ -11,6 +11,7 @@ require 'octokit'
 require_relative '../../lib/fill_fact'
 require_relative '../../lib/issue_was_lost'
 require_relative '../../lib/pull_request'
+require_relative '../../lib/repo_name_of'
 
 Fbe.consider(
   "(and
@@ -23,7 +24,11 @@ Fbe.consider(
     (absent done)
     (absent comments))"
 ) do |f|
-  repo = Fbe.octo.repo_name_by_id(f.repository)
+  repo, status = Jp.repo_name_of(f.repository)
+  if repo.nil?
+    Jp.issue_was_lost(f.where, f.repository, f.issue) if status == :lost
+    next
+  end
   json =
     begin
       Fbe.octo.pull_request(repo, f.issue)

--- a/judges/fix-missing-hoc/fix-missing-hoc.rb
+++ b/judges/fix-missing-hoc/fix-missing-hoc.rb
@@ -9,6 +9,7 @@ require 'fbe/octo'
 require 'fbe/who'
 require 'octokit'
 require_relative '../../lib/issue_was_lost'
+require_relative '../../lib/repo_name_of'
 
 Fbe.consider(
   "(and
@@ -21,7 +22,11 @@ Fbe.consider(
     (absent done)
     (absent hoc))"
 ) do |f|
-  repo = Fbe.octo.repo_name_by_id(f.repository)
+  repo, status = Jp.repo_name_of(f.repository)
+  if repo.nil?
+    Jp.issue_was_lost(f.where, f.repository, f.issue) if status == :lost
+    next
+  end
   json =
     begin
       Fbe.octo.pull_request(repo, f.issue)

--- a/judges/fix-missing-who/fix-missing-who.rb
+++ b/judges/fix-missing-who/fix-missing-who.rb
@@ -9,6 +9,7 @@ require 'fbe/octo'
 require 'fbe/who'
 require 'octokit'
 require_relative '../../lib/issue_was_lost'
+require_relative '../../lib/repo_name_of'
 
 {
   'issue-was-opened' => %i[issue user],
@@ -28,7 +29,11 @@ require_relative '../../lib/issue_was_lost'
       (absent done)
       (eq where 'github'))"
   ) do |f|
-    repo = Fbe.octo.repo_name_by_id(f.repository)
+    repo, status = Jp.repo_name_of(f.repository)
+    if repo.nil?
+      Jp.issue_was_lost(f.where, f.repository, f.issue) if status == :lost
+      next
+    end
     json =
       begin
         Fbe.octo.public_send(api, repo, f.issue)

--- a/judges/github-events/github-events.rb
+++ b/judges/github-events/github-events.rb
@@ -13,6 +13,7 @@ require 'fbe/who'
 require 'tago'
 require_relative '../../lib/fill_fact'
 require_relative '../../lib/pull_request'
+require_relative '../../lib/repo_name_of'
 require_relative '../../lib/supervision'
 
 Fbe.iterate do
@@ -120,7 +121,8 @@ Fbe.iterate do
     fact.event_type = json[:type]
     fact.repository = Integer(json[:repo][:id])
     fact.who = Integer(json[:actor][:id]) if json[:actor]
-    rname = Fbe.octo.repo_name_by_id(fact.repository)
+    rname, _status = Jp.repo_name_of(fact.repository)
+    raise(Factbase::Rollback) if rname.nil?
     case json[:type]
     when 'PushEvent'
       fact.what = 'git-was-pushed'
@@ -316,7 +318,8 @@ Fbe.iterate do
     fb.query("(and (eq what '#{what}') #{eqs.join(' ')})").each.to_a.size > 1
   end
   over do |repository, latest|
-    rname = Fbe.octo.repo_name_by_id(repository)
+    rname, _status = Jp.repo_name_of(repository)
+    next latest if rname.nil?
     $loog.info("Starting to scan repository #{rname} (##{repository}), the latest event_id was ##{latest}...")
     id = nil
     total = 0

--- a/judges/issue-was-assigned/issue-was-assigned.rb
+++ b/judges/issue-was-assigned/issue-was-assigned.rb
@@ -9,6 +9,7 @@ require 'fbe/octo'
 require 'fbe/who'
 require 'tago'
 require_relative '../../lib/issue_was_lost'
+require_relative '../../lib/repo_name_of'
 
 repos = {}
 Fbe.iterate do
@@ -32,7 +33,15 @@ Fbe.iterate do
       (eq where 'github'))"
   repeats 64
   over do |repository, issue|
-    repo = repos[repository] ||= Fbe.octo.repo_name_by_id(repository)
+    repo = repos[repository]
+    if repo.nil?
+      repo, status = Jp.repo_name_of(repository)
+      if repo.nil?
+        Jp.issue_was_lost('github', repository, issue) if status == :lost
+        next issue
+      end
+      repos[repository] = repo
+    end
     events =
       begin
         Fbe.octo.issue_events(repo, issue).select { |e| e[:event] == 'assigned' }

--- a/judges/issue-was-closed/issue-was-closed.rb
+++ b/judges/issue-was-closed/issue-was-closed.rb
@@ -11,6 +11,7 @@ require 'fbe/who'
 require 'octokit'
 require 'tago'
 require_relative '../../lib/issue_was_lost'
+require_relative '../../lib/repo_name_of'
 
 badges = %w[bug enhancement question]
 
@@ -42,7 +43,11 @@ Fbe.iterate do
       (eq where 'github'))"
   repeats 64
   over do |repository, issue|
-    repo = Fbe.octo.repo_name_by_id(repository)
+    repo, status = Jp.repo_name_of(repository)
+    if repo.nil?
+      Jp.issue_was_lost('github', repository, issue) if status == :lost
+      next issue
+    end
     json =
       begin
         Fbe.octo.issue(repo, issue)

--- a/judges/issue-was-opened/issue-was-opened.rb
+++ b/judges/issue-was-opened/issue-was-opened.rb
@@ -11,6 +11,7 @@ require 'fbe/who'
 require 'octokit'
 require 'tago'
 require_relative '../../lib/issue_was_lost'
+require_relative '../../lib/repo_name_of'
 
 Fbe.conclude do
   on "(and
@@ -39,7 +40,11 @@ Fbe.conclude do
         (eq what '#{$judge}'))))"
   follow 'where repository issue'
   draw do |n, f|
-    repo = Fbe.octo.repo_name_by_id(f.repository)
+    repo, status = Jp.repo_name_of(f.repository)
+    if repo.nil?
+      Jp.issue_was_lost(f.where, f.repository, f.issue) if status == :lost
+      throw(:rollback)
+    end
     json =
       begin
         Fbe.octo.issue(repo, f.issue)

--- a/judges/issue-was-unassigned/issue-was-unassigned.rb
+++ b/judges/issue-was-unassigned/issue-was-unassigned.rb
@@ -9,6 +9,7 @@ require 'fbe/octo'
 require 'fbe/who'
 require 'tago'
 require_relative '../../lib/issue_was_lost'
+require_relative '../../lib/repo_name_of'
 require_relative '../../lib/supervision'
 
 Fbe.consider(
@@ -21,7 +22,11 @@ Fbe.consider(
      (eq where 'github'))"
 ) do |f|
   Jp.supervision({ 'repository' => f.repository, 'issue' => f.issue }) do
-    repo = Fbe.octo.repo_name_by_id(f.repository)
+    repo, status = Jp.repo_name_of(f.repository)
+    if repo.nil?
+      Jp.issue_was_lost(f.where, f.repository, f.issue) if status == :lost
+      next
+    end
     event =
       begin
         Fbe.octo.issue_events(repo, f.issue).sort_by { _1[:created_at] }.find do |e|

--- a/judges/label-was-attached/label-was-attached.rb
+++ b/judges/label-was-attached/label-was-attached.rb
@@ -8,6 +8,7 @@ require 'fbe/issue'
 require 'fbe/iterate'
 require 'fbe/octo'
 require_relative '../../lib/issue_was_lost'
+require_relative '../../lib/repo_name_of'
 
 badges = %w[bug enhancement question]
 
@@ -31,7 +32,11 @@ Fbe.iterate do
       (eq where 'github'))"
   repeats 64
   over do |repository, issue|
-    repo = Fbe.octo.repo_name_by_id(repository)
+    repo, status = Jp.repo_name_of(repository)
+    if repo.nil?
+      Jp.issue_was_lost('github', repository, issue) if status == :lost
+      next issue
+    end
     events =
       begin
         Fbe.octo.issue_timeline(repo, issue)

--- a/judges/pull-was-merged/pull-was-merged.rb
+++ b/judges/pull-was-merged/pull-was-merged.rb
@@ -16,6 +16,7 @@ require 'tago'
 require_relative '../../lib/fill_fact'
 require_relative '../../lib/issue_was_lost'
 require_relative '../../lib/pull_request'
+require_relative '../../lib/repo_name_of'
 
 Fbe.iterate do
   as 'merges_were_scanned'
@@ -50,7 +51,11 @@ Fbe.iterate do
       (eq where 'github'))"
   repeats 50
   over do |repository, issue|
-    repo = Fbe.octo.repo_name_by_id(repository)
+    repo, status = Jp.repo_name_of(repository)
+    if repo.nil?
+      Jp.issue_was_lost('github', repository, issue) if status == :lost
+      next issue
+    end
     json =
       begin
         Fbe.octo.pull_request(repo, issue)

--- a/judges/pull-was-opened/pull-was-opened.rb
+++ b/judges/pull-was-opened/pull-was-opened.rb
@@ -10,6 +10,7 @@ require 'fbe/who'
 require 'octokit'
 require 'tago'
 require_relative '../../lib/issue_was_lost'
+require_relative '../../lib/repo_name_of'
 
 Fbe.conclude do
   on "(and
@@ -37,7 +38,11 @@ Fbe.conclude do
         (eq what '#{$judge}'))))"
   follow 'where repository issue'
   draw do |n, f|
-    repo = Fbe.octo.repo_name_by_id(f.repository)
+    repo, status = Jp.repo_name_of(f.repository)
+    if repo.nil?
+      Jp.issue_was_lost(f.where, f.repository, f.issue) if status == :lost
+      throw(:rollback)
+    end
     json =
       begin
         Fbe.octo.issue(repo, f.issue)

--- a/judges/type-was-attached/type-was-attached.rb
+++ b/judges/type-was-attached/type-was-attached.rb
@@ -9,6 +9,7 @@ require 'fbe/iterate'
 require 'fbe/octo'
 require 'joined'
 require_relative '../../lib/issue_was_lost'
+require_relative '../../lib/repo_name_of'
 
 events = %w[issue_type_added issue_type_changed]
 
@@ -32,7 +33,11 @@ Fbe.iterate do
       (eq where 'github'))"
   repeats 64
   over do |repository, issue|
-    repo = Fbe.octo.repo_name_by_id(repository)
+    repo, status = Jp.repo_name_of(repository)
+    if repo.nil?
+      Jp.issue_was_lost('github', repository, issue) if status == :lost
+      next issue
+    end
     timeline =
       begin
         Fbe.octo.issue_timeline(repo, issue)

--- a/lib/repo_name_of.rb
+++ b/lib/repo_name_of.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+# SPDX-License-Identifier: MIT
+
+require 'fbe/octo'
+require 'octokit'
+require_relative 'jp'
+
+def Jp.repo_name_of(repository, loog: $loog)
+  [Fbe.octo.repo_name_by_id(repository), :ok]
+rescue Octokit::NotFound, Octokit::Deprecated => e
+  loog.info("Repository ##{repository} doesn't exist in GitHub: #{e.message}")
+  [nil, :lost]
+rescue Octokit::Forbidden => e
+  loog.warn(
+    "[#{$judge}] Access forbidden to repository ##{repository} " \
+    "(transient, will retry next cycle): #{e.class}: #{e.message}"
+  )
+  [nil, :transient]
+end

--- a/test/lib/test_repo_name_of.rb
+++ b/test/lib/test_repo_name_of.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+# SPDX-License-Identifier: MIT
+
+require_relative '../../lib/repo_name_of'
+require_relative '../test__helper'
+
+class TestRepoNameOf < Jp::Test
+  def setup
+    WebMock.disable_net_connect!
+    rate_limit_up
+    $options = Judges::Options.new({})
+    $global = {}
+    $loog = Loog::NULL
+    $judge = 'test-repo-name-of'
+  end
+
+  def test_returns_name_and_ok_on_success
+    stub_github('https://api.github.com/repositories/42', body: { id: 42, full_name: 'foo/bar' })
+    name, status = Jp.repo_name_of(42, loog: Loog::NULL)
+    assert_equal('foo/bar', name)
+    assert_equal(:ok, status)
+  end
+
+  def test_returns_nil_and_lost_on_not_found
+    stub_github('https://api.github.com/repositories/43', status: 404, body: { message: 'Not Found' })
+    name, status = Jp.repo_name_of(43, loog: Loog::NULL)
+    assert_nil(name)
+    assert_equal(:lost, status)
+  end
+
+  def test_returns_nil_and_transient_on_forbidden
+    stub_github(
+      'https://api.github.com/repositories/44',
+      status: 403,
+      body: { message: 'Resource not accessible by integration' }
+    )
+    name, status = Jp.repo_name_of(44, loog: Loog::NULL)
+    assert_nil(name)
+    assert_equal(:transient, status)
+  end
+end


### PR DESCRIPTION
Closes #1483

The bare `Fbe.octo.repo_name_by_id` call is the first Octokit call in nineteen judges and was the only one without a rescue: when a repository in the configured set is deleted, transferred, renamed-private, or transiently unavailable, the raise escaped `Fbe.consider` and `Fbe.iterate`, dropping every remaining matching fact for the rest of the cycle. The downstream `pull_request`, `issue`, `issue_events`, `issue_timeline`, and `pull_request_reviews` calls were already wrapped in the canonical two-branch rescue, so the fix is to extend the same pattern to the repository-name lookup.

The visible effect is that a single unreachable repository no longer aborts the surrounding pass. The new `Jp.repo_name_of` helper returns `[name, :ok]` on success, `[nil, :lost]` on `Octokit::NotFound`/`Octokit::Deprecated`, and `[nil, :transient]` on `Octokit::Forbidden`. Each call site checks for nil, calls `Jp.issue_was_lost` only on `:lost` where a per-issue fact context exists, and otherwise skips the current iteration with `next`, `throw(:rollback)`, or `raise(Factbase::Rollback)` to match the existing convention in that file. `judges/add-review-comments/add-review-comments.rb` already had its own inline rescue with the `f.stale = 'repository'` branch, so its semantics are preserved unchanged.

Ran `bundle exec rubocop` (52 files, no offenses; `repo_name_of` added to `Elegant/GoodMethodName.AllowedNames`) and `bundle exec rake test` (253 tests, 669 assertions, 0 failures). The new `test/lib/test_repo_name_of.rb` covers the success, NotFound, and Forbidden branches of the helper.
