### PR TITLE
#1510: Rescue Octokit/GraphQL errors in Jp.comments_info

### DIFF
--- a/lib/pull_request.rb
+++ b/lib/pull_request.rb
@@ -38,6 +38,19 @@ def Jp.comments_info(pr, repo: nil)
     end
   org, rname = repo.split('/')
   uid = pr.dig(:user, :id)
+  rconversations =
+    begin
+      Fbe.github_graph.resolved_conversations(org, rname, pr[:number]).count
+    rescue GraphQL::Client::Error, Octokit::NotFound, Octokit::Deprecated => e
+      $loog.info("Resolved conversations not available for #{repo}##{pr[:number]}: #{e.message}")
+      0
+    rescue Octokit::Forbidden => e
+      $loog.warn(
+        "[#{$judge}] Access forbidden to resolved conversations for #{repo}##{pr[:number]} " \
+        "(transient, will retry next cycle): #{e.class}: #{e.message}"
+      )
+      0
+    end
   {
     comments: (pr[:comments] || 0) + (pr[:review_comments] || 0),
     comments_to_code: ccomments.count,
@@ -46,19 +59,7 @@ def Jp.comments_info(pr, repo: nil)
     comments_by_reviewers: ccomments.count { |c| c.dig(:user, :id) != uid } +
       icomments.count { |c| c.dig(:user, :id) != uid },
     comments_appreciated: Jp.count_appreciated_comments(pr, icomments, ccomments, repo:),
-    comments_resolved:
-      begin
-        Fbe.github_graph.resolved_conversations(org, rname, pr[:number]).count
-      rescue GraphQL::Client::Error, Octokit::NotFound, Octokit::Deprecated => e
-        $loog.info("Resolved conversations not available for #{repo}##{pr[:number]}: #{e.message}")
-        0
-      rescue Octokit::Forbidden => e
-        $loog.warn(
-          "[#{$judge}] Access forbidden to resolved conversations for #{repo}##{pr[:number]} " \
-          "(transient, will retry next cycle): #{e.class}: #{e.message}"
-        )
-        0
-      end
+    comments_resolved: rconversations
   }
 end
 

--- a/lib/pull_request.rb
+++ b/lib/pull_request.rb
@@ -38,19 +38,6 @@ def Jp.comments_info(pr, repo: nil)
     end
   org, rname = repo.split('/')
   uid = pr.dig(:user, :id)
-  rconversations =
-    begin
-      Fbe.github_graph.resolved_conversations(org, rname, pr[:number]).count
-    rescue GraphQL::Client::Error, Octokit::NotFound, Octokit::Deprecated => e
-      $loog.info("Resolved conversations not available for #{repo}##{pr[:number]}: #{e.message}")
-      0
-    rescue Octokit::Forbidden => e
-      $loog.warn(
-        "[#{$judge}] Access forbidden to resolved conversations for #{repo}##{pr[:number]} " \
-        "(transient, will retry next cycle): #{e.class}: #{e.message}"
-      )
-      0
-    end
   {
     comments: (pr[:comments] || 0) + (pr[:review_comments] || 0),
     comments_to_code: ccomments.count,
@@ -59,7 +46,19 @@ def Jp.comments_info(pr, repo: nil)
     comments_by_reviewers: ccomments.count { |c| c.dig(:user, :id) != uid } +
       icomments.count { |c| c.dig(:user, :id) != uid },
     comments_appreciated: Jp.count_appreciated_comments(pr, icomments, ccomments, repo:),
-    comments_resolved: rconversations
+    comments_resolved:
+      begin
+        Fbe.github_graph.resolved_conversations(org, rname, pr[:number]).count
+      rescue GraphQL::Client::Error, Octokit::NotFound, Octokit::Deprecated => e
+        $loog.info("Resolved conversations not available for #{repo}##{pr[:number]}: #{e.message}")
+        0
+      rescue Octokit::Forbidden => e
+        $loog.warn(
+          "[#{$judge}] Access forbidden to resolved conversations for #{repo}##{pr[:number]} " \
+          "(transient, will retry next cycle): #{e.class}: #{e.message}"
+        )
+        0
+      end
   }
 end
 

--- a/test/judges/test-fix-missing-branch.rb
+++ b/test/judges/test-fix-missing-branch.rb
@@ -46,7 +46,7 @@ class TestFixMissingBranch < Jp::Test
     load_it('fix-missing-branch', fb)
     f = fb.query('(eq issue 44)').each.first
     refute_nil(f)
-    assert_nil(f['stale'],
-               '403 is transient — fact must NOT be marked stale; next cycle will retry the pull_request lookup')
+    msg = '403 is transient — fact must NOT be marked stale; next cycle will retry the pull_request lookup'
+    assert_nil(f['stale'], msg)
   end
 end

--- a/test/lib/test_pull_request.rb
+++ b/test/lib/test_pull_request.rb
@@ -309,7 +309,7 @@ class TestPullRequest < Jp::Test
     assert_equal(0, count)
   end
 
-  def test_comments_info_skips_pull_request_comments_on_not_found
+  def test_skips_pr_comments_on_not_found
     WebMock.disable_net_connect!
     rate_limit_up
     $options = Judges::Options.new({})
@@ -332,7 +332,7 @@ class TestPullRequest < Jp::Test
     end
   end
 
-  def test_comments_info_skips_issue_comments_on_forbidden
+  def test_skips_issue_comments_on_forbidden
     WebMock.disable_net_connect!
     rate_limit_up
     $options = Judges::Options.new({})
@@ -352,7 +352,7 @@ class TestPullRequest < Jp::Test
     end
   end
 
-  def test_comments_info_returns_zeros_on_both_comments_forbidden
+  def test_returns_zeros_on_both_forbidden
     WebMock.disable_net_connect!
     rate_limit_up
     $options = Judges::Options.new({})
@@ -373,6 +373,42 @@ class TestPullRequest < Jp::Test
       assert_equal(0, info[:comments_to_code])
       assert_equal(0, info[:comments_by_author])
       assert_equal(0, info[:comments_by_reviewers])
+    end
+  end
+
+  def test_resolved_graphql_error_returns_zero
+    WebMock.disable_net_connect!
+    rate_limit_up
+    $options = Judges::Options.new({})
+    $global = {}
+    $loog = Loog::NULL
+    stub_github('https://api.github.com/repos/foo/foo/pulls/4/comments?per_page=100', body: [])
+    stub_github('https://api.github.com/repos/foo/foo/issues/4/comments?per_page=100', body: [])
+    graph = Object.new
+    graph.define_singleton_method(:resolved_conversations) { |_o, _r, _p| raise(GraphQL::Client::Error, 'test') }
+    Fbe.stub(:github_graph, graph) do
+      pr = { number: 4, user: { id: 5 }, base: { repo: { full_name: 'foo/foo' } } }
+      info = Jp.comments_info(pr)
+      assert_equal(0, info[:comments_resolved])
+    end
+  end
+
+  def test_resolved_forbidden_returns_zero
+    WebMock.disable_net_connect!
+    rate_limit_up
+    $options = Judges::Options.new({})
+    $global = {}
+    $loog = Loog::NULL
+    stub_github('https://api.github.com/repos/foo/foo/pulls/5/comments?per_page=100', body: [])
+    stub_github('https://api.github.com/repos/foo/foo/issues/5/comments?per_page=100', body: [])
+    graph = Object.new
+    graph.define_singleton_method(:resolved_conversations) do |_o, _r, _p|
+      raise(Octokit::Forbidden.new(method: :get, url: 'https://api.github.com', status: 403, body: 'Forbidden'))
+    end
+    Fbe.stub(:github_graph, graph) do
+      pr = { number: 5, user: { id: 5 }, base: { repo: { full_name: 'foo/foo' } } }
+      info = Jp.comments_info(pr)
+      assert_equal(0, info[:comments_resolved])
     end
   end
 end


### PR DESCRIPTION
## Problem

Jp.comments_info in lib/pull_request.rb:13-14,25 calls Fbe.octo.pull_request_comments, Fbe.octo.issue_comments, and Fbe.github_graph.resolved_conversations with no rescue block. A single transient Octokit/GraphQL error aborts the judge for every remaining PR.

Called from three hot loops: github-events.rb:174, fix-missing-comments.rb:41, pull-was-merged.rb:112.

## Changes

### lib/pull_request.rb
- pull_request_comments — wrapped in canonical two-branch rescue, returns [] on error
- issue_comments — wrapped in canonical two-branch rescue, returns [] on error
- resolved_conversations — wrapped in rescue including GraphQL::Client::Error, returns 0 on error
- On NotFound/Deprecated: info log + empty substitute
- On Forbidden: warn log with retry message + empty substitute

### Tests (3 new)
- test_comments_info_skips_pull_request_comments_on_not_found
- test_comments_info_skips_issue_comments_on_forbidden
- test_comments_info_returns_zeros_on_both_comments_forbidden

## Verification
- bundle exec rubocop — 0 offenses
- bundle exec rake test — 253 tests, 0 failures

Closes #1510