### PR TITLE
#1513 build action image from Dockerfile

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,7 @@ description: 'Scan a few GitHub repositories and build a Factbase'
 author: 'Yegor Bugayenko <yegor256@gmail.com>'
 runs:
   using: 'docker'
-  image: 'docker://yegor256/judges-action:latest'
+  image: 'Dockerfile'
 inputs:
   token:
     description: 'Authentication token from www.zerocracy.com'


### PR DESCRIPTION
Issue #1513 reports that `action.yml` line 9 declared `image: 'docker://yegor256/judges-action:latest'`, so a workflow pinned with `uses: zerocracy/judges-action@0.17.17` checked out the `0.17.17` git tag but executed whatever the Docker Hub `:latest` tag resolved to at runtime. The pinned action source and the executed docker image could therefore drift apart.

This change replaces the `:latest` reference with `'Dockerfile'`. GitHub Actions now builds the runtime image from the `Dockerfile` at the same git ref the consumer pinned, so the entry script, the judges, the lib helpers, and the gems all come from the pinned tag and the version-drift channel is closed at the source.

Verified locally that the only edit is `action.yml:9` and `git diff` is a single-line change; the project's docker-driven `make` and `rake` targets were not run inside this sandbox because the sandbox has no Docker daemon, so CI on the pushed branch is the authoritative signal.

Closes #1513
