### PR TITLE
#1702: prevent regex injection in update-version action

### DIFF
--- a/.github/actions/update-version/action.yml
+++ b/.github/actions/update-version/action.yml
@@ -28,7 +28,12 @@ runs:
           }
           const fs = require('fs');
           let readme = fs.readFileSync('README.md', 'utf8');
-          const escaped = '${{ inputs.repo }}'.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+          const repo = '${{ inputs.repo }}';
+          if (!/^[a-zA-Z0-9_.-]+$/.test(repo)) {
+            core.setFailed('Invalid repo name: ' + repo);
+            return;
+          }
+          const escaped = repo.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
           readme = readme.replace(new RegExp(escaped + '@.+$', 'gm'), `${{ inputs.repo }}@${latest}`);
           fs.writeFileSync('README.md', readme);
           core.info(`Updated ${{ inputs.repo }} to ${latest}`);


### PR DESCRIPTION
## Description

The `update-version` composite action constructs a `new RegExp()` from `inputs.repo`. A malicious repo name could inject regex patterns.

## Fix

Validate `inputs.repo` against an allowlist pattern (`/^[a-zA-Z0-9_.-]+$/`) before using it in regex construction.

Closes #1702