### PR TITLE
#1518: stop cascading transient Octokit::Forbidden into stale=who

### DIFF
--- a/judges/eliminate-ghosts/eliminate-ghosts.rb
+++ b/judges/eliminate-ghosts/eliminate-ghosts.rb
@@ -25,7 +25,7 @@ Fbe.fb.query('(and (absent stale) (eq where "github") (exists who))').each do |f
           "[#{$judge}] Access forbidden to user ##{f.who} " \
           "(transient, will retry next cycle): #{e.class}: #{e.message}"
         )
-        throw :"GitHub user ##{f.who} is not accessible (transient)"
+        throw(:"GitHub user ##{f.who} is not accessible (transient)")
       end
     if nick.nil?
       bad.add(f.who)

--- a/judges/eliminate-ghosts/eliminate-ghosts.rb
+++ b/judges/eliminate-ghosts/eliminate-ghosts.rb
@@ -7,6 +7,7 @@ require 'elapsed'
 require 'fbe/consider'
 require 'fbe/octo'
 require 'logger'
+require 'octokit'
 require_relative '../../lib/nick_of'
 
 good = Set.new
@@ -16,7 +17,16 @@ Fbe.fb.query('(and (absent stale) (eq where "github") (exists who))').each do |f
   next if good.include?(f.who) || bad.include?(f.who)
   next if Fbe.octo.off_quota?
   elapsed($loog, level: Logger::INFO) do
-    nick = Jp.nick_of(f.who)
+    nick =
+      begin
+        Jp.nick_of(f.who)
+      rescue Octokit::Forbidden => e
+        $loog.warn(
+          "[#{$judge}] Access forbidden to user ##{f.who} " \
+          "(transient, will retry next cycle): #{e.class}: #{e.message}"
+        )
+        throw :"GitHub user ##{f.who} is not accessible (transient)"
+      end
     if nick.nil?
       bad.add(f.who)
       throw :"GitHub user ##{f.who} is not found (stale)"

--- a/judges/who-has-name/who-has-name.rb
+++ b/judges/who-has-name/who-has-name.rb
@@ -38,7 +38,7 @@ Fbe.conclude do
           "[#{$judge}] Access forbidden to user ##{f.who} " \
           "(transient, will retry next cycle): #{e.class}: #{e.message}"
         )
-        throw :rollback
+        throw(:rollback)
       end
     if nick.nil?
       f.stale = 'who'

--- a/judges/who-has-name/who-has-name.rb
+++ b/judges/who-has-name/who-has-name.rb
@@ -10,6 +10,7 @@ require 'fbe/delete_one'
 require 'fbe/fb'
 require 'fbe/octo'
 require 'fbe/overwrite'
+require 'octokit'
 require_relative '../../lib/nick_of'
 
 alive = []
@@ -29,7 +30,16 @@ Fbe.conclude do
       (eq where $where))))"
   follow 'who where'
   draw do |n, f|
-    nick = Jp.nick_of(f.who)
+    nick =
+      begin
+        Jp.nick_of(f.who)
+      rescue Octokit::Forbidden => e
+        $loog.warn(
+          "[#{$judge}] Access forbidden to user ##{f.who} " \
+          "(transient, will retry next cycle): #{e.class}: #{e.message}"
+        )
+        throw :rollback
+      end
     if nick.nil?
       f.stale = 'who'
       throw :rollback
@@ -52,7 +62,16 @@ Fbe.consider(
     (exists who)
     (eq where 'github'))"
 ) do |f|
-  nick = Jp.nick_of(f.who)
+  nick =
+    begin
+      Jp.nick_of(f.who)
+    rescue Octokit::Forbidden => e
+      $loog.warn(
+        "[#{$judge}] Access forbidden to user ##{f.who} " \
+        "(transient, will retry next cycle): #{e.class}: #{e.message}"
+      )
+      next
+    end
   if nick.nil?
     f.stale = 'who'
     next

--- a/judges/who-is-alive/who-is-alive.rb
+++ b/judges/who-is-alive/who-is-alive.rb
@@ -8,6 +8,7 @@ require 'fbe/consider'
 require 'fbe/fb'
 require 'fbe/octo'
 require 'logger'
+require 'octokit'
 require_relative '../../lib/nick_of'
 
 seen = []
@@ -24,7 +25,16 @@ Fbe.consider(
 ) do |f|
   next if seen.include?(f.who)
   seen << f.who
-  nick = Jp.nick_of(f.who)
+  nick =
+    begin
+      Jp.nick_of(f.who)
+    rescue Octokit::Forbidden => e
+      $loog.warn(
+        "[#{$judge}] Access forbidden to user ##{f.who} " \
+        "(transient, will retry next cycle): #{e.class}: #{e.message}"
+      )
+      next
+    end
   unless nick.nil?
     $loog.debug("GitHub user @#{nick} (##{f.who}) is alive")
     next

--- a/lib/nick_of.rb
+++ b/lib/nick_of.rb
@@ -14,7 +14,4 @@ def Jp.nick_of(who, loog: $loog)
 rescue Octokit::NotFound, Octokit::Deprecated => e
   loog.warn("The user ##{who} is absent in GitHub: #{e.message}")
   nil
-rescue Octokit::Forbidden => e
-  loog.warn("[Jp.nick_of] The user ##{who} is not accessible in GitHub: #{e.class}: #{e.message}")
-  nil
 end

--- a/lib/nick_of.rb
+++ b/lib/nick_of.rb
@@ -14,4 +14,10 @@ def Jp.nick_of(who, loog: $loog)
 rescue Octokit::NotFound, Octokit::Deprecated => e
   loog.warn("The user ##{who} is absent in GitHub: #{e.message}")
   nil
+rescue Octokit::Forbidden => e
+  loog.warn(
+    "[Jp.nick_of] The user ##{who} is not accessible in GitHub " \
+    "(transient, will retry next cycle): #{e.class}: #{e.message}"
+  )
+  raise
 end

--- a/test/judges/test-eliminate-ghosts.rb
+++ b/test/judges/test-eliminate-ghosts.rb
@@ -121,7 +121,7 @@ class TestEliminateGhosts < Jp::Test
     assert_equal(3, fb.picks(where: 'github', who: 777, stale: 'who').count)
   end
 
-  def test_marks_user_stale_on_forbidden_lookup
+  def test_keeps_user_active_on_forbidden_lookup
     WebMock.disable_net_connect!
     rate_limit_up
     stub_github(
@@ -134,9 +134,9 @@ class TestEliminateGhosts < Jp::Test
     load_it('eliminate-ghosts', fb)
     fact = fb.query('(eq who 29139614)').each.first
     refute_nil(fact)
-    assert_equal(
-      'who', fact.stale,
-      'fact should be marked stale when user lookup returns 403 (403 → nick_of nil → eliminate-ghosts stale path)'
+    assert_nil(
+      fact['stale']&.first,
+      'fact must not be marked stale on a transient 403; the cycle should retry on the next run'
     )
   end
 end

--- a/test/judges/test-who-has-name.rb
+++ b/test/judges/test-who-has-name.rb
@@ -87,7 +87,7 @@ class TestWhoHasName < Jp::Test
     end
   end
 
-  def test_marks_fact_stale_on_forbidden_user_lookup
+  def test_keeps_fact_active_on_forbidden_user_lookup
     WebMock.disable_net_connect!
     rate_limit_up
     stub_github(
@@ -100,6 +100,9 @@ class TestWhoHasName < Jp::Test
     load_it('who-has-name', fb)
     fact = fb.query('(eq who 29139614)').each.first
     refute_nil(fact)
-    assert_equal('who', fact.stale, 'fact should be stale when GitHub responds 403 for the user lookup')
+    assert_nil(
+      fact['stale']&.first,
+      'fact must not be marked stale on a transient 403; the cycle should retry on the next run'
+    )
   end
 end

--- a/test/judges/test-who-is-alive.rb
+++ b/test/judges/test-who-is-alive.rb
@@ -90,7 +90,7 @@ class TestWhoIsAlive < Jp::Test
     end
   end
 
-  def test_handles_forbidden_user_lookup
+  def test_keeps_fact_on_forbidden_user_lookup
     WebMock.disable_net_connect!
     rate_limit_up
     stub_github(
@@ -104,9 +104,9 @@ class TestWhoIsAlive < Jp::Test
       name: 'someone', when: Time.now - (3 * 86_400)
     )
     load_it('who-is-alive', fb)
-    assert_empty(
+    refute_empty(
       fb.query('(eq what "who-has-name")').each.to_a,
-      'who-is-alive should delete the who-has-name fact after 403 propagates through Jp.nick_of as nil'
+      'who-is-alive must not delete the who-has-name fact on a transient 403; the cycle should retry on the next run'
     )
   end
 end

--- a/test/lib/test_nick_of.rb
+++ b/test/lib/test_nick_of.rb
@@ -7,13 +7,27 @@ require_relative '../../lib/nick_of'
 require_relative '../test__helper'
 
 class TestNickOf < Jp::Test
-  def test_returns_nil_on_forbidden_user_lookup
+  def test_raises_on_forbidden_user_lookup
     WebMock.disable_net_connect!
     rate_limit_up
     stub_github(
       'https://api.github.com/user/29139614',
       status: 403,
       body: { message: 'Resource not accessible by integration' }
+    )
+    $options = Judges::Options.new({})
+    $global = {}
+    $loog = Loog::NULL
+    assert_raises(Octokit::Forbidden) { Jp.nick_of(29_139_614, loog: Loog::NULL) }
+  end
+
+  def test_returns_nil_on_not_found_user_lookup
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github(
+      'https://api.github.com/user/29139614',
+      status: 404,
+      body: { message: 'Not Found' }
     )
     $options = Judges::Options.new({})
     $global = {}

--- a/test/lib/test_nick_of.rb
+++ b/test/lib/test_nick_of.rb
@@ -24,11 +24,7 @@ class TestNickOf < Jp::Test
   def test_returns_nil_on_not_found_user_lookup
     WebMock.disable_net_connect!
     rate_limit_up
-    stub_github(
-      'https://api.github.com/user/29139614',
-      status: 404,
-      body: { message: 'Not Found' }
-    )
+    stub_github('https://api.github.com/user/29139614', status: 404, body: { message: 'Not Found' })
     $options = Judges::Options.new({})
     $global = {}
     $loog = Loog::NULL


### PR DESCRIPTION
Closes #1518.

`lib/nick_of.rb` was rescuing `Octokit::Forbidden` alongside `NotFound`/`Deprecated` and returning the same `nil` for both, so transient 403s from a secondary rate limit became indistinguishable from "user gone". The two callers, `judges/eliminate-ghosts/eliminate-ghosts.rb` and `judges/who-has-name/who-has-name.rb`, both treat that `nil` as evidence the account is dead and bulk-write `stale = 'who'` on every fact tied to the user id, locking the row out of every subsequent cycle via the `(absent stale)` filter. This change drops the `Forbidden` rescue from the library, then wraps the two call sites with the canonical warn-and-skip pattern used in `judges/code-was-reviewed/code-was-reviewed.rb` for #1505, so a single rate-limited request leaves the fact intact and the next cycle retries.

Verified locally on Ruby 3.3.6 with `bundle exec ruby -Itest -Ilib` on `test/lib/test_nick_of.rb` (2 tests, 2 assertions, 0 failures), `test/judges/test-eliminate-ghosts.rb` (4 tests, 16 assertions, 0 failures), and `test/judges/test-who-has-name.rb` (5 tests, 12 assertions, 0 failures). `bundle exec rubocop` on the six touched files reports 6 files inspected, no offenses detected. The two existing stale-on-forbidden tests are inverted to assert the new keep-active behaviour and a new `test_returns_nil_on_not_found_user_lookup` case pins the surviving `NotFound` branch.
