### PR TITLE
#804 milestone-was-set judge implemented

### DIFF
--- a/judges/milestone-was-set/milestone-was-set.rb
+++ b/judges/milestone-was-set/milestone-was-set.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+# SPDX-License-Identifier: MIT
+
+require 'fbe/fb'
+require 'fbe/if_absent'
+require 'fbe/octo'
+require 'fbe/unmask_repos'
+require 'octokit'
+
+Fbe.unmask_repos do |repo|
+  milestones =
+    begin
+      Fbe.octo.list_milestones(repo, state: 'all')
+    rescue NoMethodError => e
+      raise unless e.name == :list_milestones
+      $loog.debug("list_milestones() not available (likely FakeOctokit), skipping #{repo}")
+      next
+    rescue Octokit::NotFound, Octokit::Deprecated => e
+      $loog.info("Milestones not available for #{repo}: #{e.message}")
+      next
+    rescue Octokit::Forbidden => e
+      $loog.warn("[#{$judge}] Access forbidden to milestones for #{repo}: #{e.class}: #{e.message}")
+      next
+    end
+  milestones.each do |m|
+    Fbe.fb.txn do |fbt|
+      f =
+        Fbe.if_absent(fb: fbt) do |ff|
+          ff.what = $judge
+          ff.milestone = m[:number]
+          ff.repository = Fbe.octo.repo_id_by_name(repo)
+          ff.where = 'github'
+        end
+      next if f.nil?
+      f.when = m[:created_at]
+      due = m[:due_on]
+      f.deadline = due if due
+      f.who = m.dig(:creator, :id)
+      f.details = "Milestone #{m[:title].inspect} ##{m[:number]} was set in #{repo}."
+      $loog.info("Milestone ##{m[:number]} found in #{repo}: #{m[:title].inspect}")
+    end
+  end
+end
+
+Fbe.octo.print_trace!

--- a/judges/milestone-was-set/milestone-was-set.yml
+++ b/judges/milestone-was-set/milestone-was-set.yml
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+# SPDX-License-Identifier: MIT
+---
+options:
+  testing: true
+  repositories: foo/foo
+input:
+  -
+    _id: 1
+    what: issue-was-opened
+    where: github
+    repository: 680
+    issue: 42
+    who: 4444
+    when: 2025-05-27T23:54:44Z
+expected:
+  - /fb[count(f)=1]
+  - /fb/f[what='issue-was-opened' and issue=42 and repository=680]

--- a/test/judges/test-milestone-was-set.rb
+++ b/test/judges/test-milestone-was-set.rb
@@ -1,0 +1,145 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+# SPDX-License-Identifier: MIT
+
+require 'factbase'
+require_relative '../test__helper'
+
+class TestMilestoneWasSet < Jp::Test
+  using SmartFactbase
+
+  def test_creates_milestone_fact
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repos/foo/foo', body: { id: 42, full_name: 'foo/foo' })
+    stub_request(:get, 'https://api.github.com/repos/foo/foo/milestones?per_page=100&state=all').to_return(
+      status: 200,
+      body: [
+        {
+          number: 1,
+          title: 'v1.0',
+          description: 'First release',
+          due_on: '2025-06-01T00:00:00Z',
+          created_at: '2025-01-15T10:00:00Z',
+          creator: { id: 526_301, login: 'yegor256' }
+        }
+      ].to_json,
+      headers: { 'Content-Type' => 'application/json' }
+    )
+    fb = Factbase.new
+    load_it('milestone-was-set', fb)
+    assert_equal(1, fb.all.size)
+    f = fb.pick(what: 'milestone-was-set')
+    refute_nil(f)
+    assert_equal(1, f.milestone)
+    assert_equal(42, f.repository)
+    assert_equal('github', f.where)
+    assert_equal(Time.parse('2025-01-15T10:00:00Z'), f.when)
+    assert_equal(Time.parse('2025-06-01T00:00:00Z'), f.deadline)
+    assert_equal(526_301, f.who)
+  end
+
+  def test_handles_empty_milestones
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repos/foo/foo', body: { id: 42, full_name: 'foo/foo' })
+    stub_request(:get, 'https://api.github.com/repos/foo/foo/milestones?per_page=100&state=all').to_return(
+      status: 200, body: [].to_json, headers: { 'Content-Type' => 'application/json' }
+    )
+    fb = Factbase.new
+    load_it('milestone-was-set', fb)
+    assert_equal(0, fb.all.size)
+  end
+
+  def test_deduplicates_milestones
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repos/foo/foo', body: { id: 42, full_name: 'foo/foo' })
+    stub_request(:get, 'https://api.github.com/repos/foo/foo/milestones?per_page=100&state=all').to_return(
+      status: 200,
+      body: [
+        {
+          number: 1,
+          title: 'v1.0',
+          due_on: '2025-06-01T00:00:00Z',
+          created_at: '2025-01-15T10:00:00Z',
+          creator: { id: 526_301, login: 'yegor256' }
+        }
+      ].to_json,
+      headers: { 'Content-Type' => 'application/json' }
+    )
+    fb = Factbase.new
+    load_it('milestone-was-set', fb)
+    assert_equal(1, fb.all.size)
+    load_it('milestone-was-set', fb)
+    assert_equal(1, fb.all.size, 'must not duplicate on second run')
+  end
+
+  def test_handles_milestone_without_due_date
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repos/foo/foo', body: { id: 42, full_name: 'foo/foo' })
+    stub_request(:get, 'https://api.github.com/repos/foo/foo/milestones?per_page=100&state=all').to_return(
+      status: 200,
+      body: [
+        {
+          number: 2,
+          title: 'Backlog',
+          due_on: nil,
+          created_at: '2025-02-01T08:00:00Z',
+          creator: { id: 526_301, login: 'yegor256' }
+        }
+      ].to_json,
+      headers: { 'Content-Type' => 'application/json' }
+    )
+    fb = Factbase.new
+    load_it('milestone-was-set', fb)
+    assert_equal(1, fb.all.size)
+    f = fb.pick(what: 'milestone-was-set')
+    refute_nil(f)
+    assert_nil(f['deadline'], 'deadline should be nil when due_on is nil')
+  end
+
+  def test_rescues_forbidden_on_milestones_list
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repos/foo/foo', body: { id: 42, full_name: 'foo/foo' })
+    stub_request(:get, 'https://api.github.com/repos/foo/foo/milestones?per_page=100&state=all').to_return(
+      status: 403,
+      body: { message: 'Resource not accessible by integration' }.to_json,
+      headers: { 'Content-Type' => 'application/json' }
+    )
+    fb = Factbase.new
+    load_it('milestone-was-set', fb)
+    assert_equal(0, fb.all.size, '403 is transient — no facts created, judge continues')
+  end
+
+  def test_rescues_not_found_on_milestones_list
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repos/foo/foo', body: { id: 42, full_name: 'foo/foo' })
+    stub_request(:get, 'https://api.github.com/repos/foo/foo/milestones?per_page=100&state=all').to_return(
+      status: 404,
+      body: { message: 'Not Found' }.to_json,
+      headers: { 'Content-Type' => 'application/json' }
+    )
+    fb = Factbase.new
+    load_it('milestone-was-set', fb)
+    assert_equal(0, fb.all.size, '404 — no facts created, judge continues')
+  end
+
+  def test_rescues_deprecated_on_milestones_list
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repos/foo/foo', body: { id: 42, full_name: 'foo/foo' })
+    stub_request(:get, 'https://api.github.com/repos/foo/foo/milestones?per_page=100&state=all').to_return(
+      status: 410,
+      body: { message: 'Gone' }.to_json,
+      headers: { 'Content-Type' => 'application/json' }
+    )
+    fb = Factbase.new
+    load_it('milestone-was-set', fb)
+    assert_equal(0, fb.all.size, '410 Gone — no facts created, judge continues')
+  end
+end


### PR DESCRIPTION
## New judge: `milestone-was-set`

Closes #804.

### What
Implements a scanning judge that reads milestones from all configured repositories via `Fbe.octo.list_milestones` and creates facts:

```xml
<f what="milestone-was-set"
     milestone="1"
     repository="42"
     where="github"
     when="2025-01-15T10:00:00Z"
     deadline="2025-06-01T00:00:00Z"
     who="526301"
     details='Milestone "v1.0" #1 was set in foo/foo.'/>
```

Facts are deduplicated per `(repository, milestone)` pair via `Fbe.if_absent`.

### How
- Iterates repositories via `Fbe.unmask_repos` (standard pattern, used by QoS/QoD judges)
- Wraps `list_milestones` in `begin/rescue` for `Octokit::NotFound`, `Octokit::Deprecated`, `Octokit::Forbidden` (log + `next`)
- Rescues `NoMethodError` for FakeOctokit (which doesn't expose `list_milestones`)

### Verification
- `rubocop` — 0 offenses
- `rake test` — 257 tests, 0 failures
- `judges test --disable live` — 60 tests, all pass

### Files
- `judges/milestone-was-set/milestone-was-set.rb` — the judge
- `judges/milestone-was-set/milestone-was-set.yml` — YAML judge test (FakeOctokit fallback, verifies no crash)
- `test/judges/test-milestone-was-set.rb` — 7 Ruby unit tests:
  - creates milestone fact
  - handles empty milestone list
  - deduplicates on second run
  - handles milestone without due date
  - rescues Octokit::Forbidden (403)
  - rescues Octokit::NotFound (404)
  - rescues Octokit::Deprecated (410)

### Future improvements
- Add `list_milestones` to `Fbe::FakeOctokit` for richer YAML judge tests
- Consider tracking last-scanned milestone for incremental scans (currently re-scans all milestones each run, dedup handles it)

@yegor256 @edmoffo please review.