### PR TITLE
#1512: Guard transient errors in release count aggregation

### DIFF
--- a/judges/quantity-of-deliverables/total_releases_published.rb
+++ b/judges/quantity-of-deliverables/total_releases_published.rb
@@ -10,13 +10,13 @@ require 'net/http'
 require 'octokit'
 
 def total_releases_published(fact)
-  total =
-    Fbe.unmask_repos.sum do |repo|
+  {
+    total_releases_published: Fbe.unmask_repos.sum do |repo|
       owner, name = repo.split('/')
       begin
         Fbe.github_graph.total_releases_published(owner, name, fact.since)['releases']
       rescue GraphQL::Client::Error, Octokit::Forbidden, Net::OpenTimeout, Net::ReadTimeout,
-             SocketError, Errno::ECONNRESET, Errno::ETIMEDOUT => e
+        SocketError, Errno::ECONNRESET, Errno::ETIMEDOUT => e
         $loog.warn(
           "[#{$judge}] Can't count released projects in #{repo} " \
           "(transient, will retry next cycle): #{e.class}: #{e.message}"
@@ -24,5 +24,5 @@ def total_releases_published(fact)
         next 0
       end
     end
-  { total_releases_published: total }
+  }
 end

--- a/judges/quantity-of-deliverables/total_releases_published.rb
+++ b/judges/quantity-of-deliverables/total_releases_published.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-require 'fbe/github_graph'
 # SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
 # SPDX-License-Identifier: MIT
 
+require 'fbe/github_graph'
 require 'fbe/octo'
 require 'fbe/unmask_repos'
 require 'net/http'

--- a/judges/quantity-of-deliverables/total_releases_published.rb
+++ b/judges/quantity-of-deliverables/total_releases_published.rb
@@ -1,17 +1,28 @@
 # frozen_string_literal: true
 
+require 'fbe/github_graph'
 # SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
 # SPDX-License-Identifier: MIT
 
 require 'fbe/octo'
 require 'fbe/unmask_repos'
+require 'net/http'
+require 'octokit'
 
 def total_releases_published(fact)
-  {
-    total_releases_published:
-      Fbe.unmask_repos.sum do |repo|
-        owner, name = repo.split('/')
+  total =
+    Fbe.unmask_repos.sum do |repo|
+      owner, name = repo.split('/')
+      begin
         Fbe.github_graph.total_releases_published(owner, name, fact.since)['releases']
+      rescue GraphQL::Client::Error, Octokit::Forbidden, Net::OpenTimeout, Net::ReadTimeout,
+             SocketError, Errno::ECONNRESET, Errno::ETIMEDOUT => e
+        $loog.warn(
+          "[#{$judge}] Can't count released projects in #{repo} " \
+          "(transient, will retry next cycle): #{e.class}: #{e.message}"
+        )
+        next 0
       end
-  }
+    end
+  { total_releases_published: total }
 end

--- a/test/judges/test-quantity-of-deliverables.rb
+++ b/test/judges/test-quantity-of-deliverables.rb
@@ -190,7 +190,85 @@ class TestQuantityOfDeliverables < Jp::Test
     end
   end
 
+  def test_total_releases_published_skips_transient_graph_failures
+    WebMock.disable_net_connect!
+    graph = Object.new
+    graph.define_singleton_method(:total_releases_published) do |_owner, name, _since|
+      raise(Net::OpenTimeout, 'timeout') if name == 'bad'
+      { 'releases' => name.length }
+    end
+    unmask =
+      lambda do |&block|
+        repos = ['foo/bad', 'foo/good']
+        if block
+          repos.each { |repo| block.call(repo) }
+        else
+          repos
+        end
+      end
+    fact = Object.new
+    fact.define_singleton_method(:since) { Time.parse('2025-10-01 00:00:00 UTC') }
+    $global = {}
+    $judge = 'quantity-of-deliverables'
+    $loog = Loog::NULL
+    Fbe.stub(:unmask_repos, unmask) do
+      Fbe.stub(:github_graph, graph) do
+        load(File.join(__dir__, '../../judges/quantity-of-deliverables/total_releases_published.rb'))
+        assert_equal({ total_releases_published: 4 }, total_releases_published(fact))
+      end
+    end
+  end
+
+  def test_total_releases_published_keeps_code_errors_visible
+    WebMock.disable_net_connect!
+    graph = Object.new
+    graph.define_singleton_method(:total_releases_published) do |_owner, _name, _since|
+      raise(NoMethodError, 'unexpected')
+    end
+    fact = Object.new
+    fact.define_singleton_method(:since) { Time.parse('2025-10-01 00:00:00 UTC') }
+    unmask = proc { |&block| block.call('foo/bad') }
+    $global = {}
+    $judge = 'quantity-of-deliverables'
+    $loog = Loog::NULL
+    Fbe.stub(:unmask_repos, unmask) do
+      Fbe.stub(:github_graph, graph) do
+        load(File.join(__dir__, '../../judges/quantity-of-deliverables/total_releases_published.rb'))
+        assert_raises(NoMethodError) { total_releases_published(fact) }
+      end
+    end
+  end
+
   def test_total_releases_published
+    WebMock.disable_net_connect!
+    stub_request(:get, 'https://api.github.com/rate_limit').to_return(
+      { body: '{"rate":{"remaining":222}}', headers: { 'X-RateLimit-Remaining' => '222' } }
+    )
+    stub_github(
+      'https://api.github.com/repos/foo/foo',
+      body: { id: 42, full_name: 'foo/foo', open_issues: 0, size: 100 }
+    )
+    stub_github(
+      'https://api.github.com/repos/foo/foo/actions/runs?created=2024-08-02..2024-08-09&per_page=1',
+      body: { total_count: 0, workflow_runs: [] }
+    )
+    fb = Factbase.new
+    f = fb.insert
+    f.what = 'pmp'
+    f.area = 'scope'
+    f.qod_days = 7
+    Fbe.stub(:github_graph, Fbe::Graph::Fake.new) do
+      Time.stub(:now, Time.parse('2024-08-09 21:00:00 UTC')) do
+        load_it('quantity-of-deliverables', fb)
+        f = fb.query('(eq what "quantity-of-deliverables")').each.first
+        assert_equal(Time.parse('2024-08-03 00:00:00 +03:00'), f.since)
+        assert_equal(Time.parse('2024-08-09 21:00:00 UTC'), f.when)
+        assert_equal(7, f.total_releases_published)
+      end
+    end
+  end
+
+  def test_quantity_of_deliverables_total_releases_published
     WebMock.disable_net_connect!
     stub_request(:get, 'https://api.github.com/rate_limit').to_return(
       { body: '{"rate":{"remaining":222}}', headers: { 'X-RateLimit-Remaining' => '222' } }

--- a/test/judges/test-quantity-of-deliverables.rb
+++ b/test/judges/test-quantity-of-deliverables.rb
@@ -190,7 +190,7 @@ class TestQuantityOfDeliverables < Jp::Test
     end
   end
 
-  def test_total_releases_published_skips_transient_graph_failures
+  def test_releases_published_skips_graph_failures
     WebMock.disable_net_connect!
     graph = Object.new
     graph.define_singleton_method(:total_releases_published) do |_owner, name, _since|
@@ -219,7 +219,7 @@ class TestQuantityOfDeliverables < Jp::Test
     end
   end
 
-  def test_total_releases_published_keeps_code_errors_visible
+  def test_releases_published_keeps_code_errors
     WebMock.disable_net_connect!
     graph = Object.new
     graph.define_singleton_method(:total_releases_published) do |_owner, _name, _since|
@@ -268,7 +268,7 @@ class TestQuantityOfDeliverables < Jp::Test
     end
   end
 
-  def test_quantity_of_deliverables_total_releases_published
+  def test_deliverables_total_releases
     WebMock.disable_net_connect!
     stub_request(:get, 'https://api.github.com/rate_limit').to_return(
       { body: '{"rate":{"remaining":222}}', headers: { 'X-RateLimit-Remaining' => '222' } }


### PR DESCRIPTION
/claim #1512
Fixes #1512

## Summary
Add the same transient-GraphQL rescue handling used in `total_commits_pushed.rb` to `judges/quantity-of-deliverables/total_releases_published.rb`.

This change wraps the `Fbe.github_graph.total_releases_published(...)` call in a `rescue` for transient and network/authorization errors, logs with the established pattern, and continues to the next repository so one failing repo does not abort the entire pass.

## Validation
- `MISE_JOBS=1 mise exec ruby@4.0.5 -- bundle exec ruby -Itest -I. test/judges/test-quantity-of-deliverables.rb`
  - Result: 15 tests, 27 assertions, 0 failures, 0 errors, 0 skips
- `MISE_JOBS=1 mise exec ruby@4.0.5 -- bundle exec rubocop judges/quantity-of-deliverables/total_releases_published.rb test/judges/test-quantity-of-deliverables.rb`
  - Result: 2 files inspected, no offenses detected

## Changes
- `judges/quantity-of-deliverables/total_releases_published.rb`
  - Added rescue for `GraphQL::Client::Error`, `Octokit::Forbidden`, `Net::OpenTimeout`, `Net::ReadTimeout`, `SocketError`, `Errno::ECONNRESET`, `Errno::ETIMEDOUT`
  - Logged transient failure with existing format and continued with `next 0`
- `test/judges/test-quantity-of-deliverables.rb`
  - Added tests covering transient GraphQL timeout and unexpected code errors.

## No Secrets
No API keys, credentials, tokens, or secrets were used in this PR.
