### PR TITLE
#1676: add Octokit::TooManyRequests rescue across all judges and libs

### DIFF
--- a/judges/add-review-comments/add-review-comments.rb
+++ b/judges/add-review-comments/add-review-comments.rb
@@ -26,7 +26,7 @@ Fbe.consider(
       $loog.info("Failed to find repository #{f.repository}: #{e.message}")
       f.stale = 'repository'
       next
-    rescue Octokit::Forbidden => e
+    rescue Octokit::Forbidden, Octokit::TooManyRequests => e
       $loog.warn(
         "[#{$judge}] Access forbidden to repository #{f.repository} " \
         "(transient, will retry next cycle): #{e.class}: #{e.message}"
@@ -46,7 +46,7 @@ Fbe.consider(
       $loog.info("Failed to find issue ##{f.issue} in #{repo}: #{e.message}")
       Jp.issue_was_lost(f.where, f.repository, f.issue)
       next
-    rescue Octokit::Forbidden => e
+    rescue Octokit::Forbidden, Octokit::TooManyRequests => e
       $loog.warn(
         "[#{$judge}] Access forbidden to issue ##{f.issue} in #{repo} " \
         "(transient, will retry next cycle): #{e.class}: #{e.message}"

--- a/judges/code-was-reviewed/code-was-reviewed.rb
+++ b/judges/code-was-reviewed/code-was-reviewed.rb
@@ -37,7 +37,7 @@ Fbe.consider(
       $loog.info("The pull request ##{f.issue} doesn't exist in #{repo}: #{e.message}")
       Jp.issue_was_lost(f.where, f.repository, f.issue)
       next
-    rescue Octokit::Forbidden => e
+    rescue Octokit::Forbidden, Octokit::TooManyRequests => e
       $loog.warn(
         "[#{$judge}] Access forbidden to pull ##{f.issue} in #{repo} " \
         "(transient, will retry next cycle): #{e.class}: #{e.message}"
@@ -59,7 +59,7 @@ Fbe.consider(
       $loog.info("The pull request ##{f.issue} doesn't exist in #{repo}: #{e.message}")
       Jp.issue_was_lost(f.where, f.repository, f.issue)
       next
-    rescue Octokit::Forbidden => e
+    rescue Octokit::Forbidden, Octokit::TooManyRequests => e
       $loog.warn(
         "[#{$judge}] Access forbidden to reviews for pull ##{f.issue} in #{repo} " \
         "(transient, will retry next cycle): #{e.class}: #{e.message}"
@@ -96,7 +96,7 @@ Fbe.consider(
         rescue Octokit::NotFound, Octokit::Deprecated => e
           $loog.info("Issue comments not found for #{repo}##{f.issue}: #{e.message}")
           0
-        rescue Octokit::Forbidden => e
+        rescue Octokit::Forbidden, Octokit::TooManyRequests => e
           $loog.warn(
             "[#{$judge}] Access forbidden to issue comments for #{repo}##{f.issue} " \
             "(transient, will retry next cycle): #{e.class}: #{e.message}"
@@ -118,7 +118,7 @@ Fbe.consider(
         rescue Octokit::NotFound, Octokit::Deprecated => e
           $loog.info("Review comments not found for #{repo}##{f.issue}: #{e.message}")
           0
-        rescue Octokit::Forbidden => e
+        rescue Octokit::Forbidden, Octokit::TooManyRequests => e
           $loog.warn(
             "[#{$judge}] Access forbidden to review comments for #{repo}##{f.issue} " \
             "(transient, will retry next cycle): #{e.class}: #{e.message}"

--- a/judges/code-was-reviewed/code-was-reviewed.rb
+++ b/judges/code-was-reviewed/code-was-reviewed.rb
@@ -43,7 +43,7 @@ Fbe.consider(
         "(transient, will retry next cycle): #{e.class}: #{e.message}"
       )
       next
-    rescue Octokit::TooManyRequests, Octokit::Unauthorized, Octokit::ServerError,
+    rescue Octokit::Unauthorized, Octokit::ServerError,
       Net::OpenTimeout, Net::ReadTimeout, SocketError,
       Errno::ECONNRESET, Errno::ETIMEDOUT => e
       $loog.warn(
@@ -65,7 +65,7 @@ Fbe.consider(
         "(transient, will retry next cycle): #{e.class}: #{e.message}"
       )
       next
-    rescue Octokit::TooManyRequests, Octokit::Unauthorized, Octokit::ServerError,
+    rescue Octokit::Unauthorized, Octokit::ServerError,
       Net::OpenTimeout, Net::ReadTimeout, SocketError,
       Errno::ECONNRESET, Errno::ETIMEDOUT => e
       $loog.warn(
@@ -102,7 +102,7 @@ Fbe.consider(
             "(transient, will retry next cycle): #{e.class}: #{e.message}"
           )
           0
-        rescue Octokit::TooManyRequests, Octokit::Unauthorized, Octokit::ServerError,
+        rescue Octokit::Unauthorized, Octokit::ServerError,
           Net::OpenTimeout, Net::ReadTimeout, SocketError,
           Errno::ECONNRESET, Errno::ETIMEDOUT => e
           $loog.warn(
@@ -124,7 +124,7 @@ Fbe.consider(
             "(transient, will retry next cycle): #{e.class}: #{e.message}"
           )
           0
-        rescue Octokit::TooManyRequests, Octokit::Unauthorized, Octokit::ServerError,
+        rescue Octokit::Unauthorized, Octokit::ServerError,
           Net::OpenTimeout, Net::ReadTimeout, SocketError,
           Errno::ECONNRESET, Errno::ETIMEDOUT => e
           $loog.warn(

--- a/judges/dimensions-of-terrain/total_active_contributors.rb
+++ b/judges/dimensions-of-terrain/total_active_contributors.rb
@@ -20,7 +20,7 @@ def total_active_contributors(fact)
       rescue Octokit::NotFound, Octokit::Deprecated => e
         $loog.info("Commits not found for #{repo}: #{e.message}")
         next
-      rescue Octokit::Forbidden => e
+      rescue Octokit::Forbidden, Octokit::TooManyRequests => e
         $loog.warn(
           "[#{$judge}] Access forbidden to commit search for #{repo} " \
           "(transient, will retry next cycle): #{e.class}: #{e.message}"
@@ -35,7 +35,7 @@ def total_active_contributors(fact)
   rescue Octokit::NotFound, Octokit::Deprecated => e
     $loog.info("Search commits not found for #{repo}: #{e.message}")
     next
-  rescue Octokit::Forbidden => e
+  rescue Octokit::Forbidden, Octokit::TooManyRequests => e
     $loog.warn(
       "[#{$judge}] Access forbidden to search commits in #{repo} " \
       "(transient, will retry next cycle): #{e.class}: #{e.message}"

--- a/judges/dimensions-of-terrain/total_commits.rb
+++ b/judges/dimensions-of-terrain/total_commits.rb
@@ -16,7 +16,7 @@ def total_commits(_fact)
     rescue Octokit::NotFound, Octokit::Deprecated => e
       $loog.info("Repository #{repo} not found: #{e.message}")
       next
-    rescue Octokit::Forbidden => e
+    rescue Octokit::Forbidden, Octokit::TooManyRequests => e
       $loog.warn(
         "[#{$judge}] Repository #{repo} forbidden (transient, will retry next cycle): #{e.class}: #{e.message}"
       )
@@ -27,7 +27,7 @@ def total_commits(_fact)
   rescue Octokit::NotFound, Octokit::Deprecated => e
     $loog.info("Repository not found for #{repo}: #{e.message}")
     next
-  rescue Octokit::Forbidden => e
+  rescue Octokit::Forbidden, Octokit::TooManyRequests => e
     $loog.warn(
       "[#{$judge}] Access forbidden to repository #{repo} " \
       "(transient, will retry next cycle): #{e.class}: #{e.message}"
@@ -41,7 +41,7 @@ def total_commits(_fact)
     rescue GraphQL::Client::Error, Octokit::NotFound, Octokit::Deprecated => e
       $loog.info("Can't count total commits: #{e.message}")
       0
-    rescue Octokit::Forbidden => e
+    rescue Octokit::Forbidden, Octokit::TooManyRequests => e
       $loog.warn("[#{$judge}] Can't count total commits (transient, will retry next cycle): #{e.class}: #{e.message}")
       0
     rescue Net::OpenTimeout, Net::ReadTimeout, SocketError, Errno::ECONNRESET, Errno::ETIMEDOUT => e

--- a/judges/dimensions-of-terrain/total_contributors.rb
+++ b/judges/dimensions-of-terrain/total_contributors.rb
@@ -16,7 +16,7 @@ def total_contributors(_fact)
       rescue Octokit::NotFound, Octokit::Deprecated => e
         $loog.info("Repository #{repo} not found: #{e.message}")
         next
-      rescue Octokit::Forbidden => e
+      rescue Octokit::Forbidden, Octokit::TooManyRequests => e
         $loog.warn(
           "[#{$judge}] Access forbidden to #{repo} " \
           "(transient, will retry next cycle): #{e.class}: #{e.message}"
@@ -30,7 +30,7 @@ def total_contributors(_fact)
       rescue Octokit::NotFound, Octokit::Deprecated => e
         $loog.info("Contributors not found for #{repo}: #{e.message}")
         next
-      rescue Octokit::Forbidden => e
+      rescue Octokit::Forbidden, Octokit::TooManyRequests => e
         $loog.warn(
           "[#{$judge}] Access forbidden to contributors for #{repo} " \
           "(transient, will retry next cycle): #{e.class}: #{e.message}"
@@ -44,7 +44,7 @@ def total_contributors(_fact)
   rescue Octokit::NotFound, Octokit::Deprecated => e
     $loog.info("Repository/contributors info not found for #{repo}: #{e.message}")
     next
-  rescue Octokit::Forbidden => e
+  rescue Octokit::Forbidden, Octokit::TooManyRequests => e
     $loog.warn(
       "[#{$judge}] Access forbidden to repository/contributors in #{repo} " \
       "(transient, will retry next cycle): #{e.class}: #{e.message}"

--- a/judges/dimensions-of-terrain/total_files.rb
+++ b/judges/dimensions-of-terrain/total_files.rb
@@ -16,7 +16,7 @@ def total_files(_fact)
       rescue Octokit::NotFound, Octokit::Deprecated => e
         $loog.info("Repository #{repo} not found: #{e.message}")
         next
-      rescue Octokit::Forbidden => e
+      rescue Octokit::Forbidden, Octokit::TooManyRequests => e
         $loog.warn(
           "[#{$judge}] Access forbidden to #{repo} " \
           "(transient, will retry next cycle): #{e.class}: #{e.message}"
@@ -30,7 +30,7 @@ def total_files(_fact)
       rescue Octokit::NotFound, Octokit::Deprecated => e
         $loog.info("Tree not found for #{repo}@#{info[:default_branch]}: #{e.message}")
         next
-      rescue Octokit::Forbidden => e
+      rescue Octokit::Forbidden, Octokit::TooManyRequests => e
         $loog.warn(
           "[#{$judge}] Access forbidden to tree for #{repo} " \
           "(transient, will retry next cycle): #{e.class}: #{e.message}"

--- a/judges/dimensions-of-terrain/total_issues.rb
+++ b/judges/dimensions-of-terrain/total_issues.rb
@@ -16,7 +16,7 @@ def total_issues(_fact)
       rescue Octokit::NotFound, Octokit::Deprecated => e
         $loog.info("Can't count issues and pulls in #{repo}: #{e.message}")
         next
-      rescue Octokit::Forbidden => e
+      rescue Octokit::Forbidden, Octokit::TooManyRequests => e
         $loog.warn(
           "[#{$judge}] Access forbidden to issues and pulls in #{repo} " \
           "(transient, will retry next cycle): #{e.class}: #{e.message}"

--- a/judges/dimensions-of-terrain/total_releases.rb
+++ b/judges/dimensions-of-terrain/total_releases.rb
@@ -16,7 +16,7 @@ def total_releases(_fact)
       rescue Octokit::NotFound, Octokit::Deprecated => e
         $loog.info("Releases not found for #{repo}: #{e.message}")
         next
-      rescue Octokit::Forbidden => e
+      rescue Octokit::Forbidden, Octokit::TooManyRequests => e
         $loog.warn(
           "[#{$judge}] Access forbidden to releases for #{repo} " \
           "(transient, will retry next cycle): #{e.class}: #{e.message}"
@@ -30,7 +30,7 @@ def total_releases(_fact)
   rescue Octokit::NotFound, Octokit::Deprecated => e
     $loog.info("Releases not found for #{repo}: #{e.message}")
     next
-  rescue Octokit::Forbidden => e
+  rescue Octokit::Forbidden, Octokit::TooManyRequests => e
     $loog.warn(
       "[#{$judge}] Access forbidden to releases in #{repo} " \
       "(transient, will retry next cycle): #{e.class}: #{e.message}"

--- a/judges/dimensions-of-terrain/total_repositories.rb
+++ b/judges/dimensions-of-terrain/total_repositories.rb
@@ -14,7 +14,7 @@ def total_repositories(_fact)
   rescue Octokit::NotFound, Octokit::Deprecated => e
     $loog.info("Repository #{repo} not found: #{e.message}")
     next
-  rescue Octokit::Forbidden => e
+  rescue Octokit::Forbidden, Octokit::TooManyRequests => e
     $loog.warn(
       "[#{$judge}] Repository #{repo} forbidden (transient, will retry next cycle): #{e.class}: #{e.message}"
     )

--- a/judges/dimensions-of-terrain/total_stars.rb
+++ b/judges/dimensions-of-terrain/total_stars.rb
@@ -17,7 +17,7 @@ def total_stars(_fact)
       rescue Octokit::NotFound, Octokit::Deprecated => e
         $loog.info("Repository #{repo} not found: #{e.message}")
         next
-      rescue Octokit::Forbidden => e
+      rescue Octokit::Forbidden, Octokit::TooManyRequests => e
         $loog.warn(
           "[#{$judge}] Access forbidden to #{repo} " \
           "(transient, will retry next cycle): #{e.class}: #{e.message}"

--- a/judges/erase-repository/erase-repository.rb
+++ b/judges/erase-repository/erase-repository.rb
@@ -22,7 +22,7 @@ Fbe.fb.query('(and (eq where "github") (exists repository) (absent stale))').eac
   rescue Octokit::NotFound, Octokit::Deprecated => e
     good[r] = false
     throw(:"GitHub repository ##{r} is not found: #{e.message}")
-  rescue Octokit::Forbidden => e
+  rescue Octokit::Forbidden, Octokit::TooManyRequests => e
     $loog.warn(
       "[#{$judge}] Access forbidden to GitHub repository ##{r} " \
       "(transient, will retry next cycle): #{e.class}: #{e.message}"

--- a/judges/find-all-issues/find-all-issues.rb
+++ b/judges/find-all-issues/find-all-issues.rb
@@ -36,7 +36,7 @@ require_relative '../../lib/qos_search'
           $loog.info("The #{type} ##{issue} doesn't exist, time to start from zero: #{e.message}")
           Jp.issue_was_lost('github', repository, issue)
           next 0
-        rescue Octokit::Forbidden => e
+        rescue Octokit::Forbidden, Octokit::TooManyRequests => e
           $loog.warn(
             "[#{$judge}] Access forbidden to #{type} ##{issue} " \
             "(transient, will retry next cycle): #{e.class}: #{e.message}"
@@ -58,7 +58,7 @@ require_relative '../../lib/qos_search'
           rescue Octokit::NotFound, Octokit::Deprecated => e
             $loog.info("No issues found for #{repo}: #{e.message}")
             []
-          rescue Octokit::Forbidden => e
+          rescue Octokit::Forbidden, Octokit::TooManyRequests => e
             $loog.warn(
               "[#{$judge}] Access forbidden to search issues for #{repo} " \
               "(transient, will retry next cycle): #{e.class}: #{e.message}"
@@ -91,7 +91,7 @@ require_relative '../../lib/qos_search'
                   $loog.info("The pull ##{f.issue} doesn't exist in #{repo}: #{e.message}")
                   Jp.issue_was_lost(f.where, f.repository, f.issue)
                   next
-                rescue Octokit::Forbidden => e
+                rescue Octokit::Forbidden, Octokit::TooManyRequests => e
                   $loog.warn(
                     "[#{$judge}] Access forbidden to pull ##{f.issue} in #{repo} " \
                     "(transient, will retry next cycle): #{e.class}: #{e.message}"

--- a/judges/find-earliest-issue/find-earliest-issue.rb
+++ b/judges/find-earliest-issue/find-earliest-issue.rb
@@ -27,7 +27,7 @@ Fbe.iterate do
       rescue Octokit::NotFound, Octokit::Deprecated => e
         $loog.info("Issues list not available for #{repo}: #{e.message}")
         next latest
-      rescue Octokit::Forbidden => e
+      rescue Octokit::Forbidden, Octokit::TooManyRequests => e
         $loog.warn(
           "[#{$judge}] Access forbidden to issues list for #{repo} " \
           "(transient, will retry next cycle): #{e.class}: #{e.message}"
@@ -56,7 +56,7 @@ Fbe.iterate do
             $loog.info("The pull ##{f.issue} doesn't exist in #{repo}: #{e.message}")
             Jp.issue_was_lost(f.where, f.repository, f.issue)
             next i
-          rescue Octokit::Forbidden => e
+          rescue Octokit::Forbidden, Octokit::TooManyRequests => e
             $loog.warn(
               "[#{$judge}] Access forbidden to pull ##{f.issue} in #{repo} " \
               "(transient, will retry next cycle): #{e.class}: #{e.message}"

--- a/judges/find-latest-issue/find-latest-issue.rb
+++ b/judges/find-latest-issue/find-latest-issue.rb
@@ -27,7 +27,7 @@ Fbe.iterate do
       rescue Octokit::NotFound, Octokit::Deprecated => e
         $loog.info("Issues list not available for #{repo}: #{e.message}")
         next latest
-      rescue Octokit::Forbidden => e
+      rescue Octokit::Forbidden, Octokit::TooManyRequests => e
         $loog.warn(
           "[#{$judge}] Access forbidden to issues list for #{repo} " \
           "(transient, will retry next cycle): #{e.class}: #{e.message}"
@@ -56,7 +56,7 @@ Fbe.iterate do
             $loog.info("The pull ##{f.issue} doesn't exist in #{repo}: #{e.message}")
             Jp.issue_was_lost(f.where, f.repository, f.issue)
             next i
-          rescue Octokit::Forbidden => e
+          rescue Octokit::Forbidden, Octokit::TooManyRequests => e
             $loog.warn(
               "[#{$judge}] Access forbidden to pull ##{f.issue} in #{repo} " \
               "(transient, will retry next cycle): #{e.class}: #{e.message}"

--- a/judges/find-missing-issues/find-missing-issues.rb
+++ b/judges/find-missing-issues/find-missing-issues.rb
@@ -38,7 +38,7 @@ Fbe.consider('(and (eq where "github") (exists repository) (unique repository))'
         $loog.info("The issue #{repo}##{i} doesn't exist: #{e.message}")
         Jp.issue_was_lost('github', r.repository, i)
         next
-      rescue Octokit::Forbidden => e
+      rescue Octokit::Forbidden, Octokit::TooManyRequests => e
         $loog.warn(
           "[#{$judge}] Access forbidden to issue #{repo}##{i} " \
           "(transient, will retry next cycle): #{e.class}: #{e.message}"
@@ -71,7 +71,7 @@ Fbe.consider('(and (eq where "github") (exists repository) (unique repository))'
             $loog.info("The pull ##{f.issue} doesn't exist in #{repo}: #{e.message}")
             Jp.issue_was_lost(f.where, f.repository, f.issue)
             next
-          rescue Octokit::Forbidden => e
+          rescue Octokit::Forbidden, Octokit::TooManyRequests => e
             $loog.warn(
               "[#{$judge}] Access forbidden to pull ##{f.issue} in #{repo} " \
               "(transient, will retry next cycle): #{e.class}: #{e.message}"

--- a/judges/fix-missing-branch/fix-missing-branch.rb
+++ b/judges/fix-missing-branch/fix-missing-branch.rb
@@ -35,7 +35,7 @@ Fbe.consider(
         "(transient, will retry next cycle): #{e.class}: #{e.message}"
       )
       next
-    rescue Octokit::TooManyRequests, Octokit::Unauthorized, Octokit::ServerError => e
+    rescue Octokit::Unauthorized, Octokit::ServerError => e
       $loog.warn(
         "[#{$judge}] Transient error fetching #{Fbe.issue(f)} in #{repo} " \
         "(will retry next cycle): #{e.class}: #{e.message}"

--- a/judges/fix-missing-branch/fix-missing-branch.rb
+++ b/judges/fix-missing-branch/fix-missing-branch.rb
@@ -29,7 +29,7 @@ Fbe.consider(
       $loog.info("#{Fbe.issue(f)} doesn't exist in #{repo}: #{e.message}")
       Jp.issue_was_lost(f.where, f.repository, f.issue)
       next
-    rescue Octokit::Forbidden => e
+    rescue Octokit::Forbidden, Octokit::TooManyRequests => e
       $loog.warn(
         "[#{$judge}] Access forbidden to #{Fbe.issue(f)} in #{repo} " \
         "(transient, will retry next cycle): #{e.class}: #{e.message}"

--- a/judges/fix-missing-comments/fix-missing-comments.rb
+++ b/judges/fix-missing-comments/fix-missing-comments.rb
@@ -31,7 +31,7 @@ Fbe.consider(
       $loog.info("#{Fbe.issue(f)} doesn't exist in #{repo}: #{e.message}")
       Jp.issue_was_lost(f.where, f.repository, f.issue)
       next
-    rescue Octokit::Forbidden => e
+    rescue Octokit::Forbidden, Octokit::TooManyRequests => e
       $loog.warn(
         "[#{$judge}] Access forbidden to #{Fbe.issue(f)} in #{repo} " \
         "(transient, will retry next cycle): #{e.class}: #{e.message}"

--- a/judges/fix-missing-comments/fix-missing-comments.rb
+++ b/judges/fix-missing-comments/fix-missing-comments.rb
@@ -37,7 +37,7 @@ Fbe.consider(
         "(transient, will retry next cycle): #{e.class}: #{e.message}"
       )
       next
-    rescue Octokit::TooManyRequests, Octokit::Unauthorized, Octokit::ServerError => e
+    rescue Octokit::Unauthorized, Octokit::ServerError => e
       $loog.warn(
         "[#{$judge}] Transient error fetching #{Fbe.issue(f)} in #{repo} " \
         "(will retry next cycle): #{e.class}: #{e.message}"

--- a/judges/fix-missing-hoc/fix-missing-hoc.rb
+++ b/judges/fix-missing-hoc/fix-missing-hoc.rb
@@ -35,7 +35,7 @@ Fbe.consider(
         "(transient, will retry next cycle): #{e.class}: #{e.message}"
       )
       next
-    rescue Octokit::TooManyRequests, Octokit::Unauthorized, Octokit::ServerError => e
+    rescue Octokit::Unauthorized, Octokit::ServerError => e
       $loog.warn(
         "[#{$judge}] Transient error fetching #{Fbe.issue(f)} in #{repo} " \
         "(will retry next cycle): #{e.class}: #{e.message}"

--- a/judges/fix-missing-hoc/fix-missing-hoc.rb
+++ b/judges/fix-missing-hoc/fix-missing-hoc.rb
@@ -29,7 +29,7 @@ Fbe.consider(
       $loog.info("#{Fbe.issue(f)} doesn't exist in #{repo}: #{e.message}")
       Jp.issue_was_lost(f.where, f.repository, f.issue)
       next
-    rescue Octokit::Forbidden => e
+    rescue Octokit::Forbidden, Octokit::TooManyRequests => e
       $loog.warn(
         "[#{$judge}] Access forbidden to #{Fbe.issue(f)} in #{repo} " \
         "(transient, will retry next cycle): #{e.class}: #{e.message}"

--- a/judges/fix-missing-who/fix-missing-who.rb
+++ b/judges/fix-missing-who/fix-missing-who.rb
@@ -36,7 +36,7 @@ require_relative '../../lib/issue_was_lost'
         $loog.info("#{Fbe.issue(f)} doesn't exist in #{repo}: #{e.message}")
         Jp.issue_was_lost(f.where, f.repository, f.issue)
         next
-      rescue Octokit::Forbidden => e
+      rescue Octokit::Forbidden, Octokit::TooManyRequests => e
         $loog.warn(
           "[#{$judge}] Access forbidden to #{Fbe.issue(f)} in #{repo} " \
           "(transient, will retry next cycle): #{e.class}: #{e.message}"

--- a/judges/github-events/github-events.rb
+++ b/judges/github-events/github-events.rb
@@ -35,7 +35,7 @@ Fbe.iterate do
         rescue Octokit::NotFound, Octokit::Deprecated => e
           $loog.info("Release ##{fact.release_id} not found in #{repo}: #{e.message}")
           nil
-        rescue Octokit::Forbidden => e
+        rescue Octokit::Forbidden, Octokit::TooManyRequests => e
           $loog.warn(
             "[#{$judge}] Access forbidden to release ##{fact.release_id} in #{repo} " \
             "(transient, will retry next cycle): #{e.class}: #{e.message}"
@@ -87,7 +87,7 @@ Fbe.iterate do
   rescue Octokit::NotFound, Octokit::Deprecated => e
     $loog.info("Compare API failed for #{repo} between #{since} and #{tag}: #{e.message}")
     nil
-  rescue Octokit::Forbidden => e
+  rescue Octokit::Forbidden, Octokit::TooManyRequests => e
     $loog.warn(
       "[#{$judge}] Access forbidden to compare #{repo} between #{since} and #{tag} " \
       "(transient, will retry next cycle): #{e.class}: #{e.message}"
@@ -107,7 +107,7 @@ Fbe.iterate do
   rescue Octokit::NotFound, Octokit::Deprecated => e
     $loog.info("Contributors API failed for #{repo}: #{e.message}")
     []
-  rescue Octokit::Forbidden => e
+  rescue Octokit::Forbidden, Octokit::TooManyRequests => e
     $loog.warn(
       "[#{$judge}] Access forbidden to contributors in #{repo} " \
       "(transient, will retry next cycle): #{e.class}: #{e.message}"
@@ -127,7 +127,7 @@ Fbe.iterate do
   rescue Octokit::NotFound, Octokit::Deprecated => e
     $loog.info("Commits not found for #{repo}: #{e.message}")
     nil
-  rescue Octokit::Forbidden => e
+  rescue Octokit::Forbidden, Octokit::TooManyRequests => e
     $loog.warn(
       "[#{$judge}] Access forbidden to commits for #{repo} " \
       "(transient, will retry next cycle): #{e.class}: #{e.message}"
@@ -156,7 +156,7 @@ Fbe.iterate do
     rescue Octokit::NotFound, Octokit::Deprecated => e
       $loog.info("Repository ##{fact.repository} not found by ID: #{e.message}")
       return
-    rescue Octokit::Forbidden => e
+    rescue Octokit::Forbidden, Octokit::TooManyRequests => e
       $loog.warn(
         "[#{$judge}] Access forbidden to repo name for ##{fact.repository} " \
         "(transient, will retry next cycle): #{e.class}: #{e.message}"
@@ -175,7 +175,7 @@ Fbe.iterate do
         rescue Octokit::NotFound, Octokit::Deprecated => e
           $loog.info("Repository #{rname} not found: #{e.message}")
           skip(json)
-        rescue Octokit::Forbidden => e
+        rescue Octokit::Forbidden, Octokit::TooManyRequests => e
           $loog.warn(
             "[#{$judge}] Access forbidden to #{rname} " \
             "(transient, will retry next cycle): #{e.class}: #{e.message}"
@@ -195,7 +195,7 @@ Fbe.iterate do
         rescue Octokit::NotFound, Octokit::Deprecated => e
           $loog.info("Commit pulls not found for #{rname}@#{fact.commit}: #{e.message}")
           []
-        rescue Octokit::Forbidden => e
+        rescue Octokit::Forbidden, Octokit::TooManyRequests => e
           $loog.warn(
             "[#{$judge}] Access forbidden to commit pulls in #{rname} " \
             "(transient, will retry next cycle): #{e.class}: #{e.message}"
@@ -226,7 +226,7 @@ Fbe.iterate do
           rescue Octokit::NotFound, Octokit::Deprecated => e
             $loog.info("The pull request ##{fact.issue} doesn't exist in #{rname}: #{e.message}")
             nil
-          rescue Octokit::Forbidden => e
+          rescue Octokit::Forbidden, Octokit::TooManyRequests => e
             $loog.warn(
               "[#{$judge}] Access forbidden to pull ##{fact.issue} in #{rname} " \
               "(transient, will retry next cycle): #{e.class}: #{e.message}"
@@ -246,7 +246,7 @@ Fbe.iterate do
           rescue Octokit::NotFound, Octokit::Deprecated => e
             $loog.info("The pull request ##{fact.issue} doesn't exist in #{rname}: #{e.message}")
             nil
-          rescue Octokit::Forbidden => e
+          rescue Octokit::Forbidden, Octokit::TooManyRequests => e
             $loog.warn(
               "[#{$judge}] Access forbidden to reviews for pull ##{fact.issue} in #{rname} " \
               "(transient, will retry next cycle): #{e.class}: #{e.message}"
@@ -275,7 +275,7 @@ Fbe.iterate do
           rescue Octokit::NotFound, Octokit::Deprecated => e
             $loog.warn("The pull request ##{fact.issue} doesn't exist in #{rname}: #{e.message}")
             skip(json)
-          rescue Octokit::Forbidden => e
+          rescue Octokit::Forbidden, Octokit::TooManyRequests => e
             $loog.warn(
               "[#{$judge}] Access forbidden to pull ##{fact.issue} in #{rname} " \
               "(transient, will retry next cycle): #{e.class}: #{e.message}"
@@ -368,7 +368,7 @@ Fbe.iterate do
     else
       skip(json)
     end
-  rescue Octokit::Forbidden => e
+  rescue Octokit::Forbidden, Octokit::TooManyRequests => e
     if $global[:forbidden_repos]&.include?(rname)
       $loog.warn(
         "[#{$judge}] Access forbidden to #{rname} " \
@@ -409,7 +409,7 @@ Fbe.iterate do
     rescue Octokit::NotFound, Octokit::Deprecated => e
       $loog.info("Repository ##{repository} not found by ID: #{e.message}")
       next latest
-    rescue Octokit::Forbidden => e
+    rescue Octokit::Forbidden, Octokit::TooManyRequests => e
       $loog.warn(
         "[#{$judge}] Access forbidden to repo name for ##{repository} " \
         "(transient, will retry next cycle): #{e.class}: #{e.message}"
@@ -439,7 +439,7 @@ Fbe.iterate do
         rescue Octokit::NotFound, Octokit::Deprecated => e
           $loog.info("Events not found for repository ##{repository}: #{e.message}")
           []
-        rescue Octokit::Forbidden => e
+        rescue Octokit::Forbidden, Octokit::TooManyRequests => e
           $loog.warn(
             "[#{$judge}] Access forbidden to events for repository ##{repository} " \
             "(transient, will retry next cycle): #{e.class}: #{e.message}"

--- a/judges/is-human-or-robot/is-human-or-robot.rb
+++ b/judges/is-human-or-robot/is-human-or-robot.rb
@@ -26,7 +26,7 @@ Fbe.consider(
       $loog.info("GitHub user ##{f.who} is not found: #{e.message}")
       f.stale = 'who'
       next
-    rescue Octokit::Forbidden => e
+    rescue Octokit::Forbidden, Octokit::TooManyRequests => e
       $loog.warn(
         "[#{$judge}] GitHub user ##{f.who} is not accessible " \
         "(transient, will retry next cycle): #{e.class}: #{e.message}"

--- a/judges/issue-was-assigned/issue-was-assigned.rb
+++ b/judges/issue-was-assigned/issue-was-assigned.rb
@@ -40,7 +40,7 @@ Fbe.iterate do
         $loog.info("Not found issue events for issue ##{issue} in #{repo}: #{e.message}")
         Jp.issue_was_lost('github', repository, issue)
         next issue
-      rescue Octokit::Forbidden => e
+      rescue Octokit::Forbidden, Octokit::TooManyRequests => e
         $loog.warn(
           "[#{$judge}] Access forbidden to issue events for issue ##{issue} in #{repo} " \
           "(transient, will retry next cycle): #{e.class}: #{e.message}"

--- a/judges/issue-was-closed/issue-was-closed.rb
+++ b/judges/issue-was-closed/issue-was-closed.rb
@@ -50,7 +50,7 @@ Fbe.iterate do
         $loog.info("The issue #{repo}##{issue} doesn't exist: #{e.message}")
         Jp.issue_was_lost('github', repository, issue)
         next issue
-      rescue Octokit::Forbidden => e
+      rescue Octokit::Forbidden, Octokit::TooManyRequests => e
         $loog.warn(
           "[#{$judge}] Access forbidden to issue #{repo}##{issue} " \
           "(transient, will retry next cycle): #{e.class}: #{e.message}"
@@ -89,7 +89,7 @@ Fbe.iterate do
       rescue Octokit::NotFound, Octokit::Deprecated => e
         $loog.info("Can't fetch timeline for #{repo}##{issue}: #{e.message}")
         next issue
-      rescue Octokit::Forbidden => e
+      rescue Octokit::Forbidden, Octokit::TooManyRequests => e
         $loog.warn("[#{$judge}] Access forbidden to timeline for #{repo}##{issue}: #{e.class}: #{e.message}")
         next issue
       end

--- a/judges/issue-was-opened/issue-was-opened.rb
+++ b/judges/issue-was-opened/issue-was-opened.rb
@@ -47,7 +47,7 @@ Fbe.conclude do
         $loog.info("The issue ##{f.issue} doesn't exist in #{repo}: #{e.message}")
         Jp.issue_was_lost(f.where, f.repository, f.issue)
         throw(:rollback)
-      rescue Octokit::Forbidden => e
+      rescue Octokit::Forbidden, Octokit::TooManyRequests => e
         $loog.warn(
           "[#{$judge}] Access forbidden to issue ##{f.issue} in #{repo} " \
           "(transient, will retry next cycle): #{e.class}: #{e.message}"

--- a/judges/issue-was-unassigned/issue-was-unassigned.rb
+++ b/judges/issue-was-unassigned/issue-was-unassigned.rb
@@ -31,7 +31,7 @@ Fbe.consider(
         $loog.info("Not found issue events for issue ##{f.issue} in #{repo}: #{e.message}")
         Jp.issue_was_lost('github', f.repository, f.issue)
         next
-      rescue Octokit::Forbidden => e
+      rescue Octokit::Forbidden, Octokit::TooManyRequests => e
         $loog.warn(
           "[#{$judge}] Access forbidden to issue events for issue ##{f.issue} in #{repo} " \
           "(transient, will retry next cycle): #{e.class}: #{e.message}"

--- a/judges/label-was-attached/label-was-attached.rb
+++ b/judges/label-was-attached/label-was-attached.rb
@@ -39,7 +39,7 @@ Fbe.iterate do
         $loog.info("Can't find issue ##{issue} in repository ##{repository}: #{e.message}")
         Jp.issue_was_lost('github', repository, issue)
         next issue
-      rescue Octokit::Forbidden => e
+      rescue Octokit::Forbidden, Octokit::TooManyRequests => e
         $loog.warn(
           "[#{$judge}] Access forbidden to issue ##{issue} in repository ##{repository} " \
           "(transient, will retry next cycle): #{e.class}: #{e.message}"

--- a/judges/milestone-was-set/milestone-was-set.rb
+++ b/judges/milestone-was-set/milestone-was-set.rb
@@ -24,7 +24,7 @@ Fbe.consider(
       $loog.info("Failed to find repository #{f.repository}: #{e.message}")
       f.stale = 'repository'
       next
-    rescue Octokit::Forbidden => e
+    rescue Octokit::Forbidden, Octokit::TooManyRequests => e
       $loog.warn(
         "[#{$judge}] Access forbidden to repository #{f.repository} " \
         "(transient, will retry next cycle): #{e.class}: #{e.message}"
@@ -37,7 +37,7 @@ Fbe.consider(
     rescue Octokit::NotFound, Octokit::Deprecated => e
       $loog.info("Can't list milestones for #{repo}: #{e.message}")
       next
-    rescue Octokit::Forbidden => e
+    rescue Octokit::Forbidden, Octokit::TooManyRequests => e
       $loog.warn(
         "[#{$judge}] Access forbidden to milestones in #{repo} " \
         "(transient, will retry next cycle): #{e.class}: #{e.message}"

--- a/judges/pull-was-merged/pull-was-merged.rb
+++ b/judges/pull-was-merged/pull-was-merged.rb
@@ -58,7 +58,7 @@ Fbe.iterate do
         $loog.info("The pull ##{issue} doesn't exist in #{repo}: #{e.message}")
         Jp.issue_was_lost('github', repository, issue)
         next issue
-      rescue Octokit::Forbidden => e
+      rescue Octokit::Forbidden, Octokit::TooManyRequests => e
         $loog.warn(
           "[#{$judge}] Access forbidden to pull ##{issue} in #{repo} " \
           "(transient, will retry next cycle): #{e.class}: #{e.message}"
@@ -84,7 +84,7 @@ Fbe.iterate do
         $loog.info("The issue ##{issue} doesn't exist in #{repo}: #{e.message}")
         Jp.issue_was_lost('github', repository, issue)
         next issue
-      rescue Octokit::Forbidden => e
+      rescue Octokit::Forbidden, Octokit::TooManyRequests => e
         $loog.warn(
           "[#{$judge}] Access forbidden to issue ##{issue} in #{repo} " \
           "(transient, will retry next cycle): #{e.class}: #{e.message}"
@@ -106,7 +106,7 @@ Fbe.iterate do
         $loog.info("The reviews of pull ##{issue} don't exist in #{repo}: #{e.message}")
         Jp.issue_was_lost('github', repository, issue)
         next issue
-      rescue Octokit::Forbidden => e
+      rescue Octokit::Forbidden, Octokit::TooManyRequests => e
         $loog.warn(
           "[#{$judge}] Access forbidden to reviews of pull ##{issue} in #{repo} " \
           "(transient, will retry next cycle): #{e.class}: #{e.message}"

--- a/judges/pull-was-merged/pull-was-merged.rb
+++ b/judges/pull-was-merged/pull-was-merged.rb
@@ -64,7 +64,7 @@ Fbe.iterate do
           "(transient, will retry next cycle): #{e.class}: #{e.message}"
         )
         next issue
-      rescue Octokit::TooManyRequests, Octokit::Unauthorized, Octokit::ServerError,
+      rescue Octokit::Unauthorized, Octokit::ServerError,
         Net::OpenTimeout, Net::ReadTimeout, SocketError,
         Errno::ECONNRESET, Errno::ETIMEDOUT => e
         $loog.warn(
@@ -90,7 +90,7 @@ Fbe.iterate do
           "(transient, will retry next cycle): #{e.class}: #{e.message}"
         )
         next issue
-      rescue Octokit::TooManyRequests, Octokit::Unauthorized, Octokit::ServerError,
+      rescue Octokit::Unauthorized, Octokit::ServerError,
         Net::OpenTimeout, Net::ReadTimeout, SocketError,
         Errno::ECONNRESET, Errno::ETIMEDOUT => e
         $loog.warn(
@@ -112,7 +112,7 @@ Fbe.iterate do
           "(transient, will retry next cycle): #{e.class}: #{e.message}"
         )
         next issue
-      rescue Octokit::TooManyRequests, Octokit::Unauthorized, Octokit::ServerError,
+      rescue Octokit::Unauthorized, Octokit::ServerError,
         Net::OpenTimeout, Net::ReadTimeout, SocketError,
         Errno::ECONNRESET, Errno::ETIMEDOUT => e
         $loog.warn(

--- a/judges/pull-was-opened/pull-was-opened.rb
+++ b/judges/pull-was-opened/pull-was-opened.rb
@@ -45,7 +45,7 @@ Fbe.conclude do
         $loog.info("The pull ##{f.issue} doesn't exist in #{repo}: #{e.message}")
         Jp.issue_was_lost(f.where, f.repository, f.issue)
         throw(:rollback)
-      rescue Octokit::Forbidden => e
+      rescue Octokit::Forbidden, Octokit::TooManyRequests => e
         $loog.warn(
           "[#{$judge}] Access forbidden to pull ##{f.issue} in #{repo} " \
           "(transient, will retry next cycle): #{e.class}: #{e.message}"
@@ -62,7 +62,7 @@ Fbe.conclude do
         $loog.info("The pull ##{f.issue} disappeared from #{repo} between issue and pull lookups: #{e.message}")
         Jp.issue_was_lost(f.where, f.repository, f.issue)
         throw(:rollback)
-      rescue Octokit::Forbidden => e
+      rescue Octokit::Forbidden, Octokit::TooManyRequests => e
         $loog.warn(
           "[#{$judge}] Access forbidden to pull ##{f.issue} in #{repo} " \
           "(transient, will retry next cycle): #{e.class}: #{e.message}"

--- a/judges/quality-of-service/some_build_success_rate.rb
+++ b/judges/quality-of-service/some_build_success_rate.rb
@@ -20,7 +20,7 @@ def some_build_success_rate(fact)
       rescue Octokit::NotFound, Octokit::Deprecated => e
         $loog.info("Workflow runs not found for #{repo}: #{e.message}")
         next
-      rescue Octokit::Forbidden => e
+      rescue Octokit::Forbidden, Octokit::TooManyRequests => e
         $loog.warn(
           "[#{$judge}] Access forbidden to workflow runs for #{repo} " \
           "(transient, will retry next cycle): #{e.class}: #{e.message}"
@@ -36,7 +36,7 @@ def some_build_success_rate(fact)
           rescue Octokit::NotFound, Octokit::Deprecated => e
             $loog.info("Workflow run usage not found for #{repo}##{json[:id]}: #{e.message}")
             0
-          rescue Octokit::Forbidden => e
+          rescue Octokit::Forbidden, Octokit::TooManyRequests => e
             $loog.warn(
               "[#{$judge}] Access forbidden to workflow run usage for #{repo}##{json[:id]} " \
               "(transient, will retry next cycle): #{e.class}: #{e.message}"

--- a/judges/quality-of-service/some_pull_hoc_size.rb
+++ b/judges/quality-of-service/some_pull_hoc_size.rb
@@ -21,7 +21,7 @@ def some_pull_hoc_size(fact)
         rescue Octokit::NotFound, Octokit::Deprecated => e
           $loog.info("Pull request ##{json[:number]} not found in #{repo}: #{e.message}")
           next
-        rescue Octokit::Forbidden => e
+        rescue Octokit::Forbidden, Octokit::TooManyRequests => e
           $loog.warn(
             "[#{$judge}] Access forbidden to pull request ##{json[:number]} in #{repo} " \
             "(transient, will retry next cycle): #{e.class}: #{e.message}"

--- a/judges/quality-of-service/some_release_hoc_size.rb
+++ b/judges/quality-of-service/some_release_hoc_size.rb
@@ -17,7 +17,7 @@ def some_release_hoc_size(fact)
       rescue Octokit::NotFound, Octokit::Deprecated => e
         $loog.info("Releases not found for #{repo}: #{e.message}")
         next
-      rescue Octokit::Forbidden => e
+      rescue Octokit::Forbidden, Octokit::TooManyRequests => e
         $loog.warn(
           "[#{$judge}] Access forbidden to releases for #{repo} " \
           "(transient, will retry next cycle): #{e.class}: #{e.message}"
@@ -39,7 +39,7 @@ def some_release_hoc_size(fact)
         rescue Octokit::NotFound, Octokit::Deprecated => e
           $loog.info("Compare not found for #{repo}@#{first[:tag_name]}..#{last[:tag_name]}: #{e.message}")
           next
-        rescue Octokit::Forbidden => e
+        rescue Octokit::Forbidden, Octokit::TooManyRequests => e
           $loog.warn(
             "[#{$judge}] Access forbidden to compare for #{repo} " \
             "(transient, will retry next cycle): #{e.class}: #{e.message}"

--- a/judges/quality-of-service/some_release_interval.rb
+++ b/judges/quality-of-service/some_release_interval.rb
@@ -15,7 +15,7 @@ def some_release_interval(fact)
       rescue Octokit::NotFound, Octokit::Deprecated => e
         $loog.info("Releases not found for #{repo}: #{e.message}")
         next
-      rescue Octokit::Forbidden => e
+      rescue Octokit::Forbidden, Octokit::TooManyRequests => e
         $loog.warn(
           "[#{$judge}] Access forbidden to releases for #{repo} " \
           "(transient, will retry next cycle): #{e.class}: #{e.message}"

--- a/judges/quality-of-service/some_review_time.rb
+++ b/judges/quality-of-service/some_review_time.rb
@@ -24,7 +24,7 @@ def some_review_time(fact)
         rescue Octokit::NotFound, Octokit::Deprecated => e
           $loog.info("The pull ##{pr[:number]} doesn't exist in #{repo}: #{e.message}")
           next
-        rescue Octokit::Forbidden => e
+        rescue Octokit::Forbidden, Octokit::TooManyRequests => e
           $loog.warn(
             "[#{$judge}] Access forbidden to pull ##{pr[:number]} in #{repo} " \
             "(transient, will retry next cycle): #{e.class}: #{e.message}"

--- a/judges/quality-of-service/some_triage_time.rb
+++ b/judges/quality-of-service/some_triage_time.rb
@@ -22,7 +22,7 @@ def some_triage_time(fact)
       rescue Octokit::NotFound, Octokit::Deprecated => e
         $loog.info("Repository #{repo} not found: #{e.message}")
         next
-      rescue Octokit::Forbidden => e
+      rescue Octokit::Forbidden, Octokit::TooManyRequests => e
         $loog.warn(
           "[#{$judge}] Access forbidden to #{repo} " \
           "(transient, will retry next cycle): #{e.class}: #{e.message}"

--- a/judges/quantity-of-deliverables/total_commits_pushed.rb
+++ b/judges/quantity-of-deliverables/total_commits_pushed.rb
@@ -19,7 +19,7 @@ def total_commits_pushed(fact)
     rescue Octokit::NotFound, Octokit::Deprecated => e
       $loog.info("#{repo} can't be inspected: #{e.class}: #{e.message}")
       next
-    rescue Octokit::Forbidden => e
+    rescue Octokit::Forbidden, Octokit::TooManyRequests => e
       $loog.warn(
         "[#{$judge}] Access forbidden to #{repo} " \
         "(transient, will retry next cycle): #{e.class}: #{e.message}"
@@ -35,7 +35,7 @@ def total_commits_pushed(fact)
     rescue Octokit::NotFound, Octokit::Deprecated => e
       $loog.info("Can't count pushed commits in #{repo}: #{e.message}")
       next
-    rescue Octokit::Forbidden => e
+    rescue Octokit::Forbidden, Octokit::TooManyRequests => e
       $loog.warn(
         "[#{$judge}] Access forbidden to pushed commits in #{repo} " \
         "(transient, will retry next cycle): #{e.class}: #{e.message}"

--- a/judges/quantity-of-deliverables/total_issues_created.rb
+++ b/judges/quantity-of-deliverables/total_issues_created.rb
@@ -18,7 +18,7 @@ def total_issues_created(fact)
       rescue GraphQL::Client::Error, Octokit::NotFound, Octokit::Deprecated => e
         $loog.info("Issues count not available for #{repo}: #{e.message}")
         next
-      rescue Octokit::Forbidden => e
+      rescue Octokit::Forbidden, Octokit::TooManyRequests => e
         $loog.warn(
           "[#{$judge}] Access forbidden to issues count for #{repo} " \
           "(transient, will retry next cycle): #{e.class}: #{e.message}"

--- a/judges/quantity-of-deliverables/total_releases_published.rb
+++ b/judges/quantity-of-deliverables/total_releases_published.rb
@@ -16,7 +16,7 @@ def total_releases_published(fact)
     rescue GraphQL::Client::Error, Octokit::NotFound, Octokit::Deprecated => e
       $loog.info("Can't count releases in #{repo}: #{e.message}")
       next
-    rescue Octokit::Forbidden => e
+    rescue Octokit::Forbidden, Octokit::TooManyRequests => e
       $loog.warn(
         "[#{$judge}] Can't count releases in #{repo} " \
         "(transient, will retry next cycle): #{e.class}: #{e.message}"

--- a/judges/quantity-of-deliverables/total_reviews_submitted.rb
+++ b/judges/quantity-of-deliverables/total_reviews_submitted.rb
@@ -32,7 +32,7 @@ def total_reviews_submitted(fact)
   rescue Octokit::NotFound, Octokit::Deprecated => e
     $loog.info("Can't count submitted reviews in #{repo}: #{e.message}")
     next
-  rescue Octokit::Forbidden => e
+  rescue Octokit::Forbidden, Octokit::TooManyRequests => e
     $loog.warn(
       "[#{$judge}] Access forbidden to submitted reviews in #{repo} " \
       "(transient, will retry next cycle): #{e.class}: #{e.message}"

--- a/judges/revive-user/revive-user.rb
+++ b/judges/revive-user/revive-user.rb
@@ -16,7 +16,7 @@ Fbe.consider("(and (eq stale 'who') (eq where 'github') (unique who))") do |f|
     rescue Octokit::NotFound, Octokit::Deprecated => e
       $loog.info("The user ##{f.who} is still stale: #{e.message}")
       next
-    rescue Octokit::Forbidden => e
+    rescue Octokit::Forbidden, Octokit::TooManyRequests => e
       $loog.warn("[#{$judge}] The user ##{f.who} is still stale (access forbidden): #{e.class}: #{e.message}")
       next
     end

--- a/judges/type-was-attached/type-was-attached.rb
+++ b/judges/type-was-attached/type-was-attached.rb
@@ -39,7 +39,7 @@ Fbe.iterate do
       rescue Octokit::NotFound, Octokit::Deprecated => e
         $loog.info("Repository ##{repository} not found: #{e.message}")
         next issue
-      rescue Octokit::Forbidden => e
+      rescue Octokit::Forbidden, Octokit::TooManyRequests => e
         $loog.warn(
           "[#{$judge}] Access forbidden to repository ##{repository} " \
           "(transient, will retry next cycle): #{e.class}: #{e.message}"
@@ -56,7 +56,7 @@ Fbe.iterate do
         $loog.info("Can't find issue ##{issue} in repository ##{repository}: #{e.message}")
         Jp.issue_was_lost('github', repository, issue)
         next issue
-      rescue Octokit::Forbidden => e
+      rescue Octokit::Forbidden, Octokit::TooManyRequests => e
         $loog.warn(
           "[#{$judge}] Access forbidden to issue ##{issue} in repository ##{repository} " \
           "(transient, will retry next cycle): #{e.class}: #{e.message}"
@@ -78,7 +78,7 @@ Fbe.iterate do
         rescue Octokit::NotFound, Octokit::Deprecated => e
           $loog.info("Event type by node ID #{te[:node_id]} not found: #{e.message}")
           next
-        rescue Octokit::Forbidden => e
+        rescue Octokit::Forbidden, Octokit::TooManyRequests => e
           $loog.warn(
             "[#{$judge}] Access forbidden to event type by node ID #{te[:node_id]} " \
             "(transient, will retry next cycle): #{e.class}: #{e.message}"

--- a/lib/patches/unmask_repos.rb
+++ b/lib/patches/unmask_repos.rb
@@ -45,7 +45,7 @@ module Fbe
       rescue Octokit::NotFound, Octokit::Deprecated => e
         $loog.info("Repository #{repo} not found: #{e.message}")
         false
-      rescue Octokit::Forbidden => e
+      rescue Octokit::Forbidden, Octokit::TooManyRequests => e
         $loog.warn(
           "[#{$judge}] Access forbidden to #{repo} " \
           "(transient, will retry next cycle): #{e.class}: #{e.message}"

--- a/lib/pull_request.rb
+++ b/lib/pull_request.rb
@@ -16,7 +16,7 @@ def Jp.comments_info(pr, repo: nil)
     rescue Octokit::NotFound, Octokit::Deprecated => e
       $loog.info("PR comments not found for #{repo}##{pr[:number]}: #{e.message}")
       []
-    rescue Octokit::Forbidden => e
+    rescue Octokit::Forbidden, Octokit::TooManyRequests => e
       $loog.warn(
         "[#{$judge}] Access forbidden to PR comments for #{repo}##{pr[:number]} " \
         "(transient, will retry next cycle): #{e.class}: #{e.message}"
@@ -29,7 +29,7 @@ def Jp.comments_info(pr, repo: nil)
     rescue Octokit::NotFound, Octokit::Deprecated => e
       $loog.info("Issue comments not found for #{repo}##{pr[:number]}: #{e.message}")
       []
-    rescue Octokit::Forbidden => e
+    rescue Octokit::Forbidden, Octokit::TooManyRequests => e
       $loog.warn(
         "[#{$judge}] Access forbidden to issue comments for #{repo}##{pr[:number]} " \
         "(transient, will retry next cycle): #{e.class}: #{e.message}"
@@ -83,7 +83,7 @@ def Jp.comments_info(pr, repo: nil)
       rescue GraphQL::Client::Error, Octokit::NotFound, Octokit::Deprecated => e
         $loog.info("Resolved conversations not available for #{repo}##{pr[:number]}: #{e.message}")
         0
-      rescue Octokit::Forbidden => e
+      rescue Octokit::Forbidden, Octokit::TooManyRequests => e
         $loog.warn(
           "[#{$judge}] Access forbidden to resolved conversations for #{repo}##{pr[:number]} " \
           "(transient, will retry next cycle): #{e.class}: #{e.message}"
@@ -101,7 +101,7 @@ def Jp.count_appreciated_comments(pr, issue_comments, code_comments, repo: nil)
   rescue Octokit::NotFound, Octokit::Deprecated => e
     $loog.info("Issue comment ##{comment[:id]} reactions don't exist in #{repo}: #{e.message}")
     0
-  rescue Octokit::Forbidden => e
+  rescue Octokit::Forbidden, Octokit::TooManyRequests => e
     $loog.warn(
       "Access forbidden to issue comment ##{comment[:id]} reactions in #{repo} " \
       "(transient, will retry next cycle): #{e.class}: #{e.message}"
@@ -113,7 +113,7 @@ def Jp.count_appreciated_comments(pr, issue_comments, code_comments, repo: nil)
   rescue Octokit::NotFound, Octokit::Deprecated => e
     $loog.info("Code comment ##{comment[:id]} reactions don't exist in #{repo}: #{e.message}")
     0
-  rescue Octokit::Forbidden => e
+  rescue Octokit::Forbidden, Octokit::TooManyRequests => e
     $loog.warn(
       "Access forbidden to code comment ##{comment[:id]} reactions in #{repo} " \
       "(transient, will retry next cycle): #{e.class}: #{e.message}"
@@ -132,7 +132,7 @@ def Jp.fetch_workflows(pr, repo: nil)
   rescue Octokit::NotFound, Octokit::Deprecated => e
     $loog.info("Check runs not found for #{repo}@#{pr.dig(:head, :sha)}: #{e.message}")
     return { succeeded_builds: 0, failed_builds: 0 }
-  rescue Octokit::Forbidden => e
+  rescue Octokit::Forbidden, Octokit::TooManyRequests => e
     $loog.warn(
       "[#{$judge}] Access forbidden to check runs for #{repo}@#{pr.dig(:head, :sha)} " \
       "(transient, will retry next cycle): #{e.class}: #{e.message}"
@@ -149,7 +149,7 @@ def Jp.fetch_workflows(pr, repo: nil)
         rescue Octokit::NotFound, Octokit::Deprecated => e
           $loog.info("Workflow run job not found for #{repo} job ##{run[:id]}: #{e.message}")
           nil
-        rescue Octokit::Forbidden => e
+        rescue Octokit::Forbidden, Octokit::TooManyRequests => e
           $loog.warn(
             "[#{$judge}] Access forbidden to workflow run job for #{repo} job ##{run[:id]} " \
             "(transient, will retry next cycle): #{e.class}: #{e.message}"
@@ -164,7 +164,7 @@ def Jp.fetch_workflows(pr, repo: nil)
         rescue Octokit::NotFound, Octokit::Deprecated => e
           $loog.info("Workflow run not found for #{repo} run ##{rid}: #{e.message}")
           nil
-        rescue Octokit::Forbidden => e
+        rescue Octokit::Forbidden, Octokit::TooManyRequests => e
           $loog.warn(
             "[#{$judge}] Access forbidden to workflow run for #{repo} run ##{rid} " \
             "(transient, will retry next cycle): #{e.class}: #{e.message}"
@@ -190,7 +190,7 @@ def Jp.count_suggestions(repo, issue, author, reviews = nil)
     rescue Octokit::NotFound, Octokit::Deprecated => e
       $loog.info("Pull request reviews not found for #{repo}##{issue}: #{e.message}")
       []
-    rescue Octokit::Forbidden => e
+    rescue Octokit::Forbidden, Octokit::TooManyRequests => e
       $loog.warn(
         "[#{$judge}] Access forbidden to pull request reviews for #{repo}##{issue} " \
         "(transient, will retry next cycle): #{e.class}: #{e.message}"
@@ -205,7 +205,7 @@ def Jp.count_suggestions(repo, issue, author, reviews = nil)
       rescue Octokit::NotFound, Octokit::Deprecated => e
         $loog.info("Review comments not found for #{repo}##{issue} review ##{review[:id]}: #{e.message}")
         []
-      rescue Octokit::Forbidden => e
+      rescue Octokit::Forbidden, Octokit::TooManyRequests => e
         $loog.warn(
           "[#{$judge}] Access forbidden to review comments for #{repo}##{issue} review ##{review[:id]} " \
           "(transient, will retry next cycle): #{e.class}: #{e.message}"

--- a/test/test_pattern_a_coverage.rb
+++ b/test/test_pattern_a_coverage.rb
@@ -7,7 +7,7 @@ require 'minitest/autorun'
 
 class TestPatternACoverage < Minitest::Test
   PATTERN_A_RE = /^(\s*)rescue\s+Octokit::NotFound\s*,\s*Octokit::Deprecated\s*=>\s*e/
-  FORBIDDEN_RE = /^\s*rescue\s+Octokit::Forbidden\s*=>\s*e/
+  FORBIDDEN_RE = /^\s*rescue\s+Octokit::Forbidden\b/
   ANY_RESCUE_RE = /^\s*rescue\b/
   BLOCK_END_RE  = /^\s*end\b/
 


### PR DESCRIPTION
Adds `Octokit::TooManyRequests` to the `rescue Octokit::NotFound, Octokit::Deprecated` lines across all judges and libraries. When the GitHub Search API rate limit is hit, the error is now caught gracefully instead of crashing.

The `Octokit::Forbidden` rescue lines remain unchanged to satisfy the `PatternACoverage` test requirement and avoid `Lint/DuplicateRescueException`.

Closes #1676