### PR TITLE
#1494: Use pull_request endpoint in fix-missing-branch

### DIFF
--- a/judges/fix-missing-branch/fix-missing-branch.rb
+++ b/judges/fix-missing-branch/fix-missing-branch.rb
@@ -24,7 +24,7 @@ Fbe.consider(
   repo = Fbe.octo.repo_name_by_id(f.repository)
   json =
     begin
-      Fbe.octo.issue(repo, f.issue)
+      Fbe.octo.pull_request(repo, f.issue)
     rescue Octokit::NotFound, Octokit::Deprecated => e
       $loog.info("#{Fbe.issue(f)} doesn't exist in #{repo}: #{e.message}")
       Jp.issue_was_lost(f.where, f.repository, f.issue)
@@ -36,7 +36,7 @@ Fbe.consider(
       )
       next
     end
-  ref = json.dig(:pull_request, :head, :ref)
+  ref = json.dig(:head, :ref)
   if ref.nil?
     f.stale = 'branch'
     $loog.info("Branch is lost in #{Fbe.issue(f)}")

--- a/judges/fix-missing-branch/stale-branch.yml
+++ b/judges/fix-missing-branch/stale-branch.yml
@@ -11,4 +11,5 @@ input:
     issue: 94
 expected:
   - /fb[count(f)=1]
-  - /fb/f[stale]
+  - /fb/f[branch]
+  - /fb/f[not(stale)]

--- a/test/judges/test-fix-missing-branch.rb
+++ b/test/judges/test-fix-missing-branch.rb
@@ -9,13 +9,35 @@ require_relative '../test__helper'
 class TestFixMissingBranch < Jp::Test
   using SmartFactbase
 
-  def test_rescues_forbidden_on_issue_lookup
+  def test_finds_branch_via_pull_request
     WebMock.disable_net_connect!
     rate_limit_up
     stub_github('https://api.github.com/repos/foo/foo', body: { id: 42, full_name: 'foo/foo' })
     stub_github('https://api.github.com/repositories/42', body: { id: 42, full_name: 'foo/foo' })
     stub_github(
-      'https://api.github.com/repos/foo/foo/issues/44',
+      'https://api.github.com/repos/foo/foo/pulls/44',
+      body: {
+        number: 44,
+        state: 'open',
+        head: { ref: 'feature-branch', sha: 'abc123' }
+      }
+    )
+    fb = Factbase.new
+    fb.with(_id: 1, what: 'pull-was-opened', repository: 42, issue: 44, where: 'github')
+    load_it('fix-missing-branch', fb)
+    f = fb.query('(eq issue 44)').each.first
+    refute_nil(f)
+    assert_equal('feature-branch', f['branch'].first, 'branch must be extracted from pull_request.head.ref')
+    assert_nil(f['stale'], 'fact must NOT be marked stale when branch is found')
+  end
+
+  def test_rescues_forbidden_on_pull_request_lookup
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repos/foo/foo', body: { id: 42, full_name: 'foo/foo' })
+    stub_github('https://api.github.com/repositories/42', body: { id: 42, full_name: 'foo/foo' })
+    stub_github(
+      'https://api.github.com/repos/foo/foo/pulls/44',
       status: 403,
       body: { message: 'Resource not accessible by integration' }
     )
@@ -24,6 +46,7 @@ class TestFixMissingBranch < Jp::Test
     load_it('fix-missing-branch', fb)
     f = fb.query('(eq issue 44)').each.first
     refute_nil(f)
-    assert_nil(f['stale'], '403 is transient — fact must NOT be marked stale; next cycle will retry the issue lookup')
+    assert_nil(f['stale'],
+               '403 is transient — fact must NOT be marked stale; next cycle will retry the pull_request lookup')
   end
 end


### PR DESCRIPTION
This PR fixes a bug in `fix-missing-branch` where `Fbe.octo.issue` was used to fetch pull request data. The REST Issues endpoint (`GET /repos/{owner}/{repo}/issues/{n}`) returns a thin `pull_request` sub-object without `head.ref`, so `json.dig(:pull_request, :head, :ref)` always returned `nil`. Every `pull-was-opened` fact was permanently marked `stale = 'branch'` and the happy-path branch (lines 43-46) was unreachable on real GitHub data.

**Changes:**

- `judges/fix-missing-branch/fix-missing-branch.rb` — replaced `Fbe.octo.issue` with `Fbe.octo.pull_request` and changed the dig path from `:pull_request, :head, :ref` to `:head, :ref`, matching the working pattern in `judges/pull-was-opened/pull-was-opened.rb:60`
- `test/judges/test-fix-missing-branch.rb` — added `test_finds_branch_via_pull_request` (success path with `head.ref` stub) and `test_rescues_forbidden_on_pull_request_lookup`
- `judges/fix-missing-branch/stale-branch.yml` — updated YAML test to match FakeOctokit behavior (always returns `head.ref` from `pull_request`)

This mirrors the same dispatch error pattern already fixed in `fix-missing-who.rb` (#1489) and in `pull-was-opened.rb`.

Closes #1494