### PR TITLE
#1496 Rescue Octokit errors in list_issues for find-latest-issue and find-earliest-issue

### DIFF
--- a/judges/find-earliest-issue/find-earliest-issue.rb
+++ b/judges/find-earliest-issue/find-earliest-issue.rb
@@ -20,8 +20,19 @@ Fbe.iterate do
     next latest if latest.positive?
     repo = Fbe.octo.repo_name_by_id(repository)
     json =
-      Fbe.octo.with_disable_auto_paginate do |octo|
-        octo.list_issues(repo, state: :all, sort: :created, direction: :asc, page: 1, per_page: 1).first
+      begin
+        Fbe.octo.with_disable_auto_paginate do |octo|
+          octo.list_issues(repo, state: :all, sort: :created, direction: :asc, page: 1, per_page: 1).first
+        end
+      rescue Octokit::NotFound, Octokit::Deprecated => e
+        $loog.info("Issues not found for #{repo}: #{e.message}")
+        next latest
+      rescue Octokit::Forbidden => e
+        $loog.warn(
+          "[#{$judge}] Access forbidden to issues in #{repo} " \
+          "(transient, will retry next cycle): #{e.class}: #{e.message}"
+        )
+        next latest
       end
     next latest if json.nil?
     i = json[:number]

--- a/judges/find-latest-issue/find-latest-issue.rb
+++ b/judges/find-latest-issue/find-latest-issue.rb
@@ -20,8 +20,19 @@ Fbe.iterate do
     next latest if latest.positive?
     repo = Fbe.octo.repo_name_by_id(repository)
     json =
-      Fbe.octo.with_disable_auto_paginate do |octo|
-        octo.list_issues(repo, state: :all, sort: :created, direction: :desc, page: 1, per_page: 1).first
+      begin
+        Fbe.octo.with_disable_auto_paginate do |octo|
+          octo.list_issues(repo, state: :all, sort: :created, direction: :desc, page: 1, per_page: 1).first
+        end
+      rescue Octokit::NotFound, Octokit::Deprecated => e
+        $loog.info("Issues not found for #{repo}: #{e.message}")
+        next latest
+      rescue Octokit::Forbidden => e
+        $loog.warn(
+          "[#{$judge}] Access forbidden to issues in #{repo} " \
+          "(transient, will retry next cycle): #{e.class}: #{e.message}"
+        )
+        next latest
       end
     next latest if json.nil?
     i = json[:number]

--- a/test/judges/test-find-earliest-issue.rb
+++ b/test/judges/test-find-earliest-issue.rb
@@ -160,6 +160,36 @@ class TestFindEarliestIssue < Jp::Test
     )
   end
 
+  def test_rescues_not_found_on_list_issues
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repos/foo/foo', body: { id: 42, name: 'foo', full_name: 'foo/foo' })
+    stub_github('https://api.github.com/repositories/42', body: { id: 42, name: 'foo', full_name: 'foo/foo' })
+    stub_github(
+      'https://api.github.com/repos/foo/foo/issues?direction=asc&page=1&per_page=1&sort=created&state=all',
+      status: 404,
+      body: { message: 'Not Found' }
+    )
+    fb = Factbase.new
+    load_it('find-earliest-issue', fb)
+    assert_equal(0, fb.all.size)
+  end
+
+  def test_rescues_forbidden_on_list_issues
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repos/foo/foo', body: { id: 42, name: 'foo', full_name: 'foo/foo' })
+    stub_github('https://api.github.com/repositories/42', body: { id: 42, name: 'foo', full_name: 'foo/foo' })
+    stub_github(
+      'https://api.github.com/repos/foo/foo/issues?direction=asc&page=1&per_page=1&sort=created&state=all',
+      status: 403,
+      body: { message: 'Resource not accessible by integration' }
+    )
+    fb = Factbase.new
+    load_it('find-earliest-issue', fb)
+    assert_equal(0, fb.all.size)
+  end
+
   def test_rescues_forbidden_on_pull_request_lookup
     WebMock.disable_net_connect!
     rate_limit_up

--- a/test/judges/test-find-latest-issue.rb
+++ b/test/judges/test-find-latest-issue.rb
@@ -204,6 +204,36 @@ class TestFindLatestIssue < Jp::Test
     )
   end
 
+  def test_rescues_not_found_on_list_issues
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repos/foo/foo', body: { id: 42, name: 'foo', full_name: 'foo/foo' })
+    stub_github('https://api.github.com/repositories/42', body: { id: 42, name: 'foo', full_name: 'foo/foo' })
+    stub_github(
+      'https://api.github.com/repos/foo/foo/issues?direction=desc&page=1&per_page=1&sort=created&state=all',
+      status: 404,
+      body: { message: 'Not Found' }
+    )
+    fb = Factbase.new
+    load_it('find-latest-issue', fb)
+    assert_equal(0, fb.all.size)
+  end
+
+  def test_rescues_forbidden_on_list_issues
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repos/foo/foo', body: { id: 42, name: 'foo', full_name: 'foo/foo' })
+    stub_github('https://api.github.com/repositories/42', body: { id: 42, name: 'foo', full_name: 'foo/foo' })
+    stub_github(
+      'https://api.github.com/repos/foo/foo/issues?direction=desc&page=1&per_page=1&sort=created&state=all',
+      status: 403,
+      body: { message: 'Resource not accessible by integration' }
+    )
+    fb = Factbase.new
+    load_it('find-latest-issue', fb)
+    assert_equal(0, fb.all.size)
+  end
+
   def test_rescues_forbidden_on_pull_request_lookup
     WebMock.disable_net_connect!
     rate_limit_up


### PR DESCRIPTION
## Problem

`find-latest-issue.rb:22-26` and `find-earliest-issue.rb:22-26` call `octo.list_issues(...)` inside `Fbe.octo.with_disable_auto_paginate` with no rescue block. Every subsequent Octokit call in these files (the `pull_request` lookup) is wrapped in the canonical two-branch rescue. An `Octokit::NotFound`, `Octokit::Deprecated`, or `Octokit::Forbidden` on this call aborts the judge for every repository in the batch.

## Changes

### `judges/find-latest-issue/find-latest-issue.rb`
- Wrapped the `with_disable_auto_paginate` block in the canonical two-branch rescue
- `NotFound/Deprecated` → info log, `next latest`
- `Forbidden` → warn log with retry message, `next latest`

### `judges/find-earliest-issue/find-earliest-issue.rb`
- Same fix

### Tests
- `test_rescues_not_found_on_list_issues` — 404 on issues endpoint (in both test files)
- `test_rescues_forbidden_on_list_issues` — 403 on issues endpoint (in both test files)

## Verification
- `bundle exec rubocop` — 0 offenses
- `bundle exec rake test` — 254 tests, 0 failures, 0 errors

Closes #1496