### PR TITLE
#1537: Rescue Octokit/GraphQL errors in type-was-attached.rb

### DIFF
--- a/judges/type-was-attached/type-was-attached.rb
+++ b/judges/type-was-attached/type-was-attached.rb
@@ -53,7 +53,22 @@ Fbe.iterate do
         $loog.debug("No #{events.joined} events at #{repo}##{issue}")
         next
       end
-      tee = Fbe.github_graph.issue_type_event(te[:node_id])
+      tee =
+        begin
+          Fbe.github_graph.issue_type_event(te[:node_id])
+        rescue Octokit::NotFound, Octokit::Deprecated => e
+          $loog.info("Event type by node ID #{te[:node_id]} not found: #{e.message}")
+          next
+        rescue Octokit::Forbidden => e
+          $loog.warn(
+            "[#{$judge}] Access forbidden to event type by node ID #{te[:node_id]} " \
+            "(transient, will retry next cycle): #{e.class}: #{e.message}"
+          )
+          next
+        rescue GraphQL::Client::Error => e
+          $loog.warn("[#{$judge}] GraphQL error fetching event type by node ID #{te[:node_id]}: #{e.message}")
+          next
+        end
       if tee.nil?
         $loog.debug("Can't fetch event by node ID #{te[:node_id]}")
         next

--- a/judges/type-was-attached/type-was-attached.rb
+++ b/judges/type-was-attached/type-was-attached.rb
@@ -3,6 +3,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
 # SPDX-License-Identifier: MIT
 
+require 'fbe/github_graph'
 require 'fbe/if_absent'
 require 'fbe/issue'
 require 'fbe/iterate'

--- a/lib/pull_request.rb
+++ b/lib/pull_request.rb
@@ -38,6 +38,19 @@ def Jp.comments_info(pr, repo: nil)
     end
   org, rname = repo.split('/')
   uid = pr.dig(:user, :id)
+  rconversations =
+    begin
+      Fbe.github_graph.resolved_conversations(org, rname, pr[:number]).count
+    rescue GraphQL::Client::Error, Octokit::NotFound, Octokit::Deprecated => e
+      $loog.info("Resolved conversations not available for #{repo}##{pr[:number]}: #{e.message}")
+      0
+    rescue Octokit::Forbidden => e
+      $loog.warn(
+        "[#{$judge}] Access forbidden to resolved conversations for #{repo}##{pr[:number]} " \
+        "(transient, will retry next cycle): #{e.class}: #{e.message}"
+      )
+      0
+    end
   {
     comments: (pr[:comments] || 0) + (pr[:review_comments] || 0),
     comments_to_code: ccomments.count,
@@ -46,19 +59,7 @@ def Jp.comments_info(pr, repo: nil)
     comments_by_reviewers: ccomments.count { |c| c.dig(:user, :id) != uid } +
       icomments.count { |c| c.dig(:user, :id) != uid },
     comments_appreciated: Jp.count_appreciated_comments(pr, icomments, ccomments, repo:),
-    comments_resolved:
-      begin
-        Fbe.github_graph.resolved_conversations(org, rname, pr[:number]).count
-      rescue GraphQL::Client::Error, Octokit::NotFound, Octokit::Deprecated => e
-        $loog.info("Resolved conversations not available for #{repo}##{pr[:number]}: #{e.message}")
-        0
-      rescue Octokit::Forbidden => e
-        $loog.warn(
-          "[#{$judge}] Access forbidden to resolved conversations for #{repo}##{pr[:number]} " \
-          "(transient, will retry next cycle): #{e.class}: #{e.message}"
-        )
-        0
-      end
+    comments_resolved: rconversations
   }
 end
 

--- a/lib/pull_request.rb
+++ b/lib/pull_request.rb
@@ -38,19 +38,6 @@ def Jp.comments_info(pr, repo: nil)
     end
   org, rname = repo.split('/')
   uid = pr.dig(:user, :id)
-  rconversations =
-    begin
-      Fbe.github_graph.resolved_conversations(org, rname, pr[:number]).count
-    rescue GraphQL::Client::Error, Octokit::NotFound, Octokit::Deprecated => e
-      $loog.info("Resolved conversations not available for #{repo}##{pr[:number]}: #{e.message}")
-      0
-    rescue Octokit::Forbidden => e
-      $loog.warn(
-        "[#{$judge}] Access forbidden to resolved conversations for #{repo}##{pr[:number]} " \
-        "(transient, will retry next cycle): #{e.class}: #{e.message}"
-      )
-      0
-    end
   {
     comments: (pr[:comments] || 0) + (pr[:review_comments] || 0),
     comments_to_code: ccomments.count,
@@ -59,7 +46,19 @@ def Jp.comments_info(pr, repo: nil)
     comments_by_reviewers: ccomments.count { |c| c.dig(:user, :id) != uid } +
       icomments.count { |c| c.dig(:user, :id) != uid },
     comments_appreciated: Jp.count_appreciated_comments(pr, icomments, ccomments, repo:),
-    comments_resolved: rconversations
+    comments_resolved:
+      begin
+        Fbe.github_graph.resolved_conversations(org, rname, pr[:number]).count
+      rescue GraphQL::Client::Error, Octokit::NotFound, Octokit::Deprecated => e
+        $loog.info("Resolved conversations not available for #{repo}##{pr[:number]}: #{e.message}")
+        0
+      rescue Octokit::Forbidden => e
+        $loog.warn(
+          "[#{$judge}] Access forbidden to resolved conversations for #{repo}##{pr[:number]} " \
+          "(transient, will retry next cycle): #{e.class}: #{e.message}"
+        )
+        0
+      end
   }
 end
 

--- a/test/judges/test-fix-missing-branch.rb
+++ b/test/judges/test-fix-missing-branch.rb
@@ -46,7 +46,7 @@ class TestFixMissingBranch < Jp::Test
     load_it('fix-missing-branch', fb)
     f = fb.query('(eq issue 44)').each.first
     refute_nil(f)
-    assert_nil(f['stale'],
-               '403 is transient — fact must NOT be marked stale; next cycle will retry the pull_request lookup')
+    msg = '403 is transient — fact must NOT be marked stale; next cycle will retry the pull_request lookup'
+    assert_nil(f['stale'], msg)
   end
 end


### PR DESCRIPTION
Closes #1537

Added canonical rescue block to `Fbe.github_graph.issue_type_event` call at line 56:
- `Octokit::NotFound, Octokit::Deprecated` → info + `next` (skip event)
- `Octokit::Forbidden` → warn + `next` (transient, retry next cycle)
- `GraphQL::Client::Error` → warn + `next`

## Verification
- `bundle exec rubocop` → 0 offenses ✅
- `bundle exec rake test` → 259 tests, 0 failures ✅