### PR TITLE
#1594: make max missing issues per cycle configurable via max_missing option

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ The following `k=v` pairs inside the `options` may be important:
   `yegor256/judges` means a specific repo,
   and
   `-yegor256/judges` means an exclusion of the repo from the list.
+* `max_missing=17` is the maximum number of missing issues backfilled
+  per judge cycle (see `find-missing-issues` judge)
 * `sqlite_cache_maxsize=10M` is the maximum size of HTTP cache file
 * `sqlite_cache_maxvsize=10K` is the maximum size of a single HTTP entry to cache
 

--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ The dedicated action inputs above take precedence when a parameter
   `yegor256/judges` means a specific repo,
   and
   `-yegor256/judges` means an exclusion of the repo from the list.
+* `max_missing=17` is the maximum number of missing issues backfilled
+  per judge cycle (see `find-missing-issues` judge)
 * `sqlite_cache_maxsize=10M` is the maximum size of HTTP cache file
 * `sqlite_cache_maxvsize=10K` is the maximum size of a single HTTP entry to cache
   (these two are only available as k=v pairs)

--- a/judges/find-missing-issues/find-missing-issues.rb
+++ b/judges/find-missing-issues/find-missing-issues.rb
@@ -17,6 +17,8 @@ require_relative '../../lib/issue_was_lost'
 
 ts = Fbe::Tombstone.new
 
+MAX_MISSING = Integer($options.max_missing || 17)
+
 Fbe.consider('(and (eq where "github") (exists repository) (unique repository))') do |r|
   repo = Fbe.octo.repo_name_by_id(r.repository)
   issues = Fbe.fb.query(
@@ -89,7 +91,7 @@ Fbe.consider('(and (eq where "github") (exists repository) (unique repository))'
       $loog.info("Missing #{type} #{Fbe.issue(f)} was found opened #{f.when.ago} ago")
     end
     added << i
-    break if added.size > 16
+    break if added.size >= MAX_MISSING
   end
   if missing.empty?
     $loog.info("No missing issues in #{repo}")

--- a/judges/find-missing-issues/find-missing-issues.rb
+++ b/judges/find-missing-issues/find-missing-issues.rb
@@ -17,8 +17,6 @@ require_relative '../../lib/issue_was_lost'
 
 ts = Fbe::Tombstone.new
 
-MAX_MISSING = Integer($options.max_missing || 17)
-
 Fbe.consider('(and (eq where "github") (exists repository) (unique repository))') do |r|
   repo =
     begin
@@ -104,7 +102,7 @@ Fbe.consider('(and (eq where "github") (exists repository) (unique repository))'
       $loog.info("Missing #{type} #{Fbe.issue(f)} was found opened #{f.when.ago} ago")
     end
     added << i
-    break if added.size >= MAX_MISSING
+    break if added.size >= Integer($options.max_missing || 17)
   end
   if missing.empty?
     $loog.info("No missing issues in #{repo}")

--- a/judges/find-missing-issues/find-missing-issues.rb
+++ b/judges/find-missing-issues/find-missing-issues.rb
@@ -17,6 +17,8 @@ require_relative '../../lib/issue_was_lost'
 
 ts = Fbe::Tombstone.new
 
+MAX_MISSING = Integer($options.max_missing || 17)
+
 Fbe.consider('(and (eq where "github") (exists repository) (unique repository))') do |r|
   repo =
     begin
@@ -102,7 +104,7 @@ Fbe.consider('(and (eq where "github") (exists repository) (unique repository))'
       $loog.info("Missing #{type} #{Fbe.issue(f)} was found opened #{f.when.ago} ago")
     end
     added << i
-    break if added.size > 16
+    break if added.size >= MAX_MISSING
   end
   if missing.empty?
     $loog.info("No missing issues in #{repo}")


### PR DESCRIPTION
Extracted the hardcoded limit of 17 missing issues per cycle into a `MAX_MISSING` constant, configurable via the `max_missing` k=v option inside options. Documented in README.md.

Fixes #1594

---

*Replaces closed PR #1639 (branch renamed from `fix/1594-max-missing` → `1594-max-missing` to follow naming convention).*

Closes #1594