### PR TITLE
#1686: remove vitals_url override from INPUT_OPTIONS to prevent phishing

### DIFF
--- a/entry.sh
+++ b/entry.sh
@@ -105,16 +105,12 @@ VITALS_URL="https://${GITHUB_REPOSITORY_OWNER}.github.io/${GITHUB_REPO_NAME}/${n
 
 declare -a options=()
 while IFS= read -r o; do
-    s=$(echo "${o}" | xargs)
+    s=$(echo "${o}" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
     if [ "${s}" = "" ]; then
         continue
     fi
     k=$(echo "${s} "| cut -f1 -d '=')
     v=$(echo "${s}" | cut -f2- -d '=')
-    if [[ "${k}" == vitals_url ]]; then
-        VITALS_URL="${v}"
-        continue
-    fi
     options+=("--option=${k}=${v}");
 done <<< "${INPUT_OPTIONS}"
 if [ -z "${INPUT_REPOSITORIES}" ]; then


### PR DESCRIPTION
## Changes

Fixes #1686, fixes #1685.

### entry.sh
- Remove the `vitals_url` override from INPUT_OPTIONS processing. Users could redirect
  the Vitals link to arbitrary URLs via `INPUT_OPTIONS=vitals_url=https://evil.com`.
  The vitals_url is now always auto-generated from the repository name.
- Replace `xargs` with `sed` trim to prevent corruption of special characters
  (quotes, backslashes) in option values.

## Background

The `vitals_url` is auto-generated as `https://{owner}.github.io/{repo}/{factbase}-vitals.html`
and is a fixed value derived from the action context. There is no legitimate use case
for overriding it via k=v options — doing so creates a phishing vector in the job summary.