### PR TITLE
#1574: fix PushEvent ref parsing for multi-segment branch names

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,9 @@ The following `k=v` pairs inside the `options` may be important:
 * `sqlite_cache_maxsize=10M` is the maximum size of HTTP cache file
 * `sqlite_cache_maxvsize=10K` is the maximum size of a single HTTP entry to cache
 
+Note: `action_version` and `vitals_url` are automatically populated
+  by the entry point and should not be set manually.
+
 The `zerocracy/pages-action` plugin is responsible for rendering
   the summary HTML page: its configuration is not explained here,
   check its [own repository](https://github.com/zerocracy/pages-action).

--- a/judges/github-events/github-events.rb
+++ b/judges/github-events/github-events.rb
@@ -177,7 +177,7 @@ Fbe.iterate do
           raise
         end
       fact.default_branch = repo[:default_branch]
-      fact.to_master = fact.default_branch == fact.ref.split('/')[2] ? 1 : 0
+      fact.to_master = fact.default_branch == fact.ref.sub('refs/heads/', '') ? 1 : 0
       fact.by_owner = 1 if repo.dig(:owner, :id) == fact.who
       if fact.to_master.zero?
         $loog.debug("Push #{fact.commit} to non-default branch #{fact.default_branch.inspect}, ignoring it")


### PR DESCRIPTION
When a branch name contains slashes (e.g. `feature/bugfix`), `split('/')[2]` only captures the first segment after `heads/`, causing `to_master` to be incorrectly set to `0`. Uses `sub('refs/heads/', '')` instead, which correctly parses any branch name.

Fixes #1574