### PR TITLE
#1702 #1703: harden update-version against regex and replacement injection

### DIFF
--- a/.github/actions/update-version/action.yml
+++ b/.github/actions/update-version/action.yml
@@ -28,7 +28,12 @@ runs:
           }
           const fs = require('fs');
           let readme = fs.readFileSync('README.md', 'utf8');
-          const escaped = '${{ inputs.repo }}'.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-          readme = readme.replace(new RegExp(escaped + '@.+$', 'gm'), `${{ inputs.repo }}@${latest}`);
+          const repo = '${{ inputs.repo }}';
+          if (!/^[a-zA-Z0-9_.-]+$/.test(repo)) {
+            core.setFailed('Invalid repo name: ' + repo);
+            return;
+          }
+          const escaped = repo.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+          readme = readme.replace(new RegExp(escaped + '@.+$', 'gm'), () => repo + '@' + latest);
           fs.writeFileSync('README.md', readme);
           core.info(`Updated ${{ inputs.repo }} to ${latest}`);


### PR DESCRIPTION
## Changes

Fixes #1702, fixes #1703.

### .github/actions/update-version/action.yml

Three hardening measures:

1. **Input validation**: reject `inputs.repo` that doesn't match `/^[a-zA-Z0-9_.-]+$/` — prevents regex injection from future callers
2. **Regex escape completeness**: ensure all special regex characters are escaped before constructing `new RegExp()`
3. **Replacement injection**: use a function callback for `String.prototype.replace()` instead of a string replacement — avoids `$` backreference interpretation (`$&`, ``, `$'`, etc.) in the replacement value

## Background

While `inputs.repo` is currently hardcoded to `judges-action` in `up.yml`, the composite action is reusable, and future callers could pass untrusted values.