### PR TITLE
#1522 cover Jp.issue_was_lost with test/lib/test_issue_was_lost.rb

### DIFF
--- a/test/lib/test_issue_was_lost.rb
+++ b/test/lib/test_issue_was_lost.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+# SPDX-License-Identifier: MIT
+
+require 'factbase'
+require 'fbe/tombstone'
+require 'loog'
+require_relative '../../lib/issue_was_lost'
+require_relative '../test__helper'
+
+class TestIssueWasLost < Minitest::Test
+  def test_marks_prior_fact_stale_and_returns_early
+    fb = Factbase.new
+    f = fb.insert
+    f.where = 'github'
+    f.repository = 42
+    f.issue = 7
+    f.what = 'pull-was-opened'
+    Fbe.stub(:fb, fb) do
+      $loog = Loog::NULL
+      Jp.issue_was_lost('github', 42, 7)
+      facts = fb.query("(and (eq where 'github') (eq repository 42) (eq issue 7))").each.to_a
+      assert_equal(1, facts.size, 'no new issue-was-lost fact inserted when a pre-existing fact was upgraded')
+      assert_equal('issue', facts.first.stale, 'pre-existing fact must carry stale = issue')
+    end
+  end
+
+  def test_inserts_fresh_fact_when_none_exists
+    fb = Factbase.new
+    Fbe.stub(:fb, fb) do
+      $loog = Loog::NULL
+      Jp.issue_was_lost('github', 42, 99)
+      lost = fb.query("(and (eq what 'issue-was-lost') (eq where 'github') (eq repository 42) (eq issue 99))").each.to_a
+      assert_equal(1, lost.size, 'a fresh issue-was-lost fact must be inserted when no prior fact exists')
+      assert_equal('issue', lost.first.stale, 'the fresh fact must carry stale = issue')
+      refute_nil(lost.first.when, 'the fresh fact must carry a when timestamp')
+      assert(Fbe::Tombstone.new(fb: fb).has?('github', 42, 99), 'issue must be buried in the tombstone')
+    end
+  end
+
+  def test_raises_on_second_call_for_same_issue
+    fb = Factbase.new
+    Fbe.stub(:fb, fb) do
+      $loog = Loog::NULL
+      Jp.issue_was_lost('github', 42, 123)
+      assert_raises(RuntimeError, 'second call for the same (where, repository, issue) must raise') do
+        Jp.issue_was_lost('github', 42, 123)
+      end
+    end
+  end
+
+  def test_buries_issue_in_the_tombstone
+    fb = Factbase.new
+    Fbe.stub(:fb, fb) do
+      $loog = Loog::NULL
+      refute(Fbe::Tombstone.new(fb: fb).has?('github', 7, 11), 'tombstone must be empty before the call')
+      Jp.issue_was_lost('github', 7, 11)
+      assert(Fbe::Tombstone.new(fb: fb).has?('github', 7, 11), 'tombstone must contain the issue after the call')
+    end
+  end
+end


### PR DESCRIPTION
The issue points out that `lib/issue_was_lost.rb` ships without a matching `test/lib/test_*.rb`, leaving four side effects of `Jp.issue_was_lost` uncovered: the stale-upgrade early return on a pre-existing matching fact, the `Fbe.if_absent` insert that creates the new `issue-was-lost` fact, the `RuntimeError` raised when the function is called a second time for the same `(where, repository, issue)`, and the `Fbe::Tombstone.new.bury!` step. The helper is invoked from twenty-plus judges, so a regression on any branch would silently corrupt cycle state.

This patch adds `test/lib/test_issue_was_lost.rb` with one Minitest case per side effect. The fixture builds an in-memory `Factbase` and stubs `Fbe.fb` with the existing `Fbe.stub(:fb, fb)` pattern already used by `test_cover_qo.rb`. The shape and naming mirror the existing lib tests, with the `Elegant/GoodMethodName` 48-character cap respected.

Ran `bundle exec ruby -Ilib -Itest test/lib/test_issue_was_lost.rb` — 4 tests, 9 assertions, 0 failures. Ran `./bin/rubocop judges lib test Rakefile Gemfile` — 102 files inspected, no offenses. Ran every other file under `test/lib/` to confirm no neighbor regressed.

Closes #1522