### PR TITLE
#1662: prevent DSL injection in issue_was_lost factbase query

### DIFF
--- a/lib/issue_was_lost.rb
+++ b/lib/issue_was_lost.rb
@@ -8,6 +8,10 @@ require 'fbe/tombstone'
 require_relative 'jp'
 
 def Jp.issue_was_lost(where, repository, issue)
+  where = where.to_s
+  raise(ArgumentError, "Invalid 'where': #{where.inspect}") if where.include?("'")
+  repository = Integer(repository)
+  issue = Integer(issue)
   stale =
     Fbe.fb.query(
       "(and


### PR DESCRIPTION
## Description

`lib/issue_was_lost.rb` interpolates `where`, `repository`, and `issue` directly into a Factbase Sexp query. A malformed `where` value containing `'` breaks the string, while non-numeric `repository`/`issue` could inject new clauses.

## Fix

- Validate `where` has no single quotes before interpolation
- Coerce `repository` and `issue` to Integer with `Integer()` to prevent bare-atom injection

Closes #1662