### PR TITLE
#1662 #1663 #1668: escape string values in factbase Sexp queries to prevent DSL injection

### DIFF
--- a/judges/github-events/github-events.rb
+++ b/judges/github-events/github-events.rb
@@ -389,7 +389,7 @@ Fbe.iterate do
       pairs.map do |prop, value|
         val =
           case value
-          when String then "'#{value}'"
+          when String then "'#{value.gsub("'", "\\\\'")}'"
           when Time then value.utc.iso8601
           else value
           end

--- a/lib/cover_qo.rb
+++ b/lib/cover_qo.rb
@@ -9,7 +9,9 @@ require_relative 'jp'
 
 def Jp.cover_qo(days, judge: $judge, loog: $loog, today: Time.parse(ENV['TODAY'] || Time.now.utc.iso8601))
   slice = days * 24 * 60 * 60
-  facts = Fbe.fb.query("(and (eq what '#{judge}') (exists since) (exists when))").each.to_a.sort_by(&:since)
+  facts = Fbe.fb.query(
+    "(and (eq what '#{judge.gsub("'", "\\\\'")}') (exists since) (exists when))"
+  ).each.to_a.sort_by(&:since)
   last = facts.map(&:when).max
   if last.nil?
     Fbe.fb.insert.then do |n|

--- a/lib/issue_was_lost.rb
+++ b/lib/issue_was_lost.rb
@@ -8,6 +8,10 @@ require 'fbe/tombstone'
 require_relative 'jp'
 
 def Jp.issue_was_lost(where, repository, issue)
+  where = where.to_s
+  raise(ArgumentError, "Invalid 'where': #{where.inspect}") if where.include?("'")
+  repository = Integer(repository)
+  issue = Integer(issue)
   stale =
     Fbe.fb.query(
       "(and


### PR DESCRIPTION
## Changes

Three injection guards in factbase Sexp query construction:

### lib/issue_was_lost.rb (fixes #1662)
- Validate `where` has no single quotes before interpolation
- Coerce `repository` and `issue` to Integer (prevents bare-atom injection)

### judges/github-events/github-events.rb (fixes #1663)
- Escape single quotes in String values inside `twice?` query builder

### lib/cover_qo.rb (fixes #1668)
- Escape single quotes in `judge` name before query interpolation

## Background

The factbase Sexp DSL interprets single-quoted strings and bare atoms. Malformed values (strings with `'`, non-numeric `repository`/`issue`) could rewrite query predicates, leading to filter bypass or data exposure. All current callers pass well-typed values, but these guards prevent future regressions.