### PR TITLE
#1581: guard JSON.pretty_generate against serialization errors

### DIFF
--- a/lib/supervision.rb
+++ b/lib/supervision.rb
@@ -9,6 +9,11 @@ require_relative 'jp'
 def Jp.supervision(context, loog: $loog)
   yield
 rescue StandardError => e
-  loog.error("Additional context for '#{e.class}: #{e.message}':\n#{JSON.pretty_generate(context)}")
+  begin
+    info = JSON.pretty_generate(context)
+  rescue StandardError => je
+    info = "Failed to serialize context: #{je.message}\n#{context.inspect}"
+  end
+  loog.error("Additional context for '#{e.class}: #{e.message}':\n#{info}")
   raise
 end


### PR DESCRIPTION
JSON.pretty_generate can crash with SystemStackError or JSON::NestingError on circular references. Wrap in a nested rescue and fall back to .inspect.

Fixes #1581