### PR TITLE
#1521 rescue Octokit errors around comments counts in code-was-reviewed

### DIFF
--- a/judges/code-was-reviewed/code-was-reviewed.rb
+++ b/judges/code-was-reviewed/code-was-reviewed.rb
@@ -73,8 +73,32 @@ Fbe.consider(
       n.when = review[:submitted_at]
       n.hoc = pr[:additions] + pr[:deletions]
       n.author = pr.dig(:user, :id)
-      n.comments = Fbe.octo.issue_comments(repo, f.issue).count
-      n.review_comments = Fbe.octo.pull_request_review_comments(repo, f.issue, review[:id]).count
+      n.comments =
+        begin
+          Fbe.octo.issue_comments(repo, f.issue).count
+        rescue Octokit::NotFound, Octokit::Deprecated => e
+          $loog.info("Issue comments not available for #{repo}##{f.issue}: #{e.message}")
+          0
+        rescue Octokit::Forbidden => e
+          $loog.warn(
+            "[#{$judge}] Access forbidden to issue comments for #{repo}##{f.issue} " \
+            "(transient, will retry next cycle): #{e.class}: #{e.message}"
+          )
+          0
+        end
+      n.review_comments =
+        begin
+          Fbe.octo.pull_request_review_comments(repo, f.issue, review[:id]).count
+        rescue Octokit::NotFound, Octokit::Deprecated => e
+          $loog.info("Review comments not available for #{repo}##{f.issue} review ##{review[:id]}: #{e.message}")
+          0
+        rescue Octokit::Forbidden => e
+          $loog.warn(
+            "[#{$judge}] Access forbidden to review comments for #{repo}##{f.issue} review ##{review[:id]} " \
+            "(transient, will retry next cycle): #{e.class}: #{e.message}"
+          )
+          0
+        end
       n.seconds = Integer(review[:submitted_at] - pr[:created_at])
       n.details =
         "The pull request #{Fbe.issue(n)} with #{n.hoc} HoC " \
@@ -89,3 +113,5 @@ Fbe.consider(
     end
   end
 end
+
+Fbe.octo.print_trace!

--- a/test/judges/test-code-was-reviewed.rb
+++ b/test/judges/test-code-was-reviewed.rb
@@ -181,4 +181,83 @@ class TestCodeWasReviewed < Jp::Test
       'forbidden reviews lookup must not abort later candidates in the same judge batch'
     )
   end
+
+  def test_rescues_not_found_on_issue_comments
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repositories/42', body: { id: 42, full_name: 'foo/foo' })
+    stub_github(
+      'https://api.github.com/repos/foo/foo/pulls/55',
+      body: {
+        id: 55, number: 55, user: { id: 421, login: 'user' },
+        created_at: Time.parse('2025-09-01 15:35:30 UTC'), additions: 4, deletions: 1
+      }
+    )
+    stub_github(
+      'https://api.github.com/repos/foo/foo/pulls/55/reviews?per_page=100',
+      body: [
+        { id: 60_001, user: { id: 422, login: 'user2' }, submitted_at: Time.parse('2025-09-02 10:39:20 UTC') }
+      ]
+    )
+    stub_github(
+      'https://api.github.com/repos/foo/foo/issues/55/comments?per_page=100',
+      status: 404,
+      body: { message: 'Not Found' }
+    )
+    stub_github(
+      'https://api.github.com/repos/foo/foo/pulls/55/reviews/60001/comments?per_page=100',
+      body: [
+        { id: 47_500, user: { id: 422, login: 'user2' } }
+      ]
+    )
+    stub_github('https://api.github.com/user/421', body: { id: 421, login: 'user1' })
+    stub_github('https://api.github.com/user/422', body: { id: 422, login: 'user2' })
+    fb = Factbase.new
+    fb.with(_id: 1, what: 'pull-was-closed', repository: 42, issue: 55, where: 'github')
+    load_it('code-was-reviewed', fb)
+    assert(
+      fb.one?(what: 'code-was-reviewed', repository: 42, issue: 55, who: 422, hoc: 5, comments: 0, review_comments: 1),
+      'not-found on issue_comments must record the fact with comments=0 and keep review_comments live'
+    )
+  end
+
+  def test_rescues_forbidden_on_review_comments
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repositories/42', body: { id: 42, full_name: 'foo/foo' })
+    stub_github(
+      'https://api.github.com/repos/foo/foo/pulls/66',
+      body: {
+        id: 66, number: 66, user: { id: 421, login: 'user' },
+        created_at: Time.parse('2025-09-01 15:35:30 UTC'), additions: 6, deletions: 2
+      }
+    )
+    stub_github(
+      'https://api.github.com/repos/foo/foo/pulls/66/reviews?per_page=100',
+      body: [
+        { id: 70_001, user: { id: 422, login: 'user2' }, submitted_at: Time.parse('2025-09-02 10:39:20 UTC') }
+      ]
+    )
+    stub_github(
+      'https://api.github.com/repos/foo/foo/issues/66/comments?per_page=100',
+      body: [
+        { id: 48_400, user: { id: 422, login: 'user2' } },
+        { id: 48_401, user: { id: 422, login: 'user2' } }
+      ]
+    )
+    stub_github(
+      'https://api.github.com/repos/foo/foo/pulls/66/reviews/70001/comments?per_page=100',
+      status: 403,
+      body: { message: 'Resource not accessible by integration' }
+    )
+    stub_github('https://api.github.com/user/421', body: { id: 421, login: 'user1' })
+    stub_github('https://api.github.com/user/422', body: { id: 422, login: 'user2' })
+    fb = Factbase.new
+    fb.with(_id: 1, what: 'pull-was-closed', repository: 42, issue: 66, where: 'github')
+    load_it('code-was-reviewed', fb)
+    assert(
+      fb.one?(what: 'code-was-reviewed', repository: 42, issue: 66, who: 422, hoc: 8, comments: 2, review_comments: 0),
+      'forbidden on review comments must record the fact with review_comments=0 and keep comments live'
+    )
+  end
 end


### PR DESCRIPTION
Closes #1521.

`judges/code-was-reviewed/code-was-reviewed.rb:76-77` calls `Fbe.octo.issue_comments` and `Fbe.octo.pull_request_review_comments` inside the `reviews.each` `Fbe.fb.txn` block without any rescue, while every sibling Octokit call in the same file already wraps in the canonical two-branch shape. Either call can raise a transient `Octokit::Forbidden` on a secondary rate limit, an `Octokit::NotFound` on a comment thread that vanished between the reviews fetch and the comments fetch, or an `Octokit::Deprecated`, escaping the txn block, bubbling past `Fbe.consider`, and aborting the judge for every remaining merged or closed pull in the cycle.

Both calls are now wrapped in the same two-branch rescue used a few lines above: `Octokit::NotFound, Octokit::Deprecated` logs at `info` and yields `0` for that count, `Octokit::Forbidden` logs at `warn` with the transient-retry banner and yields `0`. The fact still lands when a single count endpoint fails. The file also picked up the trailing `Fbe.octo.print_trace!` call it was the only top-level judge missing, mirroring every sibling under `judges/*/*.rb`.

Test plan: `bundle exec ruby -Itest test/judges/test-code-was-reviewed.rb` — 7 tests, 10 assertions, 0 failures (adds `test_rescues_not_found_on_issue_comments` and `test_rescues_forbidden_on_review_comments`). `rubocop judges/code-was-reviewed/code-was-reviewed.rb test/judges/test-code-was-reviewed.rb` — 0 offenses.
