### PR TITLE
#1535: Fix logging level drift (warn -> info for NotFound/Deprecated)

### DIFF
--- a/judges/github-events/github-events.rb
+++ b/judges/github-events/github-events.rb
@@ -158,7 +158,7 @@ Fbe.iterate do
           begin
             Fbe.octo.pull_request(rname, fact.issue)
           rescue Octokit::NotFound, Octokit::Deprecated => e
-            $loog.warn("The pull request ##{fact.issue} doesn't exist in #{rname}: #{e.message}")
+            $loog.info("The pull request ##{fact.issue} doesn't exist in #{rname}: #{e.message}")
             nil
           rescue Octokit::Forbidden => e
             $loog.warn(
@@ -178,7 +178,7 @@ Fbe.iterate do
           begin
             Fbe.octo.pull_request_reviews(rname, fact.issue).first
           rescue Octokit::NotFound, Octokit::Deprecated => e
-            $loog.warn("The pull request ##{fact.issue} doesn't exist in #{rname}: #{e.message}")
+            $loog.info("The pull request ##{fact.issue} doesn't exist in #{rname}: #{e.message}")
             nil
           rescue Octokit::Forbidden => e
             $loog.warn(

--- a/judges/issue-was-closed/issue-was-closed.rb
+++ b/judges/issue-was-closed/issue-was-closed.rb
@@ -84,7 +84,7 @@ Fbe.iterate do
       begin
         Fbe.octo.issue_timeline(repo, issue)
       rescue Octokit::NotFound, Octokit::Deprecated => e
-        $loog.warn("Can't fetch timeline for #{repo}##{issue}: #{e.message}")
+        $loog.info("Can't fetch timeline for #{repo}##{issue}: #{e.message}")
         next issue
       rescue Octokit::Forbidden => e
         $loog.warn("[#{$judge}] Access forbidden to timeline for #{repo}##{issue}: #{e.class}: #{e.message}")

--- a/lib/nick_of.rb
+++ b/lib/nick_of.rb
@@ -12,7 +12,7 @@ def Jp.nick_of(who, loog: $loog)
   loog.debug("User ##{who} is actually @#{n}")
   n
 rescue Octokit::NotFound, Octokit::Deprecated => e
-  loog.warn("The user ##{who} is absent in GitHub: #{e.message}")
+  loog.info("The user ##{who} is absent in GitHub: #{e.message}")
   nil
 rescue Octokit::Forbidden => e
   loog.warn("[Jp.nick_of] The user ##{who} is not accessible in GitHub: #{e.class}: #{e.message}")


### PR DESCRIPTION
Per project convention: NotFound/Deprecated → `$loog.info`, Forbidden → `$loog.warn`.
Changed 4 locations that incorrectly used `warn` for NotFound:

| File | Line | Change |
|---|---|---|
| `issue-was-closed.rb` | 87 | `warn` → `info` |
| `github-events.rb` | 161, 181 | `warn` → `info` (two locations) |
| `lib/nick_of.rb` | 15 | `warn` → `info` |

## Verification
- `bundle exec rubocop` → 0 offenses ✅
- `bundle exec rake test` → 259 tests, 0 failures ✅