### PR TITLE
#1585: escape regex metacharacters in inputs.repo

### DIFF
--- a/.github/actions/update-version/action.yml
+++ b/.github/actions/update-version/action.yml
@@ -28,6 +28,7 @@ runs:
           }
           const fs = require('fs');
           let readme = fs.readFileSync('README.md', 'utf8');
-          readme = readme.replace(new RegExp('${{ inputs.repo }}@.+$', 'gm'), `${{ inputs.repo }}@${latest}`);
+          const escaped = '${{ inputs.repo }}'.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+          readme = readme.replace(new RegExp(escaped + '@.+$', 'gm'), `${{ inputs.repo }}@${latest}`);
           fs.writeFileSync('README.md', readme);
           core.info(`Updated ${{ inputs.repo }} to ${latest}`);


### PR DESCRIPTION
inputs.repo is interpolated directly into a RegExp string. If it contains metacharacters (., +, *, etc.), the regex matches incorrectly or fails. Escapes special chars before constructing the regex.

Fixes #1585