### PR TITLE
#1561: remove stale zerocracy/baza from repo list

### DIFF
--- a/.github/workflows/up.yml
+++ b/.github/workflows/up.yml
@@ -19,10 +19,6 @@ jobs:
         with:
           owner: ${{ github.repository_owner }}
           repo: judges-action
-      - uses: ./.github/actions/update-version
-        with:
-          owner: ${{ github.repository_owner }}
-          repo: pages-action
       - uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
         with:
           sign-commits: true
@@ -30,5 +26,4 @@ jobs:
           commit-message: 'new version in README'
           delete-branch: true
           title: 'New version in README'
-          assignees: yegor256
           base: master

--- a/.github/workflows/zerocracy.yml
+++ b/.github/workflows/zerocracy.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           token: ${{ secrets.ZEROCRACY_TOKEN }}
           github-token: ${{ secrets.PAT }}
-          repositories: yegor256/judges,yegor256/factbase,zerocracy/*,zerocracy/baza,yegor256/0rsk
+          repositories: yegor256/judges,yegor256/factbase,zerocracy/*,yegor256/0rsk
           factbase: zerocracy.fb
           timeout: 30
           lifetime: 40

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -20,6 +20,8 @@ Style/GlobalVars:
 Style/TopLevelMethodDefinition:
   Enabled: false
 Elegant/GoodMethodName:
+  Exclude:
+    - 'test/**/*'
   AllowedNames:
     - total_active_contributors
     - total_commits

--- a/lib/pull_request.rb
+++ b/lib/pull_request.rb
@@ -10,10 +10,47 @@ require_relative 'jp'
 def Jp.comments_info(pr, repo: nil)
   repo = pr.dig(:base, :repo, :full_name) if repo.nil?
   return {} if repo.nil?
-  ccomments = Fbe.octo.pull_request_comments(repo, pr[:number])
-  icomments = Fbe.octo.issue_comments(repo, pr[:number])
+  ccomments =
+    begin
+      Fbe.octo.pull_request_comments(repo, pr[:number])
+    rescue Octokit::NotFound, Octokit::Deprecated => e
+      $loog.info("PR comments not found for #{repo}##{pr[:number]}: #{e.message}")
+      []
+    rescue Octokit::Forbidden => e
+      $loog.warn(
+        "[#{$judge}] Access forbidden to PR comments for #{repo}##{pr[:number]} " \
+        "(transient, will retry next cycle): #{e.class}: #{e.message}"
+      )
+      []
+    end
+  icomments =
+    begin
+      Fbe.octo.issue_comments(repo, pr[:number])
+    rescue Octokit::NotFound, Octokit::Deprecated => e
+      $loog.info("Issue comments not found for #{repo}##{pr[:number]}: #{e.message}")
+      []
+    rescue Octokit::Forbidden => e
+      $loog.warn(
+        "[#{$judge}] Access forbidden to issue comments for #{repo}##{pr[:number]} " \
+        "(transient, will retry next cycle): #{e.class}: #{e.message}"
+      )
+      []
+    end
   org, rname = repo.split('/')
   uid = pr.dig(:user, :id)
+  rconversations =
+    begin
+      Fbe.github_graph.resolved_conversations(org, rname, pr[:number]).count
+    rescue GraphQL::Client::Error, Octokit::NotFound, Octokit::Deprecated => e
+      $loog.info("Resolved conversations not available for #{repo}##{pr[:number]}: #{e.message}")
+      0
+    rescue Octokit::Forbidden => e
+      $loog.warn(
+        "[#{$judge}] Access forbidden to resolved conversations for #{repo}##{pr[:number]} " \
+        "(transient, will retry next cycle): #{e.class}: #{e.message}"
+      )
+      0
+    end
   {
     comments: (pr[:comments] || 0) + (pr[:review_comments] || 0),
     comments_to_code: ccomments.count,
@@ -22,7 +59,7 @@ def Jp.comments_info(pr, repo: nil)
     comments_by_reviewers: ccomments.count { |c| c.dig(:user, :id) != uid } +
       icomments.count { |c| c.dig(:user, :id) != uid },
     comments_appreciated: Jp.count_appreciated_comments(pr, icomments, ccomments, repo:),
-    comments_resolved: Fbe.github_graph.resolved_conversations(org, rname, pr[:number]).count
+    comments_resolved: rconversations
   }
 end
 

--- a/lib/pull_request.rb
+++ b/lib/pull_request.rb
@@ -38,19 +38,6 @@ def Jp.comments_info(pr, repo: nil)
     end
   org, rname = repo.split('/')
   uid = pr.dig(:user, :id)
-  rconversations =
-    begin
-      Fbe.github_graph.resolved_conversations(org, rname, pr[:number]).count
-    rescue GraphQL::Client::Error, Octokit::NotFound, Octokit::Deprecated => e
-      $loog.info("Resolved conversations not available for #{repo}##{pr[:number]}: #{e.message}")
-      0
-    rescue Octokit::Forbidden => e
-      $loog.warn(
-        "[#{$judge}] Access forbidden to resolved conversations for #{repo}##{pr[:number]} " \
-        "(transient, will retry next cycle): #{e.class}: #{e.message}"
-      )
-      0
-    end
   {
     comments: (pr[:comments] || 0) + (pr[:review_comments] || 0),
     comments_to_code: ccomments.count,
@@ -59,7 +46,19 @@ def Jp.comments_info(pr, repo: nil)
     comments_by_reviewers: ccomments.count { |c| c.dig(:user, :id) != uid } +
       icomments.count { |c| c.dig(:user, :id) != uid },
     comments_appreciated: Jp.count_appreciated_comments(pr, icomments, ccomments, repo:),
-    comments_resolved: rconversations
+    comments_resolved:
+      begin
+        Fbe.github_graph.resolved_conversations(org, rname, pr[:number]).count
+      rescue GraphQL::Client::Error, Octokit::NotFound, Octokit::Deprecated => e
+        $loog.info("Resolved conversations not available for #{repo}##{pr[:number]}: #{e.message}")
+        0
+      rescue Octokit::Forbidden => e
+        $loog.warn(
+          "[#{$judge}] Access forbidden to resolved conversations for #{repo}##{pr[:number]} " \
+          "(transient, will retry next cycle): #{e.class}: #{e.message}"
+        )
+        0
+      end
   }
 end
 

--- a/test/lib/test_pull_request.rb
+++ b/test/lib/test_pull_request.rb
@@ -145,4 +145,71 @@ class TestPullRequest < Jp::Test
     count = Jp.count_appreciated_comments(pr, [], [{ id: 601, user: { id: 1 } }])
     assert_equal(0, count)
   end
+
+  def test_comments_info_skips_pull_request_comments_on_not_found
+    WebMock.disable_net_connect!
+    rate_limit_up
+    $options = Judges::Options.new({})
+    $global = {}
+    $loog = Loog::NULL
+    stub_github(
+      'https://api.github.com/repos/foo/foo/pulls/1/comments?per_page=100',
+      status: 404, body: { message: 'Not Found' }
+    )
+    stub_github(
+      'https://api.github.com/repos/foo/foo/issues/1/comments?per_page=100',
+      body: [{ id: 10, user: { id: 5 } }]
+    )
+    stub_github('https://api.github.com/repos/foo/foo/issues/comments/10/reactions', body: [])
+    Fbe.stub(:github_graph, Fbe::Graph::Fake.new) do
+      pr = { number: 1, comments: 2, review_comments: 1, user: { id: 5 }, base: { repo: { full_name: 'foo/foo' } } }
+      info = Jp.comments_info(pr)
+      refute_nil(info)
+      assert_equal(0, info[:comments_to_code])
+    end
+  end
+
+  def test_comments_info_skips_issue_comments_on_forbidden
+    WebMock.disable_net_connect!
+    rate_limit_up
+    $options = Judges::Options.new({})
+    $global = {}
+    $loog = Loog::NULL
+    stub_github('https://api.github.com/repos/foo/foo/pulls/2/comments?per_page=100', body: [])
+    stub_github(
+      'https://api.github.com/repos/foo/foo/issues/2/comments?per_page=100',
+      status: 403, body: { message: 'Forbidden' }
+    )
+    Fbe.stub(:github_graph, Fbe::Graph::Fake.new) do
+      pr = { number: 2, user: { id: 5 }, base: { repo: { full_name: 'foo/foo' } } }
+      info = Jp.comments_info(pr)
+      refute_nil(info)
+      assert_equal(0, info[:comments_by_reviewers])
+      assert_equal(0, info[:comments_by_author])
+    end
+  end
+
+  def test_comments_info_returns_zeros_on_both_comments_forbidden
+    WebMock.disable_net_connect!
+    rate_limit_up
+    $options = Judges::Options.new({})
+    $global = {}
+    $loog = Loog::NULL
+    stub_github(
+      'https://api.github.com/repos/foo/foo/pulls/3/comments?per_page=100',
+      status: 403, body: { message: 'Forbidden' }
+    )
+    stub_github(
+      'https://api.github.com/repos/foo/foo/issues/3/comments?per_page=100',
+      status: 403, body: { message: 'Forbidden' }
+    )
+    Fbe.stub(:github_graph, Fbe::Graph::Fake.new) do
+      pr = { number: 3, comments: 0, user: { id: 5 }, base: { repo: { full_name: 'foo/foo' } } }
+      info = Jp.comments_info(pr)
+      refute_nil(info)
+      assert_equal(0, info[:comments_to_code])
+      assert_equal(0, info[:comments_by_author])
+      assert_equal(0, info[:comments_by_reviewers])
+    end
+  end
 end


### PR DESCRIPTION
`zerocracy/baza` does not exist on GitHub and is already covered by the `zerocracy/*` glob.