### PR TITLE
#1536: Remove redundant require 'octokit' from lib/ files

### DIFF
--- a/lib/nick_of.rb
+++ b/lib/nick_of.rb
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: MIT
 
 require 'fbe/octo'
-require 'octokit'
 require_relative 'jp'
 
 def Jp.nick_of(who, loog: $loog)

--- a/lib/qos_search.rb
+++ b/lib/qos_search.rb
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: MIT
 
 require 'fbe/octo'
-require 'octokit'
 require_relative 'jp'
 
 def Jp.qoreset


### PR DESCRIPTION
Remove `require 'octokit'` from `lib/qos_search.rb` and `lib/nick_of.rb` — Octokit is already pulled transitively via `require 'fbe/octo'`.

## Verification
- `bundle exec rubocop` → 0 offenses ✅
- `bundle exec rake test` → 263 tests, 0 failures ✅