### PR TITLE
#1567: document fail-fast and dry-run inputs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ The following options are expected by the plugin
   `-yegor256/judges` means an exclusion of the repo from the list.
 * `github-token` (optional) is an authentication GitHub access token
 * `verbose` (optional) makes it print debugging info if set to `true`
+* `fail-fast` (optional) stops after the first error if set to `true`
+* `dry-run` (optional) skips all judges and makes no changes if set to `true`
 * `timeout` (optional) is how many minutes each judge can spend
 * `lifetime` (optional) is how many minutes the entire update can take
 * `cycles` (optional) is a number of update cycles to run, default is `2`

--- a/action.yml
+++ b/action.yml
@@ -24,7 +24,7 @@ inputs:
   verbose:
     description: 'Log as much debug information as possible'
     required: false
-    default: false
+    default: 'false'
   factbase:
     description: 'Path of the factbase file (also the name of the job in Zerocracy)'
     required: true
@@ -36,7 +36,7 @@ inputs:
   dry-run:
     description: 'Skip all judges, make no changes to the factbase'
     required: false
-    default: false
+    default: 'false'
   timeout:
     description: 'The number of minutes to spend on each judge'
     required: false


### PR DESCRIPTION
Adds missing documentation for `fail-fast` and `dry-run` inputs in the Configuration section of README.md.

Fixes #1567