### PR TITLE
#1570: document SKIP_VERSION_CHECKING env var in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,8 +81,8 @@ The following options are expected by the plugin
 * `token` (mandatory) is an authentication token from
   [Zerocracy.com](https://www.zerocracy.com)
 * `options` (optional) is a list of `k=v` pairs, which are explained below
-* `factbase` (mandatory) is the path of the [Factbase][factbase] file
-  (where everything is kept)
+* `factbase` (optional, default is `default.fb`) is the path of the
+  [Factbase][factbase] file (where everything is kept)
 * `repositories` (optional) is a comma-separated list of masks that
   determine the repositories to manage, where
   `yegor256/*` means all repos of the user,

--- a/README.md
+++ b/README.md
@@ -110,6 +110,15 @@ The following `k=v` pairs inside the `options` may be important:
 * `sqlite_cache_maxsize=10M` is the maximum size of HTTP cache file
 * `sqlite_cache_maxvsize=10K` is the maximum size of a single HTTP entry to cache
 
+### Environment Variables
+
+The following environment variables are recognized by the Docker entry point:
+
+* `SKIP_VERSION_CHECKING` (optional, default is unset) if set to `true`,
+  skips the version compatibility check against GitHub releases. Useful for
+  development, testing with a non-release build, air-gapped environments,
+  or faster CI when version checking is not critical.
+
 The `zerocracy/pages-action` plugin is responsible for rendering
   the summary HTML page: its configuration is not explained here,
   check its [own repository](https://github.com/zerocracy/pages-action).


### PR DESCRIPTION
Adds an `Environment Variables` subsection to the Configuration section documenting `SKIP_VERSION_CHECKING`.

Fixes #1570