### PR TITLE
#1678: advance cursor when search returns empty results

### DIFF
--- a/judges/find-all-issues/find-all-issues.rb
+++ b/judges/find-all-issues/find-all-issues.rb
@@ -109,6 +109,7 @@ require_relative '../../lib/qos_search'
           end
         end
         issue = first if issue < first
+        issue += 1 if seen.empty? && issue <= first
         m = [
           "Checked #{seen.count} #{type}s in #{repo}",
           ("(#{seen.joined(max: 8)})" unless seen.empty?),


### PR DESCRIPTION
When GitHub Search API returns an empty page of results, the cursor (`issue`) doesn't advance and the loop spins forever on the same empty page.

Added `issue += 1 if seen.empty? && issue <= first` to increment the cursor when no results are returned, ensuring forward progress.

Closes #1678