### PR TITLE
#1568: clarify action inputs vs options k=v pairs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,12 +75,13 @@ Thus, the summary page is updated hourly and you see
 
 ## Configuration
 
-The following options are expected by the plugin
+The following action inputs are set via `with:` in your workflow YAML
   (see how we [configure][ours] it):
 
 * `token` (mandatory) is an authentication token from
   [Zerocracy.com](https://www.zerocracy.com)
-* `options` (optional) is a list of `k=v` pairs, which are explained below
+* `options` (optional) is a list of `k=v` pairs for advanced tuning,
+  explained below
 * `factbase` (mandatory) is the path of the [Factbase][factbase] file
   (where everything is kept)
 * `repositories` (optional) is a comma-separated list of masks that
@@ -91,24 +92,30 @@ The following options are expected by the plugin
   `-yegor256/judges` means an exclusion of the repo from the list.
 * `github-token` (optional) is an authentication GitHub access token
 * `verbose` (optional) makes it print debugging info if set to `true`
+* `fail-fast` (optional) stops after the first error if set to `true`
+* `dry-run` (optional) skips all judges and makes no changes if set to `true`
 * `timeout` (optional) is how many minutes each judge can spend
 * `lifetime` (optional) is how many minutes the entire update can take
 * `cycles` (optional) is a number of update cycles to run, default is `2`
 * `sqlite-cache` (optional) is a path of SQLite database file with HTTP cache
 * `bots` (optional) is a comma-separated list of GitHub user logins to mark as bots
 
-The following `k=v` pairs inside the `options` may be important:
+The dedicated action inputs above take precedence when a parameter
+  is also configurable via `options` (the k=v pairs below exist for
+  backward compatibility and advanced scenarios):
 
-* `github_token=...` is a default GitHub token, usually to be set to
+* `github_token=...` is a default GitHub token (alternative to
+  `github-token` action input), usually to be set to
   `${{ secrets.GITHUB_TOKEN }}`
-* `repositories=..` is a comma-separated list of masks that
-  determine the repositories to manage, where
+* `repositories=..` is a comma-separated list of masks (alternative to
+  `repositories` action input), where
   `yegor256/*` means all repos of the user,
   `yegor256/judges` means a specific repo,
   and
   `-yegor256/judges` means an exclusion of the repo from the list.
 * `sqlite_cache_maxsize=10M` is the maximum size of HTTP cache file
 * `sqlite_cache_maxvsize=10K` is the maximum size of a single HTTP entry to cache
+  (these two are only available as k=v pairs)
 
 The `zerocracy/pages-action` plugin is responsible for rendering
   the summary HTML page: its configuration is not explained here,


### PR DESCRIPTION
Splits the Configuration section into two clearly labelled lists:

1. **Action inputs** — set via `with:` in workflow YAML (dedicated inputs take precedence)
2. **k=v pairs inside `options`** — for backward compatibility and advanced tuning

Marks `github_token` and `repositories` k=v entries as alternatives to their dedicated action inputs. Clarifies that `sqlite_cache_maxsize` and `sqlite_cache_maxvsize` are only available as k=v pairs.

Also adds the missing `fail-fast` and `dry-run` entries from #1567.

Fixes #1568