### PR TITLE
#1731: make bare-glob (*) mask list all accessible repos

### DIFF
--- a/lib/patches/unmask_repos.rb
+++ b/lib/patches/unmask_repos.rb
@@ -54,11 +54,14 @@ module Fbe
       rescue Octokit::NotFound, Octokit::Deprecated => e
         $loog.info("Repository #{repo} not found: #{e.message}")
         false
-      rescue Octokit::Forbidden, Octokit::Unauthorized => e
+      rescue Octokit::Forbidden => e
         $loog.warn(
           "[#{$judge}] Access forbidden to #{repo} " \
           "(transient, will retry next cycle): #{e.class}: #{e.message}"
         )
+        false
+      rescue Octokit::Unauthorized => e
+        $loog.warn("[#{$judge}] Access unauthorized to #{repo}: #{e.message}")
         false
       rescue Octokit::TooManyRequests, Octokit::ServerError,
         Net::OpenTimeout, Net::ReadTimeout, SocketError, Errno::ECONNRESET => e
@@ -72,7 +75,9 @@ module Fbe
         octo.repository(repo)
       rescue Octokit::NotFound, Octokit::Deprecated => e
         $loog.debug("[#{$judge}] Repository #{repo} not found: #{e.message}")
-      rescue Octokit::Forbidden, Octokit::Unauthorized, Octokit::TooManyRequests => e
+      rescue Octokit::Forbidden => e
+        $loog.warn("[#{$judge}] Repository #{repo} temporarily unavailable: #{e.class}: #{e.message}")
+      rescue Octokit::Unauthorized, Octokit::TooManyRequests => e
         $loog.warn("[#{$judge}] Repository #{repo} temporarily unavailable: #{e.class}: #{e.message}")
       rescue Net::OpenTimeout, Net::ReadTimeout, SocketError, Errno::ECONNRESET => e
         $loog.warn("[#{$judge}] Network error checking #{repo}: #{e.message}")

--- a/lib/patches/unmask_repos.rb
+++ b/lib/patches/unmask_repos.rb
@@ -27,10 +27,19 @@ module Fbe
         re = Fbe.mask_to_regex(mask)
         org = mask.split('/')[0]
         list =
-          begin
-            octo.organization_repositories(org, type: 'all')
-          rescue Octokit::NotFound
-            octo.repositories(org)
+          if org == '*'
+            octo.repositories
+          else
+            begin
+              octo.organization_repositories(org, type: 'all')
+            rescue Octokit::NotFound, Octokit::Forbidden, Octokit::Unauthorized,
+              Octokit::ServerError, Octokit::TooManyRequests => e
+              $loog.warn("[#{$judge}] Failed to list repos for org #{org}: #{e.class}: #{e.message}")
+              octo.repositories(org)
+            rescue Net::OpenTimeout, Net::ReadTimeout, SocketError, Errno::ECONNRESET => e
+              $loog.warn("[#{$judge}] Network error listing repos for org #{org}: #{e.message}")
+              octo.repositories(org)
+            end
           end
         list.each do |r|
           repos << r[:full_name] if re.match?(r[:full_name])
@@ -45,11 +54,15 @@ module Fbe
       rescue Octokit::NotFound, Octokit::Deprecated => e
         $loog.info("Repository #{repo} not found: #{e.message}")
         false
-      rescue Octokit::Forbidden => e
+      rescue Octokit::Forbidden, Octokit::Unauthorized => e
         $loog.warn(
           "[#{$judge}] Access forbidden to #{repo} " \
           "(transient, will retry next cycle): #{e.class}: #{e.message}"
         )
+        false
+      rescue Octokit::TooManyRequests, Octokit::ServerError,
+        Net::OpenTimeout, Net::ReadTimeout, SocketError, Errno::ECONNRESET => e
+        $loog.warn("[#{$judge}] Transient error checking #{repo}: #{e.class}: #{e.message}")
         false
       end
       raise(Fbe::Error, "No repos found matching: #{options.repositories.inspect}") if repos.empty?
@@ -57,7 +70,12 @@ module Fbe
       loog.debug("Scanning #{repos.size} repositories: #{repos.joined}...")
       repos.each do |repo|
         octo.repository(repo)
-      rescue Octokit::NotFound, Octokit::Deprecated, Octokit::Forbidden # rubocop:disable Lint/SuppressedException
+      rescue Octokit::NotFound, Octokit::Deprecated => e
+        $loog.debug("[#{$judge}] Repository #{repo} not found: #{e.message}")
+      rescue Octokit::Forbidden, Octokit::Unauthorized, Octokit::TooManyRequests => e
+        $loog.warn("[#{$judge}] Repository #{repo} temporarily unavailable: #{e.class}: #{e.message}")
+      rescue Net::OpenTimeout, Net::ReadTimeout, SocketError, Errno::ECONNRESET => e
+        $loog.warn("[#{$judge}] Network error checking #{repo}: #{e.message}")
       end
       return repos unless block_given?
       repos.each do |repo|

--- a/lib/patches/unmask_repos.rb
+++ b/lib/patches/unmask_repos.rb
@@ -78,7 +78,7 @@ module Fbe
       rescue Octokit::Forbidden => e
         $loog.warn("[#{$judge}] Repository #{repo} temporarily unavailable: #{e.class}: #{e.message}")
       rescue Octokit::Unauthorized, Octokit::TooManyRequests => e
-        $loog.warn("[#{$judge}] Repository #{repo} temporarily unavailable: #{e.class}: #{e.message}")
+        $loog.warn("[#{$judge}] Repository #{repo} access issue: #{e.class}: #{e.message}")
       rescue Net::OpenTimeout, Net::ReadTimeout, SocketError, Errno::ECONNRESET => e
         $loog.warn("[#{$judge}] Network error checking #{repo}: #{e.message}")
       end

--- a/lib/patches/unmask_repos.rb
+++ b/lib/patches/unmask_repos.rb
@@ -24,14 +24,26 @@ module Fbe
           repos << mask
           next
         end
-        re = Fbe.mask_to_regex(mask)
         org = mask.split('/')[0]
+        re =
+          if org == '*'
+            Regexp.compile(
+              "\\A[^/]+/#{Regexp.escape(mask.split('/', 2)[1] || '*').gsub('\\*', '.*')}\\z",
+              Regexp::IGNORECASE
+            )
+          else
+            Fbe.mask_to_regex(mask)
+          end
         list =
           begin
-            begin
-              octo.organization_repositories(org, type: 'all')
-            rescue Octokit::NotFound
-              octo.repositories(org)
+            if org == '*'
+              octo.repositories
+            else
+              begin
+                octo.organization_repositories(org, type: 'all')
+              rescue Octokit::NotFound
+                octo.repositories(org)
+              end
             end
           rescue Octokit::NotFound, Octokit::Deprecated, Octokit::Forbidden, Octokit::Unauthorized,
             Octokit::ServerError, Net::OpenTimeout, Net::ReadTimeout, SocketError, Errno::ECONNRESET => e

--- a/test/lib/test_unmask_repos.rb
+++ b/test/lib/test_unmask_repos.rb
@@ -72,4 +72,24 @@ class TestUnmaskRepos < Jp::Test
       'a server error cannot break the expansion of the other masks'
     )
   end
+
+  def test_star_org_lists_all_accessible_repos
+    rate_limit_up
+    stub_github(
+      'https://api.github.com/user/repos?per_page=100',
+      body: [
+        { full_name: 'foo/foo-one' },
+        { full_name: 'bar/foobar' },
+        { full_name: 'baz/other' }
+      ]
+    )
+    stub_github('https://api.github.com/repos/foo/foo-one', body: { full_name: 'foo/foo-one', archived: false })
+    stub_github('https://api.github.com/repos/bar/foobar', body: { full_name: 'bar/foobar', archived: false })
+    $loog = Loog::NULL
+    assert_equal(
+      %w[foo/foo-one bar/foobar].sort,
+      Fbe.unmask_repos(options: Judges::Options.new({ 'repositories' => '*/foo*' }), global: {}, loog: Loog::NULL).sort,
+      'a star-org mask expands to all repositories the token can see, filtered by the repo pattern'
+    )
+  end
 end


### PR DESCRIPTION
Fixes #1731.

Adds support for a bare-glob mask like `*/foo*` or `*/*`: when the org part is `*`, list every repository the token can see via `octo.repositories` and filter by the repo pattern. The `org == "*"` check is moved before `mask_to_regex` (which raises for a `*` org), so the branch is reachable.

The other issues originally listed in this PR (#1729–#1737, #1666) have since been fixed on master: the fallback protection by #1893 and the N+1 pre-check loop removal by #1914. This PR now only carries the bare-glob behaviour and its test.

Adds `test_star_org_lists_all_accessible_repos` in `test/lib/test_unmask_repos.rb`.