### PR TITLE
#1118: Make 8 common workflows reusable via workflow_call

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,75 @@
+# Reusable Workflows
+
+This directory contains GitHub Actions workflows for `zerocracy/judges-action`. Several of these workflows are designed to be **reusable** across other Zerocracy repositories via [`workflow_call`](https://docs.github.com/en/actions/sharing-automations/reusing-workflows).
+
+## Source of Truth
+
+`zerocracy/judges-action` is the **source of truth** for shared CI/CD workflows in the Zerocracy ecosystem. The following workflows are marked as reusable:
+
+| Workflow | Reusable |
+|----------|----------|
+| `actionlint.yml` | ✅ `workflow_call` |
+| `copyrights.yml` | ✅ `workflow_call` |
+| `markdown-lint.yml` | ✅ `workflow_call` |
+| `pdd.yml` | ✅ `workflow_call` |
+| `reuse.yml` | ✅ `workflow_call` |
+| `typos.yml` | ✅ `workflow_call` |
+| `xcop.yml` | ✅ `workflow_call` |
+| `yamllint.yml` | ✅ `workflow_call` |
+
+## How to Use in Another Repository
+
+Replace the local workflow file with a thin wrapper that delegates to judges-action. Example for `copyrights.yml`:
+
+```yaml
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+# SPDX-License-Identifier: MIT
+---
+name: copyrights
+'on':
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+jobs:
+  copyrights:
+    uses: zerocracy/judges-action/.github/workflows/copyrights.yml@master
+```
+
+> **Important:** Pin to a specific commit SHA instead of `@master` for production stability:
+> ```yaml
+> uses: zerocracy/judges-action/.github/workflows/copyrights.yml@<sha>
+> ```
+
+## Repo-Specific Workflows (NOT reusable)
+
+These workflows are specific to `zerocracy/judges-action` and should NOT be referenced from other repos:
+
+- `zerocracy.yml` — the main action runner
+- `up.yml` — version update PR
+- `titles.yml` — AI issue title generation
+- `rake.yml` — Ruby tests
+- `make.yml` — Docker build
+- `bashate.yml`, `checkmake.yml`, `hadolint.yml`, `shellcheck.yml` — infra-specific
+
+## Notes for Migration
+
+### SHA Pinning
+
+`zerocracy/judges-action` pins all third-party actions to exact commit SHAs (e.g., `actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6`). Other repos currently use semver tags (`@v6`). By switching to reusable workflows, all callers inherit SHA-pinned versions — this is **more secure and reproducible**.
+
+### Known Differences Between Repos
+
+| Aspect | judges-action | fbe / pages-action | judges |
+|--------|--------------|-------------------|--------|
+| Action versions | SHA-pinned | Semver tags | Semver tags |
+| Branch filter | `branches: [master]` | Some missing (`copyrights.yml`, `xcop.yml`) | `branches: [master]` |
+| SPDX header | Zerocracy | Zerocracy | Yegor Bugayenko |
+
+### Breaking Changes to Watch For
+
+1. **Branch filter narrowing** — If your repo relies on workflows running on all branches (e.g., `fbe/copyrights.yml` has `push:` without branch filter), switching to reusable workflows will restrict to `master` only
+2. **Config file paths** — `typos.yml` in fbe uses `.github/.typos.toml` while judges-action uses `.github/typos.toml`. Standardize paths before migrating
+3. **SPDX headers** — `yegor256/judges` has `Copyright (c) 2024-2026 Yegor Bugayenko`. This will change when referencing judges-action's workflows

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -10,6 +10,7 @@ name: actionlint
   pull_request:
     branches:
       - master
+  workflow_call:
 jobs:
   actionlint:
     timeout-minutes: 15

--- a/.github/workflows/copyrights.yml
+++ b/.github/workflows/copyrights.yml
@@ -10,6 +10,7 @@ name: copyrights
   pull_request:
     branches:
       - master
+  workflow_call:
 jobs:
   copyrights:
     timeout-minutes: 15

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -5,6 +5,7 @@
 name: markdown-lint
 'on':
   push:
+  workflow_call:
 jobs:
   markdown-lint:
     timeout-minutes: 15

--- a/.github/workflows/pdd.yml
+++ b/.github/workflows/pdd.yml
@@ -10,6 +10,7 @@ name: pdd
   pull_request:
     branches:
       - master
+  workflow_call:
 jobs:
   pdd:
     timeout-minutes: 15

--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -10,6 +10,7 @@ name: reuse
   pull_request:
     branches:
       - master
+  workflow_call:
 jobs:
   reuse:
     timeout-minutes: 15

--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -10,6 +10,7 @@ name: typos
   pull_request:
     branches:
       - master
+  workflow_call:
 jobs:
   typos:
     timeout-minutes: 15

--- a/.github/workflows/xcop.yml
+++ b/.github/workflows/xcop.yml
@@ -10,6 +10,7 @@ name: xcop
   pull_request:
     branches:
       - master
+  workflow_call:
 jobs:
   xcop:
     timeout-minutes: 15

--- a/.github/workflows/yamllint.yml
+++ b/.github/workflows/yamllint.yml
@@ -10,6 +10,7 @@ name: yamllint
   pull_request:
     branches:
       - master
+  workflow_call:
 jobs:
   yamllint:
     timeout-minutes: 15


### PR DESCRIPTION
## Problem

GitHub Actions workflow files are copy-pasted across 4+ Zerocracy repositories (`zerocracy/judges-action`, `zerocracy/fbe`, `yegor256/judges`, `zerocracy/pages-action`). Each repo maintains its own copy of:

- `actionlint.yml`
- `copyrights.yml`
- `markdown-lint.yml`
- `pdd.yml`
- `reuse.yml`
- `typos.yml`
- `xcop.yml`
- `yamllint.yml`

This creates:
- Extra maintenance work — every version bump or config change must be repeated in every repo
- Risk of inconsistencies between repos
- No clear "source of truth" for CI/CD workflows

## Solution

Made `zerocracy/judges-action` the **source of truth** for shared CI/CD workflows by adding `on: workflow_call` to these 8 workflow files. They now support being used as reusable workflows from other repositories while continuing to run on push/PR as before.

### How other repos should migrate

After this PR is merged, the following repos can replace their local copies:

**`zerocracy/fbe`**, **`yegor256/judges`**, **`zerocracy/pages-action`** — for each of the 8 files above:

```yaml
# Instead of maintaining a local copy, use:
name: <name>
'on':
  push:
    branches:
      - master
  pull_request:
    branches:
      - master
jobs:
  <name>:
    uses: zerocracy/judges-action/.github/workflows/<name>.yml@master
```

### Why judges-action?

- It's the core action repo — all other Zerocracy projects depend on it
- It has the most comprehensive workflow collection (17 workflows)
- It's public, so reusable workflows work cross-repo

### Future improvement

When someone with organization admin access creates `zerocracy/.github` (GitHub's organization-level `.github` repo), the shared workflows can be migrated there for automatic availability across all Zerocracy repos.

## Analysis: Cross-Repo Differences

During investigation, I discovered that the supposedly "identical" workflows actually have **significant differences** across repos. This makes the reusable workflow approach even more valuable — it will enforce consistency.

| Aspect | judges-action (ours) | fbe | judges | pages-action |
|--------|-------------------|-----|--------|-------------|
| **Action pinning** | SHA hashes (`@de0fac2e # v6`) | Semver tags (`@v6`) | Semver tags | Semver tags |
| **Branch filter** | Always `branches: [master]` | Missing in `copyrights.yml`, `xcop.yml` | Always `[master]` | Always `[master]` |
| **SPDX header** | `Copyright (c) 2024-2026 Zerocracy` | `Zerocracy` | `Yegor Bugayenko` | `Zerocracy` |
| **typos config path** | `.github/typos.toml` | `.github/.typos.toml` | N/A | — |
| **typos version** | `crate-ci/typos@v1.46.2` | `@v1.47.0` | — | — |

### Breaking Changes to Watch For

1. **SHA pinning** — judges-action pins all actions to exact commit SHAs. Other repos use semver tags. Callers inherit SHA-pinned versions (more secure, but a behavioral change)
2. **Branch filter narrowing** — `fbe/copyrights.yml` and `fbe/xcop.yml` run on ALL branches (no `branches:` filter). Switching to reusable workflows restricts them to `master` only
3. **Config file paths** — typos config path differs between repos (`.github/.typos.toml` vs `.github/typos.toml`)
4. **SPDX headers** — `yegor256/judges` has different copyright holder. This will change when referencing judges-action workflows

These are documented in the newly added `.github/workflows/README.md`.

## Files changed

| File | Change |
|------|--------|
| `.github/workflows/actionlint.yml` | Added `on: workflow_call` |
| `.github/workflows/copyrights.yml` | Added `on: workflow_call` |
| `.github/workflows/markdown-lint.yml` | Added `on: workflow_call` |
| `.github/workflows/pdd.yml` | Added `on: workflow_call` |
| `.github/workflows/reuse.yml` | Added `on: workflow_call` |
| `.github/workflows/typos.yml` | Added `on: workflow_call` |
| `.github/workflows/xcop.yml` | Added `on: workflow_call` |
| `.github/workflows/yamllint.yml` | Added `on: workflow_call` |
| `.github/workflows/README.md` | New — reusable workflow docs |

## Verification

- [x] `yamllint` — no errors
- [x] `bundle exec rubocop` — 0 offenses
- [x] `bundle exec rake test` — 250 tests, 0 failures

Closes #1118