### PR TITLE
#1576: remove repositories from k=v options section

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,12 +101,6 @@ The following `k=v` pairs inside the `options` may be important:
 
 * `github_token=...` is a default GitHub token, usually to be set to
   `${{ secrets.GITHUB_TOKEN }}`
-* `repositories=..` is a comma-separated list of masks that
-  determine the repositories to manage, where
-  `yegor256/*` means all repos of the user,
-  `yegor256/judges` means a specific repo,
-  and
-  `-yegor256/judges` means an exclusion of the repo from the list.
 * `sqlite_cache_maxsize=10M` is the maximum size of HTTP cache file
 * `sqlite_cache_maxvsize=10K` is the maximum size of a single HTTP entry to cache
 

--- a/lib/pull_request.rb
+++ b/lib/pull_request.rb
@@ -108,7 +108,7 @@ def Jp.fetch_workflows(pr, repo: nil)
     )
     return { succeeded_builds: 0, failed_builds: 0 }
   end
-  entries[:check_runs].each do |run|
+  (entries[:check_runs] || []).each do |run|
     next unless run.dig(:app, :slug) == 'github-actions'
     rid =
       begin


### PR DESCRIPTION
repositories is a dedicated action input handled natively by entry.sh. Listing it again as a k=v pair inside options is redundant and confusing — users may set it in both places, causing one value to silently override the other.

Fixes #1576