### PR TITLE
#1530: Rescue GraphQL/Octokit errors in quantity-of-deliverables (2 files)

### DIFF
--- a/judges/quantity-of-deliverables/total_issues_created.rb
+++ b/judges/quantity-of-deliverables/total_issues_created.rb
@@ -11,10 +11,24 @@ def total_issues_created(fact)
   pulls = 0
   Fbe.unmask_repos do |repo|
     owner, name = repo.split('/')
-    Fbe.github_graph.total_issues_created(owner, name, fact.since).then do |json|
-      issues += json['issues'] + json['pulls']
-      pulls += json['pulls']
-    end
+    json =
+      begin
+        Fbe.github_graph.total_issues_created(owner, name, fact.since)
+      rescue GraphQL::Client::Error, Octokit::NotFound, Octokit::Deprecated => e
+        $loog.info("Issues count not available for #{repo}: #{e.message}")
+        next
+      rescue Octokit::Forbidden => e
+        $loog.warn(
+          "[#{$judge}] Access forbidden to issues count for #{repo} " \
+          "(transient, will retry next cycle): #{e.class}: #{e.message}"
+        )
+        next
+      rescue Net::OpenTimeout, Net::ReadTimeout, SocketError, Errno::ECONNRESET => e
+        $loog.warn("[#{$judge}] Network error counting issues for #{repo}: #{e.message}")
+        next
+      end
+    issues += json['issues'] + json['pulls']
+    pulls += json['pulls']
   end
   {
     total_issues_created: issues,

--- a/judges/quantity-of-deliverables/total_issues_created.rb
+++ b/judges/quantity-of-deliverables/total_issues_created.rb
@@ -3,6 +3,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
 # SPDX-License-Identifier: MIT
 
+require 'fbe/github_graph'
 require 'fbe/octo'
 require 'fbe/unmask_repos'
 

--- a/judges/quantity-of-deliverables/total_releases_published.rb
+++ b/judges/quantity-of-deliverables/total_releases_published.rb
@@ -7,11 +7,25 @@ require 'fbe/octo'
 require 'fbe/unmask_repos'
 
 def total_releases_published(fact)
-  {
-    total_releases_published:
-      Fbe.unmask_repos.sum do |repo|
-        owner, name = repo.split('/')
+  total = 0
+  Fbe.unmask_repos do |repo|
+    owner, name = repo.split('/')
+    total +=
+      begin
         Fbe.github_graph.total_releases_published(owner, name, fact.since)['releases']
+      rescue GraphQL::Client::Error, Octokit::NotFound, Octokit::Deprecated => e
+        $loog.info("Releases count not available for #{repo}: #{e.message}")
+        next
+      rescue Octokit::Forbidden => e
+        $loog.warn(
+          "[#{$judge}] Access forbidden to releases count for #{repo} " \
+          "(transient, will retry next cycle): #{e.class}: #{e.message}"
+        )
+        next
+      rescue Net::OpenTimeout, Net::ReadTimeout, SocketError, Errno::ECONNRESET => e
+        $loog.warn("[#{$judge}] Network error counting releases for #{repo}: #{e.message}")
+        next
       end
-  }
+  end
+  { total_releases_published: total }
 end

--- a/judges/quantity-of-deliverables/total_releases_published.rb
+++ b/judges/quantity-of-deliverables/total_releases_published.rb
@@ -3,6 +3,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
 # SPDX-License-Identifier: MIT
 
+require 'fbe/github_graph'
 require 'fbe/octo'
 require 'fbe/unmask_repos'
 

--- a/lib/pull_request.rb
+++ b/lib/pull_request.rb
@@ -38,6 +38,19 @@ def Jp.comments_info(pr, repo: nil)
     end
   org, rname = repo.split('/')
   uid = pr.dig(:user, :id)
+  rconversations =
+    begin
+      Fbe.github_graph.resolved_conversations(org, rname, pr[:number]).count
+    rescue GraphQL::Client::Error, Octokit::NotFound, Octokit::Deprecated => e
+      $loog.info("Resolved conversations not available for #{repo}##{pr[:number]}: #{e.message}")
+      0
+    rescue Octokit::Forbidden => e
+      $loog.warn(
+        "[#{$judge}] Access forbidden to resolved conversations for #{repo}##{pr[:number]} " \
+        "(transient, will retry next cycle): #{e.class}: #{e.message}"
+      )
+      0
+    end
   {
     comments: (pr[:comments] || 0) + (pr[:review_comments] || 0),
     comments_to_code: ccomments.count,
@@ -46,19 +59,7 @@ def Jp.comments_info(pr, repo: nil)
     comments_by_reviewers: ccomments.count { |c| c.dig(:user, :id) != uid } +
       icomments.count { |c| c.dig(:user, :id) != uid },
     comments_appreciated: Jp.count_appreciated_comments(pr, icomments, ccomments, repo:),
-    comments_resolved:
-      begin
-        Fbe.github_graph.resolved_conversations(org, rname, pr[:number]).count
-      rescue GraphQL::Client::Error, Octokit::NotFound, Octokit::Deprecated => e
-        $loog.info("Resolved conversations not available for #{repo}##{pr[:number]}: #{e.message}")
-        0
-      rescue Octokit::Forbidden => e
-        $loog.warn(
-          "[#{$judge}] Access forbidden to resolved conversations for #{repo}##{pr[:number]} " \
-          "(transient, will retry next cycle): #{e.class}: #{e.message}"
-        )
-        0
-      end
+    comments_resolved: rconversations
   }
 end
 

--- a/lib/pull_request.rb
+++ b/lib/pull_request.rb
@@ -38,19 +38,6 @@ def Jp.comments_info(pr, repo: nil)
     end
   org, rname = repo.split('/')
   uid = pr.dig(:user, :id)
-  rconversations =
-    begin
-      Fbe.github_graph.resolved_conversations(org, rname, pr[:number]).count
-    rescue GraphQL::Client::Error, Octokit::NotFound, Octokit::Deprecated => e
-      $loog.info("Resolved conversations not available for #{repo}##{pr[:number]}: #{e.message}")
-      0
-    rescue Octokit::Forbidden => e
-      $loog.warn(
-        "[#{$judge}] Access forbidden to resolved conversations for #{repo}##{pr[:number]} " \
-        "(transient, will retry next cycle): #{e.class}: #{e.message}"
-      )
-      0
-    end
   {
     comments: (pr[:comments] || 0) + (pr[:review_comments] || 0),
     comments_to_code: ccomments.count,
@@ -59,7 +46,19 @@ def Jp.comments_info(pr, repo: nil)
     comments_by_reviewers: ccomments.count { |c| c.dig(:user, :id) != uid } +
       icomments.count { |c| c.dig(:user, :id) != uid },
     comments_appreciated: Jp.count_appreciated_comments(pr, icomments, ccomments, repo:),
-    comments_resolved: rconversations
+    comments_resolved:
+      begin
+        Fbe.github_graph.resolved_conversations(org, rname, pr[:number]).count
+      rescue GraphQL::Client::Error, Octokit::NotFound, Octokit::Deprecated => e
+        $loog.info("Resolved conversations not available for #{repo}##{pr[:number]}: #{e.message}")
+        0
+      rescue Octokit::Forbidden => e
+        $loog.warn(
+          "[#{$judge}] Access forbidden to resolved conversations for #{repo}##{pr[:number]} " \
+          "(transient, will retry next cycle): #{e.class}: #{e.message}"
+        )
+        0
+      end
   }
 end
 

--- a/test/judges/test-fix-missing-branch.rb
+++ b/test/judges/test-fix-missing-branch.rb
@@ -46,7 +46,7 @@ class TestFixMissingBranch < Jp::Test
     load_it('fix-missing-branch', fb)
     f = fb.query('(eq issue 44)').each.first
     refute_nil(f)
-    assert_nil(f['stale'],
-               '403 is transient — fact must NOT be marked stale; next cycle will retry the pull_request lookup')
+    msg = '403 is transient — fact must NOT be marked stale; next cycle will retry the pull_request lookup'
+    assert_nil(f['stale'], msg)
   end
 end


### PR DESCRIPTION
Added canonical rescue blocks to 2 files:

| File | Calls protected |
|---|---|
| `total_issues_created.rb` | `graphql.total_issues_created` — rescue GraphQL::Client::Error, Octokit::NotFound/Deprecated/Forbidden, network errors |
| `total_releases_published.rb` | `graphql.total_releases_published` — same rescue pattern |

## Verification
- `bundle exec rubocop` → 0 offenses ✅
- `bundle exec rake test` → 259 tests, 0 failures ✅