### PR TITLE
#1505: drop stale write on transient Octokit::Forbidden in is-human-or-robot

### DIFF
--- a/judges/is-human-or-robot/is-human-or-robot.rb
+++ b/judges/is-human-or-robot/is-human-or-robot.rb
@@ -27,8 +27,10 @@ Fbe.consider(
       f.stale = 'who'
       next
     rescue Octokit::Forbidden => e
-      $loog.warn("[#{$judge}] GitHub user ##{f.who} is not accessible: #{e.class}: #{e.message}")
-      f.stale = 'who'
+      $loog.warn(
+        "[#{$judge}] GitHub user ##{f.who} is not accessible " \
+        "(transient, will retry next cycle): #{e.class}: #{e.message}"
+      )
       next
     end
   type = json[:type]

--- a/test/judges/test-is-human-or-robot.rb
+++ b/test/judges/test-is-human-or-robot.rb
@@ -63,7 +63,7 @@ class TestIsHumanOrRobot < Jp::Test
     assert(fb.one?(where: 'github', who: 18, name: 'user4', is_human: 1))
   end
 
-  def test_marks_fact_stale_on_forbidden_user_lookup
+  def test_forbidden_user_lookup_leaves_fact_retriable
     WebMock.disable_net_connect!
     rate_limit_up
     stub_github(
@@ -76,7 +76,16 @@ class TestIsHumanOrRobot < Jp::Test
     load_it('is-human-or-robot', fb)
     fact = fb.query('(eq who 29139614)').each.first
     refute_nil(fact)
-    assert_equal('who', fact.stale, 'fact should be stale when GitHub user lookup returns 403')
+    assert_equal(
+      "Can't find 'stale' attribute out of [_id, what, repository, issue, who, where]",
+      assert_raises(RuntimeError) { fact.stale }.message,
+      'fact should not be marked stale on transient 403 so the next cycle can retry'
+    )
+    assert_equal(
+      "Can't find 'is_human' attribute out of [_id, what, repository, issue, who, where]",
+      assert_raises(RuntimeError) { fact.is_human }.message,
+      'is_human should remain absent when the 403 prevented classification'
+    )
   end
 
   def test_forbidden_user_does_not_abort_others
@@ -100,7 +109,13 @@ class TestIsHumanOrRobot < Jp::Test
     ids = classified.map(&:who)
     ids.sort!
     assert_equal([100, 300], ids, 'classified facts should be the two non-403 users')
-    assert_equal(1, staled.size, 'the 403 user should be marked stale')
-    assert_equal([200], staled.map(&:who), 'staled fact should be the 403 user')
+    assert_equal(0, staled.size, 'the 403 user must not be marked stale so the next cycle can retry')
+    forbidden = fb.query('(eq who 200)').each.first
+    refute_nil(forbidden)
+    assert_equal(
+      "Can't find 'is_human' attribute out of [_id, what, who, where]",
+      assert_raises(RuntimeError) { forbidden.is_human }.message,
+      'the 403 user should remain unclassified, ready for a retry'
+    )
   end
 end


### PR DESCRIPTION
The is-human-or-robot judge's `rescue Octokit::Forbidden` branch in `judges/is-human-or-robot/is-human-or-robot.rb` wrote `f.stale = 'who'` before falling through, contradicting the log line that promised the user "is not accessible" rather than permanently bad. Once the row carried `stale = 'who'`, the outer `Fbe.consider` filter `(absent stale)` removed it from every later cycle of the judge, and the same filter in `judges/eliminate-ghosts/eliminate-ghosts.rb` and the second `Fbe.consider` in `judges/who-has-name/who-has-name.rb` removed it there too, so the retry the rescue's log message implied never happened. The sibling rescue at `judges/code-was-reviewed/code-was-reviewed.rb:54-59` already treats 403 as transient and falls through with `next` and no stale write; this commit aligns is-human-or-robot with that pattern.

The 403 user fact now stays free of `stale` and `is_human`, so the next cycle re-fetches it once the integration token regains `read:user`, the suspended account comes back, or the secondary rate-limit window clears. The `NotFound/Deprecated` branch is untouched and keeps its `f.stale = 'who'` for the permanent-loss case.

Ran `bundle exec ruby -Ilib -Itest test/judges/test-is-human-or-robot.rb` — 4 tests, 24 assertions, 0 failures (the renamed `test_forbidden_user_lookup_leaves_fact_retriable` now asserts the fact stays unmarked, and `test_forbidden_user_does_not_abort_others` asserts zero `stale = 'who'` rows). Ran `judges test --disable live --lib lib judges` — all 28 judge(s) and 59 tests passed. Ran `bundle exec rubocop` on the two touched files — clean.

Closes #1505