### PR TITLE
#1660: rescue Octokit::Conflict in comparison() for same-SHA compare

### DIFF
--- a/judges/github-events/github-events.rb
+++ b/judges/github-events/github-events.rb
@@ -87,9 +87,9 @@ Fbe.iterate do
   rescue Octokit::NotFound, Octokit::Deprecated => e
     $loog.info("Compare API failed for #{repo} between #{since} and #{tag}: #{e.message}")
     nil
-  rescue Octokit::Forbidden => e
+  rescue Octokit::Conflict, Octokit::Forbidden => e
     $loog.warn(
-      "[#{$judge}] Access forbidden to compare #{repo} between #{since} and #{tag} " \
+      "[#{$judge}] Compare API conflict for #{repo} between #{since} and #{tag} " \
       "(transient, will retry next cycle): #{e.class}: #{e.message}"
     )
     nil

--- a/judges/github-events/github-events.rb
+++ b/judges/github-events/github-events.rb
@@ -87,7 +87,13 @@ Fbe.iterate do
   rescue Octokit::NotFound, Octokit::Deprecated => e
     $loog.info("Compare API failed for #{repo} between #{since} and #{tag}: #{e.message}")
     nil
-  rescue Octokit::Conflict, Octokit::Forbidden => e
+  rescue Octokit::Forbidden => e
+    $loog.warn(
+      "[#{$judge}] Access forbidden to compare #{repo} between #{since} and #{tag} " \
+      "(transient, will retry next cycle): #{e.class}: #{e.message}"
+    )
+    nil
+  rescue Octokit::Conflict => e
     $loog.warn(
       "[#{$judge}] Compare API conflict for #{repo} between #{since} and #{tag} " \
       "(transient, will retry next cycle): #{e.class}: #{e.message}"


### PR DESCRIPTION
Adds `rescue Octokit::Conflict` handler in `comparison()` for when the compare API is called with identical SHAs (e.g. same commit). Previously this raised an unhandled exception and crashed the judge.

The `Conflict` rescue is placed after `Forbidden` to satisfy the `PatternACoverage` test.

Closes #1660