### PR TITLE
#1648 #1656 #1724 #1727 #1732: add nil guards for arithmetic operations

### DIFF
--- a/judges/code-was-reviewed/code-was-reviewed.rb
+++ b/judges/code-was-reviewed/code-was-reviewed.rb
@@ -71,7 +71,7 @@ Fbe.consider(
         end
       next if n.nil?
       n.when = review[:submitted_at]
-      n.hoc = pr[:additions] + pr[:deletions]
+      n.hoc = (pr[:additions] || 0) + (pr[:deletions] || 0)
       n.author = pr.dig(:user, :id)
       n.comments =
         begin
@@ -99,7 +99,7 @@ Fbe.consider(
           )
           0
         end
-      n.seconds = Integer(review[:submitted_at] - pr[:created_at])
+      n.seconds = Integer(review[:submitted_at] - pr[:created_at]) if pr[:created_at] && review[:submitted_at]
       n.details =
         "The pull request #{Fbe.issue(n)} with #{n.hoc} HoC " \
         "created by #{Fbe.who(n, :author)} was reviewed by #{Fbe.who(n)} " \

--- a/judges/fix-missing-hoc/fix-missing-hoc.rb
+++ b/judges/fix-missing-hoc/fix-missing-hoc.rb
@@ -36,7 +36,7 @@ Fbe.consider(
       )
       next
     end
-  f.hoc = json[:additions] + json[:deletions]
+  f.hoc = (json[:additions] || 0) + (json[:deletions] || 0)
   $loog.info("Hoc found for #{Fbe.issue(f)}: #{f.hoc}")
 end
 

--- a/judges/github-events/github-events.rb
+++ b/judges/github-events/github-events.rb
@@ -287,8 +287,8 @@ Fbe.iterate do
         end
         skip(json) unless json.dig(:payload, :review, :state) == 'approved'
         fact.what = 'pull-was-reviewed'
-        fact.hoc = pull[:additions] + pull[:deletions]
-        fact.comments = pull[:comments] + pull[:review_comments]
+        fact.hoc = (pull[:additions] || 0) + (pull[:deletions] || 0)
+        fact.comments = (pull[:comments] || 0) + (pull[:review_comments] || 0)
         fact.review_comments = pull[:review_comments]
         fact.commits = pull[:commits]
         fact.files = pull[:changed_files]

--- a/judges/pull-was-merged/pull-was-merged.rb
+++ b/judges/pull-was-merged/pull-was-merged.rb
@@ -106,7 +106,7 @@ Fbe.iterate do
           n.where = 'github'
         end
       raise(RuntimeError, "Pull already merged in #{repo}##{issue}") if nn.nil?
-      nn.hoc = json[:additions] + json[:deletions]
+      nn.hoc = (json[:additions] || 0) + (json[:deletions] || 0)
       nn.files = json[:changed_files] if json[:changed_files]
       nn.branch = json[:head][:ref]
       Jp.fill_fact_by_hash(nn, Jp.comments_info(json))

--- a/judges/quality-of-service/some_pull_hoc_size.rb
+++ b/judges/quality-of-service/some_pull_hoc_size.rb
@@ -28,7 +28,7 @@ def some_pull_hoc_size(fact)
           )
           next
         end
-      hocs << (pull[:additions] + pull[:deletions])
+      hocs << ((pull[:additions] || 0) + (pull[:deletions] || 0))
       files << pull[:changed_files]
     end
   end

--- a/judges/quality-of-service/some_triage_time.rb
+++ b/judges/quality-of-service/some_triage_time.rb
@@ -45,6 +45,7 @@ def some_triage_time(fact)
         "
       ).each.min_by(&:when)
       next unless ff
+      next unless issue[:created_at]
       delta = ff.when - issue[:created_at]
       next if delta < threshold
       times << delta

--- a/judges/quantity-of-deliverables/total_commits_pushed.rb
+++ b/judges/quantity-of-deliverables/total_commits_pushed.rb
@@ -29,8 +29,8 @@ def total_commits_pushed(fact)
     owner, name = repo.split('/')
     begin
       Fbe.github_graph.total_commits_pushed(owner, name, fact.since).then do |json|
-        commits += json['commits']
-        hoc += json['hoc']
+        commits += json['commits'] || 0
+        hoc += json['hoc'] || 0
       end
     rescue Octokit::NotFound, Octokit::Deprecated => e
       $loog.info("Can't count pushed commits in #{repo}: #{e.message}")

--- a/judges/quantity-of-deliverables/total_releases_published.rb
+++ b/judges/quantity-of-deliverables/total_releases_published.rb
@@ -12,7 +12,7 @@ def total_releases_published(fact)
   Fbe.unmask_repos do |repo|
     owner, name = repo.split('/')
     begin
-      releases += Fbe.github_graph.total_releases_published(owner, name, fact.since)['releases']
+      releases += Fbe.github_graph.total_releases_published(owner, name, fact.since)['releases'] || 0
     rescue GraphQL::Client::Error, Octokit::NotFound, Octokit::Deprecated => e
       $loog.info("Can't count releases in #{repo}: #{e.message}")
       next


### PR DESCRIPTION
## Changes

Same pattern across 8 files — nil guards for arithmetic that crashes when API returns nil values.

### Nil additions + deletions (fixes #1648)
- `code-was-reviewed.rb`, `github-events.rb`, `pull-was-merged.rb`, `fix-missing-hoc.rb`, `some_pull_hoc_size.rb`: `|| 0` guards on `pull[:additions]` + `pull[:deletions]`

### Nil GraphQL counts (fixes #1656)
- `total_commits_pushed.rb`: `|| 0` on `json['commits']` and `json['hoc']`
- `total_releases_published.rb`: `|| 0` on `json['releases']`

### Other nil guards
- `code-was-reviewed.rb`: guard `Integer(review[:submitted_at] - pr[:created_at])` with `if` check (fixes #1724)
- `some_triage_time.rb`: `next unless issue[:created_at]` before arithmetic (fixes #1732)
- `github-events.rb`: `|| 0` on `pull[:comments] + pull[:review_comments]` (fixes #1648)

**Note:** Multiple issues grouped — all are the same nil-arithmetic pattern across judges, same fix (`|| 0` or nil guard).

Closes #1648, #1656, #1724, #1727, #1732