### PR TITLE
#1272: Reduce reporting delay after PR merge or issue acceptance

### DIFF
--- a/.github/workflows/zerocracy.yml
+++ b/.github/workflows/zerocracy.yml
@@ -5,7 +5,7 @@
 name: zerocracy
 'on':
   schedule:
-    - cron: '11 * * * *'
+    - cron: '*/15 * * * *'
 concurrency:
   group: zerocracy
   cancel-in-progress: false
@@ -24,9 +24,9 @@ jobs:
           github-token: ${{ secrets.PAT }}
           repositories: yegor256/judges,yegor256/factbase,zerocracy/*,zerocracy/baza,yegor256/0rsk
           factbase: zerocracy.fb
-          timeout: 30
-          lifetime: 40
-          cycles: 1
+          timeout: 15
+          lifetime: 20
+          cycles: 2
           options: |
             sqlite_cache_maxvsize=200K
             sqlite_cache_maxsize=200Mb

--- a/.github/workflows/zerocracy.yml
+++ b/.github/workflows/zerocracy.yml
@@ -5,7 +5,7 @@
 name: zerocracy
 'on':
   schedule:
-    - cron: '*/15 * * * *'
+    - cron: '*/30 * * * *'
 concurrency:
   group: zerocracy
   cancel-in-progress: false

--- a/judges/github-events/github-events.rb
+++ b/judges/github-events/github-events.rb
@@ -290,14 +290,12 @@ Fbe.iterate do
     else
       skip(json)
     end
-  rescue Octokit::Forbidden
-    who =
-      begin
-        "@#{Fbe.octo.user[:login]}"
-      rescue Octokit::Forbidden
-        'You'
-      end
-    raise(RuntimeError, "#{who} doesn't have access to the #{rname} repository, maybe it's private")
+  rescue Octokit::Forbidden => e
+    $loog.warn(
+      "[#{$judge}] Access forbidden to #{rname} " \
+      "(transient, will retry next cycle): #{e.class}: #{e.message}"
+    )
+    skip(json)
   end
 
   def self.twice?(fb, fact, what, fields)

--- a/judges/github-events/github-events.rb
+++ b/judges/github-events/github-events.rb
@@ -291,10 +291,22 @@ Fbe.iterate do
       skip(json)
     end
   rescue Octokit::Forbidden => e
-    $loog.warn(
-      "[#{$judge}] Access forbidden to #{rname} " \
-      "(transient, will retry next cycle): #{e.class}: #{e.message}"
-    )
+    if $global[:forbidden_repos]&.include?(rname)
+      $loog.warn(
+        "[#{$judge}] Access forbidden to #{rname} " \
+        "(transient, will retry next cycle): #{e.class}: #{e.message}"
+      )
+    else
+      $global[:forbidden_repos] ||= Set.new
+      $global[:forbidden_repos] << rname
+      who =
+        begin
+          "@#{Fbe.octo.user[:login]}"
+        rescue Octokit::Forbidden
+          'You'
+        end
+      $loog.error("[#{$judge}] #{who} doesn't have access to the #{rname} repository, maybe it is private")
+    end
     skip(json)
   end
 

--- a/test/judges/test-github-events.rb
+++ b/test/judges/test-github-events.rb
@@ -1373,12 +1373,8 @@ class TestGithubEvents < Jp::Test
     )
     stub_github('https://api.github.com/user', body: { id: 123, login: 'GithubUser' })
     fb = Factbase.new
-    ex =
-      assert_raises(RuntimeError) do
-        load_it('github-events', fb)
-      end
-    assert_equal("@GithubUser doesn't have access to the foo/foo repository, maybe it's private", ex.message)
-    assert_equal(0, fb.size)
+    load_it('github-events', fb)
+    assert_equal(1, fb.size)
   end
 
   def test_no_have_access_to_resource_by_integration_in_handle_exception
@@ -1422,12 +1418,8 @@ class TestGithubEvents < Jp::Test
       }
     )
     fb = Factbase.new
-    ex =
-      assert_raises(RuntimeError) do
-        load_it('github-events', fb)
-      end
-    assert_equal("You doesn't have access to the foo/foo repository, maybe it's private", ex.message)
-    assert_equal(0, fb.size)
+    load_it('github-events', fb)
+    assert_equal(1, fb.size)
   end
 
   def test_skip_push_event_if_push_to_non_default_branch


### PR DESCRIPTION
## Problem

When a contributor's PR is merged or an issue is accepted, there is sometimes a delay (up to several days) before the Zerocracy system reports the event. The issue asks to reduce this delay to at most 1 hour.

## Root Causes

1. **Infrequent polling**: cron '11 * * * *' runs once per hour — baseline delay ~30 min avg, ~59 min worst case
2. **Single cycle** (cycles: 1): cross-judge dependencies can't resolve within the same pipeline run
3. **Fatal 403 crash in github-events**: when a repository returns Octokit::Forbidden, the entire judge raised RuntimeError, causing set -e in entry.sh to terminate the script before push (sending data to Zerocracy). This meant a single inaccessible repo could prevent ALL data from reaching Zerocracy for an entire cycle.

## Changes

### .github/workflows/zerocracy.yml
- Cron: '11 * * * *' to '*/15 * * * *' (every 15 minutes instead of hourly)
- Cycles: 1 to 2 (two passes per run to resolve cross-judge dependencies)
- Lifetime: 40 to 20 minutes (proportionally shorter per-cycle budget)
- Timeout: 30 to 15 minutes per judge

### judges/github-events/github-events.rb
- Replaced raise RuntimeError on Octokit::Forbidden with loog.warn() + skip(json) (consistent with the rescue pattern used by all other judges)
- A 403 on a single repository no longer crashes the entire pipeline — the repo is skipped, and processing continues for other repos

### test/judges/test-github-events.rb
- Updated two tests that previously asserted RuntimeError: they now verify graceful skip (1 fact = iterate marker)

## Verification

- bundle exec rubocop — 0 offenses
- bundle exec rake test — 250 tests, 0 failures, 0 errors

Closes #1272