### PR TITLE
#1553 cover Jp.fill_fact_by_hash with regression tests

### DIFF
--- a/test/lib/test_fill_fact.rb
+++ b/test/lib/test_fill_fact.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+# SPDX-License-Identifier: MIT
+
+require 'factbase'
+require_relative '../../lib/fill_fact'
+require_relative '../test__helper'
+
+class TestFillFact < Minitest::Test
+  def test_empty_hash_leaves_fact_untouched
+    fb = Factbase.new
+    fact = fb.insert
+    fact.what = 'seed'
+    Jp.fill_fact_by_hash(fact, {})
+    assert_equal('seed', fact.what)
+    assert_equal(%w[what], fact.all_properties)
+  end
+
+  def test_multi_key_hash_sets_every_property
+    fb = Factbase.new
+    fact = fb.insert
+    Jp.fill_fact_by_hash(fact, { what: 'pull-was-merged', issue: 7, repository: 42 })
+    assert_equal('pull-was-merged', fact.what)
+    assert_equal(7, fact.issue)
+    assert_equal(42, fact.repository)
+  end
+
+  def test_symbol_and_string_keys_resolve_to_same_setter
+    fb = Factbase.new
+    sym = fb.insert
+    str = fb.insert
+    Jp.fill_fact_by_hash(sym, { who: 888 })
+    Jp.fill_fact_by_hash(str, { 'who' => 888 })
+    assert_equal(888, sym.who)
+    assert_equal(888, str.who)
+    assert_equal(sym.all_properties, str.all_properties)
+  end
+
+  def test_nil_value_raises_through_factbase_setter
+    fb = Factbase.new
+    fact = fb.insert
+    assert_raises(RuntimeError) { Jp.fill_fact_by_hash(fact, { who: nil }) }
+  end
+end


### PR DESCRIPTION
This adds the missing `test/lib/test_fill_fact.rb` that issue #1553 calls out, locking in the four behaviours of `Jp.fill_fact_by_hash` so a regression in the setter loop, the symbol coercion, or the hash iteration would surface at unit-test time rather than on a live `github-events`, `fix-missing-comments`, or `pull-was-merged` cycle.

The new file mirrors the layout of the existing `test/lib/test_*` helpers and exercises four cases: an empty hash leaving the fact untouched, a multi-key hash setting every property, both symbol and string keys mapping to the same setter, and a nil value raising through the Factbase setter — which is the current production behaviour and worth pinning so that any future relaxation is a conscious change. No production code under `lib/` or `judges/` changed.

`bundle exec ruby test/lib/test_fill_fact.rb -- --no-cov` runs the four tests with 9 assertions, 0 failures, 0 errors. `bundle exec rubocop test/lib/test_fill_fact.rb` reports no offences against the project's elegant-style rubocop profile.

Closes #1553
