### PR TITLE
#1597: Fix Factbase.new.open -> Factbase.new.import in entry.sh

### DIFF
--- a/entry.sh
+++ b/entry.sh
@@ -292,7 +292,7 @@ fi
 
 if [ -n "${GITHUB_RUN_ID}" ] && [ -n "$(printenv "INPUT_GITHUB-TOKEN")" ]; then
     churn_val=$(cat churn.txt 2>/dev/null || echo '0i/0d/0a')
-    fb_size=$(ruby -e "require 'factbase'; puts Factbase.new.open('${fb}').size" 2>/dev/null || echo '0')
+    fb_size=$(ruby -e "require 'factbase'; f=Factbase.new; f.import(File.binread(ARGV[0])); puts f.size" "$fb" 2>/dev/null || echo '0')
     title="judges-action ${action_version} did ${churn_val} to ${fb_size} facts"
     echo "Updating workflow run title to: ${title}"
     curl -s -X PATCH \


### PR DESCRIPTION
The dynamic workflow run title and Job Summary (added in #1492) always report `Facts | 0` because `entry.sh:295` calls `Factbase.new.open('${fb}')` — a method that does not exist on `Factbase`. The `NoMethodError` is silently swallowed by `2>/dev/null`, and the `|| echo '0'` fallback always wins.

The fix uses the correct API: `Factbase.new → import(File.binread(path)) → .size`. The factbase path is now passed as `ARGV[0]` rather than interpolated into Ruby source code, hardening quoting.

Closes #1597