### PR TITLE
#1658: expand qosearch rescue to handle network and server errors

### DIFF
--- a/lib/qos_search.rb
+++ b/lib/qos_search.rb
@@ -52,4 +52,13 @@ rescue Octokit::TooManyRequests => e
   @offquota = true
   $loog.warn("[#{$judge}] GitHub Search API quota exhausted, stopping search calls: #{e.message}")
   nil
+rescue Octokit::Unauthorized, Octokit::Forbidden => e
+  $loog.warn("[#{$judge}] Search API access denied: #{e.class}: #{e.message}")
+  nil
+rescue Octokit::ServerError => e
+  $loog.warn("[#{$judge}] Search API server error (transient): #{e.class}: #{e.message}")
+  nil
+rescue Net::OpenTimeout, Net::ReadTimeout, SocketError, Errno::ECONNRESET => e
+  $loog.warn("[#{$judge}] Network error during search (transient): #{e.class}: #{e.message}")
+  nil
 end


### PR DESCRIPTION
Expands the rescue block in `Jp.qosearch` to catch additional error types that can occur during GitHub Search API calls:

- `Octokit::Unauthorized`, `Octokit::Forbidden` — access denied / rate limiting
- `Octokit::ServerError` — transient server-side errors (5xx)
- `Net::OpenTimeout`, `Net::ReadTimeout`, `SocketError`, `Errno::ECONNRESET` — network-level failures

Previously only `Octokit::TooManyRequests` (search quota) was caught; all other exceptions propagated as crashes.

Closes #1658