### PR TITLE
#1663: prevent DSL injection in twice? query builder

### DIFF
--- a/judges/github-events/github-events.rb
+++ b/judges/github-events/github-events.rb
@@ -389,7 +389,7 @@ Fbe.iterate do
       pairs.map do |prop, value|
         val =
           case value
-          when String then "'#{value}'"
+          when String then "'#{value.gsub("'", "\\\\'")}'"
           when Time then value.utc.iso8601
           else value
           end

--- a/judges/github-events/github-events.rb
+++ b/judges/github-events/github-events.rb
@@ -14,6 +14,7 @@ require 'tago'
 require_relative '../../lib/fill_fact'
 require_relative '../../lib/pull_request'
 require_relative '../../lib/supervision'
+require_relative '../../lib/twice'
 
 Fbe.iterate do
   as 'events_were_scanned'
@@ -381,22 +382,6 @@ Fbe.iterate do
     end
     skip(json)
   end
-
-  def self.twice?(fb, fact, what, fields)
-    pairs = fields.map { [_1, fact[_1]&.first] }
-    pairs.reject! { _1.last.nil? }
-    eqs =
-      pairs.map do |prop, value|
-        val =
-          case value
-          when String then "'#{value.gsub("'", "\\\\'")}'"
-          when Time then value.utc.iso8601
-          else value
-          end
-        "(eq #{prop} #{val})"
-      end
-    fb.query("(and (eq what '#{what}') #{eqs.join(' ')})").each.to_a.size > 1
-  end
   over do |repository, latest|
     begin
       rname = Fbe.octo.repo_name_by_id(repository)
@@ -466,7 +451,7 @@ Fbe.iterate do
               next
             end
             fill(f, json)
-            uniques.each { |w, ff| throw :rollback if twice?(fbt, f, w, ff) }
+            uniques.each { |w, ff| throw :rollback if Jp.twice?(fbt, f, w, ff) }
             if f['issue']
               throw :rollback unless Fbe.fb.query(
                 "(and

--- a/lib/twice.rb
+++ b/lib/twice.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+# SPDX-License-Identifier: MIT
+
+require_relative 'jp'
+
+def Jp.twice?(fb, fact, what, fields)
+  pairs = fields.map { [_1, fact[_1]&.first] }
+  pairs.reject! { _1.last.nil? }
+  fb.query(
+    "(and (eq what '#{what}') " \
+    "#{pairs.map do |prop, value|
+      case value
+      when String then "(eq #{prop} '#{value.gsub("'", "\\\\'")}')"
+      when Time then "(eq #{prop} #{value.utc.iso8601})"
+      else "(eq #{prop} #{value})"
+      end
+    end.join(' ')})"
+  ).each.to_a.size > 1
+end

--- a/test/lib/test_twice.rb
+++ b/test/lib/test_twice.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+# SPDX-License-Identifier: MIT
+
+require 'factbase'
+require_relative '../../lib/twice'
+require_relative '../test__helper'
+
+class TestTwice < Jp::Test
+  def test_apostrophe_in_label_is_escaped
+    fb = Factbase.new
+    fb.insert.then do |f|
+      f.what = 'label-was-attached'
+      f.where = 'github'
+      f.repository = 42
+      f.issue = 1
+      f.label = "O'Brien"
+    end
+    fact = fb.query('(eq what "label-was-attached")').each.first
+    refute(Jp.twice?(fb, fact, 'label-was-attached', %w[where repository issue label]))
+  end
+
+  def test_apostrophe_in_label_detects_duplicate
+    fb = Factbase.new
+    2.times do
+      fb.insert.then do |f|
+        f.what = 'label-was-attached'
+        f.where = 'github'
+        f.repository = 42
+        f.issue = 1
+        f.label = "O'Brien"
+      end
+    end
+    fact = fb.query('(eq what "label-was-attached")').each.first
+    assert(Jp.twice?(fb, fact, 'label-was-attached', %w[where repository issue label]))
+  end
+end


### PR DESCRIPTION
## Description

The `twice?` function in `github-events.rb` builds a factbase query by interpolating string values wrapped in single quotes. If a value contains `'` (e.g. label name `O'Brien`), the resulting Sexp is malformed or injection-vulnerable.

## Fix

Escape single quotes in String values before Sexp interpolation.

Closes #1663