### PR TITLE
fix: #1521 trail Fbe.octo.print_trace! in code-was-reviewed

### DIFF
--- a/judges/code-was-reviewed/code-was-reviewed.rb
+++ b/judges/code-was-reviewed/code-was-reviewed.rb
@@ -113,3 +113,5 @@ Fbe.consider(
     end
   end
 end
+
+Fbe.octo.print_trace!


### PR DESCRIPTION
Issue #1521 noted that `code-was-reviewed.rb` is the only top-level judge file in `judges/*/*.rb` without the trailing `Fbe.octo.print_trace!` call that every sibling judge ends with (see `find-all-issues.rb:127`, `find-latest-issue.rb:79`, `pull-was-merged.rb:130`, and twenty-six other top-level judges on `master`). The other half of the report — rescue wrapping around `issue_comments` and `pull_request_review_comments` — already landed on `master`.

Adds one line at the end of `judges/code-was-reviewed/code-was-reviewed.rb` so the file emits the same Octokit call-count trace as the rest of the cycle on completion. No behavioural change inside the `Fbe.consider` block.

Verified by grepping `judges/*/*.rb` against `print_trace` and confirming `code-was-reviewed.rb` was the lone outlier among the top-level judge files.

Closes #1521
