### PR TITLE
#1572: document auto-populated job_id in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,10 @@ The following environment variables are recognized by the Docker entry point:
 Note: `action_version` and `vitals_url` are automatically populated
   by the entry point and should not be set manually.
 
+Note: `job_id` is automatically populated from `GITHUB_RUN_ID` and
+  should not be set manually; `action_version` and `vitals_url` are
+  also set automatically by the entry point.
+
 The `zerocracy/pages-action` plugin is responsible for rendering
   the summary HTML page: its configuration is not explained here,
   check its [own repository](https://github.com/zerocracy/pages-action).

--- a/README.md
+++ b/README.md
@@ -110,6 +110,10 @@ The following `k=v` pairs inside the `options` may be important:
 * `sqlite_cache_maxsize=10M` is the maximum size of HTTP cache file
 * `sqlite_cache_maxvsize=10K` is the maximum size of a single HTTP entry to cache
 
+Note: `job_id` is automatically populated from `GITHUB_RUN_ID` and
+  should not be set manually; `action_version` and `vitals_url` are
+  also set automatically by the entry point.
+
 The `zerocracy/pages-action` plugin is responsible for rendering
   the summary HTML page: its configuration is not explained here,
   check its [own repository](https://github.com/zerocracy/pages-action).

--- a/README.md
+++ b/README.md
@@ -117,12 +117,8 @@ The following environment variables are recognized by the Docker entry point:
   development, testing with a non-release build, air-gapped environments,
   or faster CI when version checking is not critical.
 
-Note: `action_version` and `vitals_url` are automatically populated
-  by the entry point and should not be set manually.
-
-Note: `job_id` is automatically populated from `GITHUB_RUN_ID` and
-  should not be set manually; `action_version` and `vitals_url` are
-  also set automatically by the entry point.
+Note: `job_id`, `action_version`, and `vitals_url` are automatically
+  populated by the entry point and should not be set manually.
 
 The `zerocracy/pages-action` plugin is responsible for rendering
   the summary HTML page: its configuration is not explained here,


### PR DESCRIPTION
Adds a note that `job_id`, `action_version`, and `vitals_url` are automatically set by the entry point and should not be configured manually.

Fixes #1572

---

*Replaces closed PR #1621 (branch renamed from `fix/1572-doc-job-id` → `1572-doc-job-id` to follow naming convention).*

Closes #1572