### PR TITLE
#1706: fix ruby-version from 4.0.5 to 4.0 in make.yml and rake.yml

### DIFF
--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - uses: ruby/setup-ruby@12fd324f1d0b43274fdc8130f6980590a667c455 # v1.312.0
         with:
-          ruby-version: 4.0.5
+          ruby-version: 4.0
           bundler-cache: true
       - run: sudo apt-get update && sudo apt-get install -y parallel
       - run: make

--- a/.github/workflows/rake.yml
+++ b/.github/workflows/rake.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - uses: ruby/setup-ruby@12fd324f1d0b43274fdc8130f6980590a667c455 # v1.312.0
         with:
-          ruby-version: 4.0.5
+          ruby-version: 4.0
           bundler-cache: true
       - run: bundle config set --global path "$(pwd)/vendor/bundle"
       - run: bundle install --no-color


### PR DESCRIPTION
Closes #1706

Fix `ruby-version` in CI workflow files from `4.0.5` (specific patch) to `4.0` (minor version), allowing the `ruby/setup-ruby` action to resolve the latest patch within the 4.0 series.

Applied in:
- `.github/workflows/make.yml`
- `.github/workflows/rake.yml`