### PR TITLE
#1556: rename RACK_RUN env var to RAKE_RUN

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -10,7 +10,7 @@ require 'rake/clean'
 require 'rubygems'
 require 'shellwords'
 
-ENV['RACK_RUN'] = 'true'
+ENV['RAKE_RUN'] = 'true'
 
 task default: %i[clean test judges rubocop picks]
 

--- a/test/test__helper.rb
+++ b/test/test__helper.rb
@@ -49,7 +49,7 @@ class Jp::Test < Minitest::Test
     $local = {}
     $judge = judge
     $options = options
-    $loog = loog || (ENV['RACK_RUN'] ? Loog::NULL : Loog::VERBOSE)
+    $loog = loog || (ENV['RAKE_RUN'] ? Loog::NULL : Loog::VERBOSE)
     $epoch = Time.now
     $kickoff = Time.now
     load(File.join(__dir__, "../judges/#{judge}/#{judge}.rb"))


### PR DESCRIPTION
The env var that flags test runs invoked from rake is named RACK_RUN in Rakefile and test/test__helper.rb, but Rack has no role in this project. The misspelling hides intent and clutters greps for the real Rack gem.

Both occurrences are renamed to RAKE_RUN. The variable is internal, not part of any documented input, so no external consumer is affected. The toggle continues to switch the test logger between Loog::NULL and Loog::VERBOSE.

A grep across the tree confirms no other references to the old name remain. The full make-based build relies on Docker, which is not available in this environment, so it was not run locally; CI will exercise it.

Closes #1556