### PR TITLE
#1583: add auth header to version check curl calls

### DIFF
--- a/entry.sh
+++ b/entry.sh
@@ -11,8 +11,12 @@ VERSION=0.0.0
 
 echo "The 'judges-action' ${VERSION} is running"
 
+auth_args=()
+if [ -n "$(printenv "INPUT_GITHUB-TOKEN")" ]; then
+    auth_args=(-H "Authorization: Bearer $(printenv "INPUT_GITHUB-TOKEN")")
+fi
 if [ "${SKIP_VERSION_CHECKING}" != 'true' ]; then
-    resp=$(curl --silent -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/zerocracy/judges-action/releases/latest)
+    resp=$(curl --silent "${auth_args[@]}" -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/zerocracy/judges-action/releases/latest)
     latest=$(echo -n "$resp" | jq -Rrs "try (fromjson | .tag_name) catch empty")
     if [ -z "${latest}" ]; then
         echo "!!! Could not fetch the latest version from GitHub."
@@ -264,7 +268,7 @@ else
 fi
 
 if [ "${SKIP_VERSION_CHECKING}" != 'true' ]; then
-    action_version=$(curl --retry 5 --retry-delay 5 --retry-max-time 40 --connect-timeout 5 -sL https://api.github.com/repos/zerocracy/judges-action/releases/latest | jq -r '.tag_name')
+    action_version=$(curl --retry 5 --retry-delay 5 --retry-max-time 40 --connect-timeout 5 -sL "${auth_args[@]}" https://api.github.com/repos/zerocracy/judges-action/releases/latest | jq -r '.tag_name')
     if [ "${action_version}" == "${VERSION}" ] || [ "${action_version}" == null ]; then
         action_version=${VERSION}
     else


### PR DESCRIPTION
Both curl calls to the GitHub API for version checking were unauthenticated, hitting the low unauthenticated rate limit (60/hr/IP). Uses INPUT_GITHUB-TOKEN as Bearer token in Authorization header when available.

Fixes #1583