### PR TITLE
#1661: prevent infinite loop in earliest() commit pagination

### DIFF
--- a/judges/github-events/github-events.rb
+++ b/judges/github-events/github-events.rb
@@ -110,11 +110,14 @@ Fbe.iterate do
   end
 
   def self.earliest(repo)
-    commits = Fbe.octo.commits(repo)
-    last = commits.last
-    while commits.size != 1
-      commits = Fbe.octo.commits(repo, sha: last[:sha])
+    page = 1
+    last = nil
+    loop do
+      raise(Fbe::Error, "Too many pages for commits of ##{repo}") if page > 100
+      commits = Fbe.octo.commits(repo, per_page: 100, page: page)
+      break if commits.empty?
       last = commits.last
+      page += 1
     end
     $loog.debug("The repo ##{repo} has this last commit: #{last}")
     last

--- a/test/judges/test-github-events.rb
+++ b/test/judges/test-github-events.rb
@@ -940,7 +940,7 @@ class TestGithubEvents < Jp::Test
         'X-RateLimit-Remaining' => '999'
       }
     )
-    stub_request(:get, 'https://api.github.com/repos/zerocracy/fbe/commits?per_page=100').to_return(
+    stub_request(:get, 'https://api.github.com/repos/zerocracy/fbe/commits?page=1&per_page=100').to_return(
       body: [
         { sha: '4683257342e98cd94becc2aa49900e720bd792e9' },
         { sha: '69a28ba1122af281936371bbb36f67e5b97246b1' }
@@ -950,12 +950,8 @@ class TestGithubEvents < Jp::Test
         'X-RateLimit-Remaining' => '999'
       }
     )
-    stub_request(
-      :get,
-      'https://api.github.com/repos/zerocracy/fbe/commits?' \
-      'per_page=100&sha=69a28ba1122af281936371bbb36f67e5b97246b1'
-    ).to_return(
-      body: [{ sha: '69a28ba1122af281936371bbb36f67e5b97246b1' }].to_json,
+    stub_request(:get, 'https://api.github.com/repos/zerocracy/fbe/commits?page=2&per_page=100').to_return(
+      body: [].to_json,
       headers: {
         'Content-Type': 'application/json',
         'X-RateLimit-Remaining' => '999'
@@ -1157,7 +1153,11 @@ class TestGithubEvents < Jp::Test
         { login: 'yegor512', id: 526_302 }
       ]
     )
-    stub_github('https://api.github.com/repos/foo/foo/commits?per_page=100', body: [{ sha: '4683257342e98cd94' }])
+    stub_github(
+      'https://api.github.com/repos/foo/foo/commits?page=1&per_page=100',
+      body: [{ sha: '4683257342e98cd94' }]
+    )
+    stub_github('https://api.github.com/repos/foo/foo/commits?page=2&per_page=100', body: [])
     stub_github(
       'https://api.github.com/repos/foo/foo/compare/4683257342e98cd94...0.0.3?per_page=100',
       body: {
@@ -2582,7 +2582,8 @@ class TestGithubEvents < Jp::Test
       'https://api.github.com/repos/foo/foo/contributors?per_page=100',
       body: [{ login: 'yegor256', id: 526_301 }]
     )
-    stub_github('https://api.github.com/repos/foo/foo/commits?per_page=100', body: [{ sha: 'abc123def456' }])
+    stub_github('https://api.github.com/repos/foo/foo/commits?page=1&per_page=100', body: [{ sha: 'abc123def456' }])
+    stub_github('https://api.github.com/repos/foo/foo/commits?page=2&per_page=100', body: [])
     stub_github(
       'https://api.github.com/repos/foo/foo/compare/abc123def456...1.0.0?per_page=100',
       status: 404,
@@ -2642,7 +2643,8 @@ class TestGithubEvents < Jp::Test
       status: 403,
       body: { message: 'Resource not accessible by integration' }
     )
-    stub_github('https://api.github.com/repos/foo/foo/commits?per_page=100', body: [{ sha: 'abc123def456' }])
+    stub_github('https://api.github.com/repos/foo/foo/commits?page=1&per_page=100', body: [{ sha: 'abc123def456' }])
+    stub_github('https://api.github.com/repos/foo/foo/commits?page=2&per_page=100', body: [])
     stub_github(
       'https://api.github.com/repos/foo/foo/compare/abc123def456...1.0.0?per_page=100',
       status: 403,


### PR DESCRIPTION
Changes the `earliest()` method in `github-events.rb` from sha-based pagination to page-based pagination with a safety limit of 100 pages, preventing infinite loops when commit history is very large or GitHub returns unexpected results.

Also updates test stubs to match the new `page=N` parameter in commit requests.

Closes #1661