### PR TITLE
#1577: remove github_token from k=v options section

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,8 +99,6 @@ The following options are expected by the plugin
 
 The following `k=v` pairs inside the `options` may be important:
 
-* `github_token=...` is a default GitHub token, usually to be set to
-  `${{ secrets.GITHUB_TOKEN }}`
 * `repositories=..` is a comma-separated list of masks that
   determine the repositories to manage, where
   `yegor256/*` means all repos of the user,


### PR DESCRIPTION
github-token is a dedicated action input with ${{ github.token }} as default from action.yml. The entry.sh also handles its conversion to --option automatically. Listing it again as a k=v pair is redundant and confusing.

Fixes #1577