### PR TITLE
docs(README): #1602 document sqlite_cache_min_age option default

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,11 @@ The following `k=v` pairs inside the `options` may be important:
   `-yegor256/judges` means an exclusion of the repo from the list.
 * `sqlite_cache_maxsize=10M` is the maximum size of HTTP cache file
 * `sqlite_cache_maxvsize=10K` is the maximum size of a single HTTP entry to cache
+* `sqlite_cache_min_age=3600` is the minimum value, in seconds, that is forced
+  onto the `max-age` directive of the `Cache-Control` header of every cached
+  HTTP response, so that GitHub API entries stay valid in the cache for at
+  least this long even when GitHub returns a shorter `max-age`; `entry.sh`
+  injects this default when the option is not supplied
 
 The `zerocracy/pages-action` plugin is responsible for rendering
   the summary HTML page: its configuration is not explained here,


### PR DESCRIPTION
Closes #1602.

The configuration section of `README.md` already listed `sqlite_cache_maxsize` and `sqlite_cache_maxvsize`, but said nothing about `sqlite_cache_min_age`, even though `entry.sh` always injects `--option=sqlite_cache_min_age=3600` when the user does not pass the option (see `entry.sh:186-195`). That default is consumed by `Fbe::Middleware::SqliteStore` (`fbe` gem, `lib/fbe/middleware/sqlite_store.rb`) and used to raise the `max-age` value inside `Cache-Control` response headers up to the configured floor, so cached GitHub API entries stay valid for at least this many seconds even when the server returns a shorter `max-age`.

This change adds one bullet to the configuration list with the default value, the unit, the semantics, and the fact that `entry.sh` injects the default. Nothing else changes.

---
_Generated by [Claude Code](https://claude.ai/code)_