### PR TITLE
#1144: add explicit test assertion for review absence when no reviews exist

### DIFF
--- a/test/judges/test-pull-was-merged.rb
+++ b/test/judges/test-pull-was-merged.rb
@@ -57,6 +57,13 @@ class TestPullWasMerged < Jp::Test
           details: 'Apparently, foo/foo#44 has been "pull-was-closed".'
         )
       )
+      refute_includes(
+        fb.query(
+          "(and (eq what 'pull-was-closed') (eq repository 42) (eq where 'github') (eq issue 44))"
+        ).each.first.all_properties,
+        'review',
+        'review should not be set when no reviews exist'
+      )
     end
   end
 


### PR DESCRIPTION
Closes #1144

## Changes
- Added explicit assertion in `test_pull_was_merged_with_nil_user_in_issue_comments` that verifies `review` property is NOT set when no code reviews exist on the pull request
- The actual fix (fetching reviews and setting `review` on `pull-was-merged` fact) was already implemented in PR #1147 by @Yegorov and merged into master. This PR adds the missing test coverage for the edge case where reviews are absent.

## Verification
- [x] `bundle exec rubocop` — 0 offenses
- [x] `bundle exec ruby -Ilib -Itest test/judges/test-pull-was-merged.rb -- --no-cov` — 0 failures