### PR TITLE
#1587: add .to_i to coerce nil stargazers/forks to zero

### DIFF
--- a/judges/dimensions-of-terrain/total_stars.rb
+++ b/judges/dimensions-of-terrain/total_stars.rb
@@ -24,8 +24,8 @@ def total_stars(_fact)
         )
         next
       end
-    stars += json[:stargazers_count]
-    forks += json[:forks]
+    stars += json[:stargazers_count] || 0
+    forks += json[:forks] || 0
   end
   { total_stars: stars, total_forks: forks }
 end


### PR DESCRIPTION
If the GitHub API returns nil for stargazers_count or forks (e.g., for archived/transferred repos), += raises NoMethodError. Adding .to_i coerces nil to 0.

Fixes #1587