### PR TITLE
#1575: add nil guard for :check_runs in pull_request.rb

### DIFF
--- a/lib/pull_request.rb
+++ b/lib/pull_request.rb
@@ -108,7 +108,7 @@ def Jp.fetch_workflows(pr, repo: nil)
     )
     return { succeeded_builds: 0, failed_builds: 0 }
   end
-  entries[:check_runs].each do |run|
+  (entries[:check_runs] || []).each do |run|
     next unless run.dig(:app, :slug) == 'github-actions'
     rid =
       begin


### PR DESCRIPTION
When the API response lacks the `:check_runs` key, `entries[:check_runs].each` raises NoMethodError. Adds `|| []` guard.

Fixes #1575