### PR TITLE
#1645 #1647: replace RuntimeError crashes with graceful handling

### DIFF
--- a/judges/issue-was-closed/issue-was-closed.rb
+++ b/judges/issue-was-closed/issue-was-closed.rb
@@ -69,7 +69,10 @@ Fbe.iterate do
           n.issue = issue
           n.what = $judge
         end
-      raise(RuntimeError, "Issue #{repo}##{issue} already closed") if nn.nil?
+      if nn.nil?
+        $loog.warn("Issue #{repo}##{issue} already closed")
+        next issue
+      end
       nn.when = json[:closed_at] ? Time.parse(json[:closed_at].iso8601) : Time.now
       who = json.dig(:closed_by, :id)
       if who

--- a/lib/issue_was_lost.rb
+++ b/lib/issue_was_lost.rb
@@ -25,7 +25,10 @@ def Jp.issue_was_lost(where, repository, issue)
       n.repository = repository
       n.where = where
     end
-  raise(RuntimeError, "The issue ##{issue} was already lost") unless f
+  unless f
+    $loog.warn("The issue ##{issue} was already lost")
+    return
+  end
   f.stale = 'issue'
   f.when = Time.now
   Fbe::Tombstone.new.bury!(where, repository, issue)

--- a/test/lib/test_issue_was_lost.rb
+++ b/test/lib/test_issue_was_lost.rb
@@ -39,14 +39,12 @@ class TestIssueWasLost < Minitest::Test
     end
   end
 
-  def test_raises_on_second_call_for_same_issue
+  def test_graceful_on_second_call_for_same_issue
     fb = Factbase.new
     Fbe.stub(:fb, fb) do
       $loog = Loog::NULL
       Jp.issue_was_lost('github', 42, 123)
-      assert_raises(RuntimeError, 'second call for the same (where, repository, issue) must raise') do
-        Jp.issue_was_lost('github', 42, 123)
-      end
+      Jp.issue_was_lost('github', 42, 123)
     end
   end
 


### PR DESCRIPTION
Closes #1645
Closes #1647
Both are `RuntimeError` crashes that bring down the entire judge. Replaced with `warn` + graceful skip/return.
- #1645: `issue-was-closed.rb` — `raise RuntimeError` → `warn` + `next issue`
- #1647: `issue_was_lost.rb` — `raise RuntimeError` → `warn` + `return`
- Grouped: same root cause (graceful RuntimeError handling).