### PR TITLE
#1655: guard nil repo size in total_commits_pushed

### DIFF
--- a/judges/quantity-of-deliverables/total_commits_pushed.rb
+++ b/judges/quantity-of-deliverables/total_commits_pushed.rb
@@ -14,7 +14,8 @@ def total_commits_pushed(fact)
   hoc = 0
   Fbe.unmask_repos do |repo|
     begin
-      next if Fbe.octo.repository(repo)[:size].zero?
+      json = Fbe.octo.repository(repo)
+      next if json[:size].nil? || json[:size].zero?
     rescue Octokit::NotFound, Octokit::Deprecated => e
       $loog.info("#{repo} can't be inspected: #{e.class}: #{e.message}")
       next

--- a/test/judges/test-quantity-of-deliverables.rb
+++ b/test/judges/test-quantity-of-deliverables.rb
@@ -134,6 +134,33 @@ class TestQuantityOfDeliverables < Jp::Test
     end
   end
 
+  def test_total_commits_pushed_skips_nil_size
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repos/foo/nosize', body: { id: 42, full_name: 'foo/nosize', open_issues: 0 })
+    stub_github(
+      'https://api.github.com/repos/foo/good',
+      body: { id: 43, full_name: 'foo/good', open_issues: 0, size: 100 }
+    )
+    graph = Object.new
+    graph.define_singleton_method(:total_commits_pushed) do |_owner, name, _since|
+      { 'commits' => name.length, 'hoc' => name.length * 100 }
+    end
+    fact = Object.new
+    fact.define_singleton_method(:since) { Time.parse('2025-10-01 00:00:00 UTC') }
+    unmask = proc { |&block| %w[foo/nosize foo/good].each { |repo| block.call(repo) } }
+    $global = {}
+    $judge = 'quantity-of-deliverables'
+    $loog = Loog::NULL
+    $options = Judges::Options.new({ 'repositories' => 'foo/foo' })
+    Fbe.stub(:unmask_repos, unmask) do
+      Fbe.stub(:github_graph, graph) do
+        load(File.join(__dir__, '../../judges/quantity-of-deliverables/total_commits_pushed.rb'))
+        assert_equal({ total_commits_pushed: 4, total_hoc_committed: 400 }, total_commits_pushed(fact))
+      end
+    end
+  end
+
   def test_total_commits_pushed_skips_graph_failures
     WebMock.disable_net_connect!
     rate_limit_up


### PR DESCRIPTION
`total_commits_pushed.rb:17` does `next if Fbe.octo.repository(repo)[:size].zero?`. When the repository payload omits `:size` (org-level responses or partial API results), `[:size]` is `nil` and `nil.zero?` raises `NoMethodError`, aborting the iteration cycle. The sibling judges (`total_commits.rb:25`, `total_files.rb:26`, `total_contributors.rb:26`) already use the safer `json[:size].nil? || json[:size].zero?` guard.

This aligns `total_commits_pushed` with that pattern so a missing size skips the repo instead of crashing. Added a test that stubs a repository response without a `size` key and confirms the judge skips it and still counts the healthy repo.

Closes #1655.
