### PR TITLE
#1580: validate property names in fill_fact_by_hash

### DIFF
--- a/lib/fill_fact.rb
+++ b/lib/fill_fact.rb
@@ -7,6 +7,7 @@ require_relative 'jp'
 
 def Jp.fill_fact_by_hash(fact, hash)
   hash.each do |prop, value|
+    raise(ArgumentError, "Invalid property name: #{prop.inspect}") unless /^[a-z][a-z_0-9]*$/i.match?(prop.to_s)
     fact.__send__(:"#{prop}=", value)
   end
 end


### PR DESCRIPTION
Dynamic __send__ with unchecked hash keys risks method injection. Added regex validation to only allow alphanumeric property names (starting with a letter).

Fixes #1580