### PR TITLE
#1496 rescue Octokit errors around list_issues in find-latest/earliest-issue judges

### DIFF
--- a/judges/find-earliest-issue/find-earliest-issue.rb
+++ b/judges/find-earliest-issue/find-earliest-issue.rb
@@ -20,8 +20,19 @@ Fbe.iterate do
     next latest if latest.positive?
     repo = Fbe.octo.repo_name_by_id(repository)
     json =
-      Fbe.octo.with_disable_auto_paginate do |octo|
-        octo.list_issues(repo, state: :all, sort: :created, direction: :asc, page: 1, per_page: 1).first
+      begin
+        Fbe.octo.with_disable_auto_paginate do |octo|
+          octo.list_issues(repo, state: :all, sort: :created, direction: :asc, page: 1, per_page: 1).first
+        end
+      rescue Octokit::NotFound, Octokit::Deprecated => e
+        $loog.info("Issues list not available for #{repo}: #{e.message}")
+        next latest
+      rescue Octokit::Forbidden => e
+        $loog.warn(
+          "[#{$judge}] Access forbidden to issues list for #{repo} " \
+          "(transient, will retry next cycle): #{e.class}: #{e.message}"
+        )
+        next latest
       end
     next latest if json.nil?
     i = json[:number]

--- a/judges/find-latest-issue/find-latest-issue.rb
+++ b/judges/find-latest-issue/find-latest-issue.rb
@@ -20,8 +20,19 @@ Fbe.iterate do
     next latest if latest.positive?
     repo = Fbe.octo.repo_name_by_id(repository)
     json =
-      Fbe.octo.with_disable_auto_paginate do |octo|
-        octo.list_issues(repo, state: :all, sort: :created, direction: :desc, page: 1, per_page: 1).first
+      begin
+        Fbe.octo.with_disable_auto_paginate do |octo|
+          octo.list_issues(repo, state: :all, sort: :created, direction: :desc, page: 1, per_page: 1).first
+        end
+      rescue Octokit::NotFound, Octokit::Deprecated => e
+        $loog.info("Issues list not available for #{repo}: #{e.message}")
+        next latest
+      rescue Octokit::Forbidden => e
+        $loog.warn(
+          "[#{$judge}] Access forbidden to issues list for #{repo} " \
+          "(transient, will retry next cycle): #{e.class}: #{e.message}"
+        )
+        next latest
       end
     next latest if json.nil?
     i = json[:number]

--- a/test/judges/test-find-earliest-issue.rb
+++ b/test/judges/test-find-earliest-issue.rb
@@ -160,6 +160,36 @@ class TestFindEarliestIssue < Jp::Test
     )
   end
 
+  def test_rescues_not_found_on_list_issues
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repos/foo/foo', body: { id: 42, name: 'foo', full_name: 'foo/foo' })
+    stub_github('https://api.github.com/repositories/42', body: { id: 42, name: 'foo', full_name: 'foo/foo' })
+    stub_github(
+      'https://api.github.com/repos/foo/foo/issues?direction=asc&page=1&per_page=1&sort=created&state=all',
+      status: 404,
+      body: { message: 'Not Found' }
+    )
+    fb = Factbase.new
+    load_it('find-earliest-issue', fb)
+    assert_equal(0, fb.all.size, 'no facts must be written when list_issues 404s')
+  end
+
+  def test_rescues_forbidden_on_list_issues
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repos/foo/foo', body: { id: 42, name: 'foo', full_name: 'foo/foo' })
+    stub_github('https://api.github.com/repositories/42', body: { id: 42, name: 'foo', full_name: 'foo/foo' })
+    stub_github(
+      'https://api.github.com/repos/foo/foo/issues?direction=asc&page=1&per_page=1&sort=created&state=all',
+      status: 403,
+      body: { message: 'Resource not accessible by integration' }
+    )
+    fb = Factbase.new
+    load_it('find-earliest-issue', fb)
+    assert_equal(0, fb.all.size, 'no facts must be written when list_issues 403s — next cycle will retry')
+  end
+
   def test_rescues_forbidden_on_pull_request_lookup
     WebMock.disable_net_connect!
     rate_limit_up

--- a/test/judges/test-find-latest-issue.rb
+++ b/test/judges/test-find-latest-issue.rb
@@ -204,6 +204,36 @@ class TestFindLatestIssue < Jp::Test
     )
   end
 
+  def test_rescues_not_found_on_list_issues
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repos/foo/foo', body: { id: 42, name: 'foo', full_name: 'foo/foo' })
+    stub_github('https://api.github.com/repositories/42', body: { id: 42, name: 'foo', full_name: 'foo/foo' })
+    stub_github(
+      'https://api.github.com/repos/foo/foo/issues?direction=desc&page=1&per_page=1&sort=created&state=all',
+      status: 404,
+      body: { message: 'Not Found' }
+    )
+    fb = Factbase.new
+    load_it('find-latest-issue', fb)
+    assert_equal(0, fb.all.size, 'no facts must be written when list_issues 404s')
+  end
+
+  def test_rescues_forbidden_on_list_issues
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repos/foo/foo', body: { id: 42, name: 'foo', full_name: 'foo/foo' })
+    stub_github('https://api.github.com/repositories/42', body: { id: 42, name: 'foo', full_name: 'foo/foo' })
+    stub_github(
+      'https://api.github.com/repos/foo/foo/issues?direction=desc&page=1&per_page=1&sort=created&state=all',
+      status: 403,
+      body: { message: 'Resource not accessible by integration' }
+    )
+    fb = Factbase.new
+    load_it('find-latest-issue', fb)
+    assert_equal(0, fb.all.size, 'no facts must be written when list_issues 403s — next cycle will retry')
+  end
+
   def test_rescues_forbidden_on_pull_request_lookup
     WebMock.disable_net_connect!
     rate_limit_up


### PR DESCRIPTION
Closes #1496.

Wraps the two `Fbe.octo.with_disable_auto_paginate { octo.list_issues(...) }` blocks at `judges/find-latest-issue/find-latest-issue.rb:22-25` and `judges/find-earliest-issue/find-earliest-issue.rb:22-25` in the canonical two-branch rescue. `Octokit::NotFound`/`Octokit::Deprecated` logs `info` and skips the repo with `next latest`; `Octokit::Forbidden` logs `warn` with the "transient, will retry next cycle" wording used by sibling rescues in `lib/pull_request.rb` and `judges/code-was-reviewed/code-was-reviewed.rb`. Both `next latest` paths match the existing `next latest if json.nil?` line on the next line of each file, so the iteration cursor advances cleanly to the next repo instead of aborting the cycle.

Verified locally with `bundle exec ruby -Ilib -Itest test/judges/test-find-latest-issue.rb` (10 tests, 17 assertions, 0 failures) and the same against `test/judges/test-find-earliest-issue.rb`; `rubocop --force-exclusion` clean on all four touched files. The four new tests (`test_rescues_not_found_on_list_issues` and `test_rescues_forbidden_on_list_issues` in each test file) stub a 404 and a 403 on the `issues?direction=…` endpoint and assert `fb.all.size == 0`, proving no spurious facts are written and the cycle does not raise.
