### PR TITLE
#1668: prevent DSL injection in cover_qo factbase query

### DIFF
--- a/lib/cover_qo.rb
+++ b/lib/cover_qo.rb
@@ -9,7 +9,9 @@ require_relative 'jp'
 
 def Jp.cover_qo(days, judge: $judge, loog: $loog, today: Time.parse(ENV['TODAY'] || Time.now.utc.iso8601))
   slice = days * 24 * 60 * 60
-  facts = Fbe.fb.query("(and (eq what '#{judge}') (exists since) (exists when))").each.to_a.sort_by(&:since)
+  facts = Fbe.fb.query(
+    "(and (eq what '#{judge.gsub("'", "\\\\'")}') (exists since) (exists when))"
+  ).each.to_a.sort_by(&:since)
   last = facts.map(&:when).max
   if last.nil?
     Fbe.fb.insert.then do |n|


### PR DESCRIPTION
## Description

`lib/cover_qo.rb` builds a factbase query by interpolating `judge` name. If the name contains `'`, the Sexp is malformed.

## Fix

Escape single quotes in the judge name before query interpolation.

Closes #1668