### PR TITLE
#1690 #1698 #1705: add security risk comments to Dockerfile, zerocracy.yml, .rultor.yml

### DIFF
--- a/.github/workflows/zerocracy.yml
+++ b/.github/workflows/zerocracy.yml
@@ -25,6 +25,7 @@ jobs:
         with:
           token: ${{ secrets.ZEROCRACY_TOKEN }}
           github-token: ${{ secrets.PAT }}
+          # WARNING: zerocracy/* wildcard covers ALL org repos — review when adding new repos
           repositories: yegor256/judges,yegor256/factbase,zerocracy/*,yegor256/0rsk
           factbase: zerocracy.fb
           timeout: 15

--- a/.rultor.yml
+++ b/.rultor.yml
@@ -5,6 +5,7 @@
 docker:
   image: yegor256/ruby
 assets:
+  # WARNING: cross-repo asset reference — supply chain risk (trusted from yegor256/home)
   docker-password: yegor256/home#assets/docker-password
 install: |
   sudo apt-get -y update

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,4 +21,7 @@ COPY judges /action/judges
 COPY lib /action/lib
 COPY entry.sh /action
 
+# Runs as root by design — the container needs to write to the
+# mounted GITHUB_WORKSPACE volume which is owned by the runner uid.
+# Switching to a non-root user would break workspace write access.
 ENTRYPOINT ["/action/entry.sh", "/action"]


### PR DESCRIPTION
Closes #1690 (document root user in Dockerfile)
Closes #1698 (warn about zerocracy/* wildcard)
Closes #1705 (warn about cross-repo rultor asset)

Группировка: все три — security documentation comments, разных файлы но один тип изменений.