### PR TITLE
#1559: quote boolean defaults in action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -24,7 +24,7 @@ inputs:
   verbose:
     description: 'Log as much debug information as possible'
     required: false
-    default: false
+    default: 'false'
   factbase:
     description: 'Path of the factbase file (also the name of the job in Zerocracy)'
     required: true
@@ -36,7 +36,7 @@ inputs:
   dry-run:
     description: 'Skip all judges, make no changes to the factbase'
     required: false
-    default: false
+    default: 'false'
   timeout:
     description: 'The number of minutes to spend on each judge'
     required: false


### PR DESCRIPTION
Consistent `default: 'false'` across all three boolean inputs (`verbose`, `fail-fast`, `dry-run`) — YAML 1.2 parses bare `false` as boolean but `entry.sh` compares against the string `'true'`/`'false'`.

Fixes #1559