### PR TITLE
#1589: remove --halt now,fail=1 from parallel to show all failures

### DIFF
--- a/makes/entries.sh
+++ b/makes/entries.sh
@@ -30,4 +30,4 @@ export -f run_test
 export base
 
 find "${base}/entries" -name '*.sh' -exec basename {} \; | \
-    parallel --halt now,fail=1 --line-buffer run_test
+    parallel --line-buffer run_test


### PR DESCRIPTION
--halt now,fail=1 stops all remaining jobs immediately on the first failure, hiding other broken tests. Removing it lets all tests run to completion, showing the full picture in a single CI run.

Fixes #1589