### PR TITLE
#1579: use require() instead of require_relative() for absolute paths

### DIFF
--- a/lib/incremate.rb
+++ b/lib/incremate.rb
@@ -36,7 +36,7 @@ def Jp.incremate(
         '...'
       ].compact.join
     )
-    require_relative(rb)
+    require(rb)
     elapsed($loog, level: Logger::INFO) do
       h = __send__(n, fact)
       h.each do |k, v|


### PR DESCRIPTION
Dir[] returns absolute paths when dir is absolute. require_relative resolves relative to the current file's directory — relying on it working with absolute paths is fragile. Use require() for absolute paths.

Fixes #1579