### PR TITLE
#1594: make max missing issues per cycle configurable via max_missing option

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ The following `k=v` pairs inside the `options` may be important:
   `yegor256/judges` means a specific repo,
   and
   `-yegor256/judges` means an exclusion of the repo from the list.
+* `max_missing=17` is the maximum number of missing issues backfilled
+  per judge cycle (see `find-missing-issues` judge)
 * `sqlite_cache_maxsize=10M` is the maximum size of HTTP cache file
 * `sqlite_cache_maxvsize=10K` is the maximum size of a single HTTP entry to cache
 

--- a/judges/find-missing-issues/find-missing-issues.rb
+++ b/judges/find-missing-issues/find-missing-issues.rb
@@ -17,6 +17,8 @@ require_relative '../../lib/issue_was_lost'
 
 ts = Fbe::Tombstone.new
 
+MAX_MISSING = Integer($options.max_missing || 17)
+
 Fbe.consider('(and (eq where "github") (exists repository) (unique repository))') do |r|
   repo = Fbe.octo.repo_name_by_id(r.repository)
   issues = Fbe.fb.query(
@@ -89,7 +91,7 @@ Fbe.consider('(and (eq where "github") (exists repository) (unique repository))'
       $loog.info("Missing #{type} #{Fbe.issue(f)} was found opened #{f.when.ago} ago")
     end
     added << i
-    break if added.size > 16
+    break if added.size >= MAX_MISSING
   end
   if missing.empty?
     $loog.info("No missing issues in #{repo}")


### PR DESCRIPTION
Extracted the hardcoded limit of 17 missing issues per cycle into a MAX_MISSING constant, configurable via the max_missing k=v option inside options. Documented in README.md.

Fixes #1594