### PR TITLE
#1607: return cursor instead of nil on tombstoned issues

### DIFF
--- a/judges/find-earliest-issue/find-earliest-issue.rb
+++ b/judges/find-earliest-issue/find-earliest-issue.rb
@@ -36,7 +36,7 @@ Fbe.iterate do
       end
     next latest if json.nil?
     i = json[:number]
-    next if Fbe::Tombstone.new.has?('github', repository, i)
+    next latest if Fbe::Tombstone.new.has?('github', repository, i)
     Fbe.fb.txn do |fbt|
       f =
         Fbe.if_absent(fb: fbt) do |ff|

--- a/judges/find-latest-issue/find-latest-issue.rb
+++ b/judges/find-latest-issue/find-latest-issue.rb
@@ -36,7 +36,7 @@ Fbe.iterate do
       end
     next latest if json.nil?
     i = json[:number]
-    next if Fbe::Tombstone.new.has?('github', repository, i)
+    next latest if Fbe::Tombstone.new.has?('github', repository, i)
     Fbe.fb.txn do |fbt|
       f =
         Fbe.if_absent(fb: fbt) do |ff|


### PR DESCRIPTION
Bare `next` in Fbe.iterate over blocks returns nil, but the block must return an Integer. Changed to `next latest` (the cursor variable) like all other early returns in the same blocks.

Fixes #1607