### PR TITLE
#1703: prevent replacement string injection in update-version action

### DIFF
--- a/.github/actions/update-version/action.yml
+++ b/.github/actions/update-version/action.yml
@@ -29,6 +29,6 @@ runs:
           const fs = require('fs');
           let readme = fs.readFileSync('README.md', 'utf8');
           const escaped = '${{ inputs.repo }}'.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-          readme = readme.replace(new RegExp(escaped + '@.+$', 'gm'), `${{ inputs.repo }}@${latest}`);
+          readme = readme.replace(new RegExp(escaped + '@.+$', 'gm'), () => '${{ inputs.repo }}@' + latest);
           fs.writeFileSync('README.md', readme);
           core.info(`Updated ${{ inputs.repo }} to ${latest}`);


### PR DESCRIPTION
## Description

`String.prototype.replace()` interprets `$` patterns (`$&`, ``, `$'`, etc.) in string replacement values. If a tag name ever contained these characters, the README content would be silently corrupted.

## Fix

Use a function callback instead of a string for `replace()` — function return values are used literally without any `$` processing.

Closes #1703