### PR TITLE
Guard missing tree data in total files judge

### DIFF
--- a/judges/dimensions-of-terrain/total_files.rb
+++ b/judges/dimensions-of-terrain/total_files.rb
@@ -37,7 +37,7 @@ def total_files(_fact)
         )
         next
       end
-    files += tree[:tree].count { |item| item[:type] == 'blob' }
+    files += (tree[:tree] || []).count { |item| item[:type] == 'blob' }
   end
   { total_files: files }
 end

--- a/test/judges/test-dimensions-of-terrain.rb
+++ b/test/judges/test-dimensions-of-terrain.rb
@@ -597,6 +597,49 @@ class TestDimensionsOfTerrain < Jp::Test
     end
   end
 
+  def test_total_files_with_missing_tree_key
+    WebMock.disable_net_connect!
+    stub_request(:get, 'https://api.github.com/rate_limit').to_return(
+      {
+        body: '{"rate":{"remaining":222},"resources":{"search":{"remaining":30,"limit":30}}}',
+        headers: { 'X-RateLimit-Remaining' => '222' }
+      }
+    )
+    stub_github(
+      'https://api.github.com/repos/foo/foo',
+      body: {
+        name: 'foo',
+        full_name: 'foo/foo',
+        private: false,
+        created_at: Time.parse('2024-07-11 20:35:25 UTC'),
+        updated_at: Time.parse('2024-09-23 07:23:36 UTC'),
+        pushed_at: Time.parse('2024-09-23 20:22:51 UTC'),
+        size: 19_366,
+        stargazers_count: 1,
+        forks: 1,
+        default_branch: 'master'
+      }
+    )
+    stub_github('https://api.github.com/repos/foo/foo/releases?per_page=100', body: [])
+    stub_github(
+      'https://api.github.com/repos/foo/foo/git/trees/master?recursive=true',
+      body: { sha: '492072971ad3c8644a191f', truncated: false }
+    )
+    stub_github('https://api.github.com/repos/foo/foo/contributors?per_page=100', body: [])
+    stub_github(
+      'https://api.github.com/search/commits?per_page=100&q=repo:foo/foo%20author-date:%3E2024-08-30',
+      body: { total_count: 0, incomplete_results: false, items: [] }
+    )
+    fb = Factbase.new
+    Fbe.stub(:github_graph, Fbe::Graph::Fake.new) do
+      Time.stub(:now, Time.parse('2024-09-29 21:00:00 UTC')) do
+        load_it('dimensions-of-terrain', fb, Judges::Options.new({ 'repositories' => 'foo/foo' }))
+        f = fb.query("(eq what 'dimensions-of-terrain')").each.first
+        assert_equal(0, f.total_files)
+      end
+    end
+  end
+
   def test_total_contributors
     WebMock.disable_net_connect!
     stub_request(:get, 'https://api.github.com/rate_limit').to_return(


### PR DESCRIPTION
## Summary
- guard `tree[:tree]` when the GitHub tree response omits the `tree` key
- keep `total_files` counting blobs when tree data is present
- add regression coverage for a non-empty repository whose tree response has no `tree` array

Closes #1593.

## Verification
- `git diff --check`

I could not run the Ruby test locally in this Windows workspace because `ruby` and `bundle` are not installed (`where.exe ruby` / `where.exe bundle` could not find them).