### PR TITLE
#1566: mark options as optional in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ The following options are expected by the plugin
 
 * `token` (mandatory) is an authentication token from
   [Zerocracy.com](https://www.zerocracy.com)
-* `options` (mandatory) is a list of `k=v` pairs, which are explained below
+* `options` (optional) is a list of `k=v` pairs, which are explained below
 * `factbase` (mandatory) is the path of the [Factbase][factbase] file
   (where everything is kept)
 * `repositories` (optional) is a comma-separated list of masks that


### PR DESCRIPTION
The README listed `options` as mandatory, while `action.yml` declares it `required: false`. Closes #1566.

The single-line change in the configuration list now matches the action input definition, so users no longer think `options` must be passed every time the action runs.

Verified by diffing `action.yml` against the README configuration list; no judge or test exercises this prose, so nothing else needed to run.

Closes #1566