### PR TITLE
#1680: add top-level rescue to sub-judge wrappers

### DIFF
--- a/judges/dimensions-of-terrain/dimensions-of-terrain.rb
+++ b/judges/dimensions-of-terrain/dimensions-of-terrain.rb
@@ -8,17 +8,20 @@ require 'fbe/octo'
 require 'time'
 require_relative '../../lib/incremate'
 
-f = Fbe.fb.query(
-  "(and
-    (eq what '#{$judge}')
-    (gt when (minus (to_time (env 'TODAY' '#{Time.now.utc.iso8601}')) '1 days')))"
-).each.first
-if f.nil?
-  f = Fbe.fb.insert
-  f.what = $judge
-  f.when = Time.now
+begin
+  f = Fbe.fb.query(
+    "(and
+      (eq what '#{$judge}')
+      (gt when (minus (to_time (env 'TODAY' '#{Time.now.utc.iso8601}')) '1 days')))"
+  ).each.first
+  if f.nil?
+    f = Fbe.fb.insert
+    f.what = $judge
+    f.when = Time.now
+  end
+  Jp.incremate(f, __dir__, 'total')
+rescue StandardError => e
+  $loog.warn("[#{$judge}] Dimensions-of-terrain judge failed: #{e.class}: #{e.message}")
 end
-
-Jp.incremate(f, __dir__, 'total')
 
 Fbe.octo.print_trace!

--- a/judges/quality-of-service/quality-of-service.rb
+++ b/judges/quality-of-service/quality-of-service.rb
@@ -14,8 +14,12 @@ days = Fbe.pmp.quality.qos_days
 pause = Fbe.pmp.quality.qos_pause_seconds.value || 0
 limit = Fbe.pmp.quality.qos_max_per_fact.value
 Jp.qoreset
-Jp.cover_qo(days)
-Fbe.consider("(and (eq what '#{$judge}') (exists since) (exists when))") do |f|
-  Jp.incremate(f, __dir__, 'some', avoid_duplicate: true, pause:, max_per_fact: limit)
+begin
+  Jp.cover_qo(days)
+  Fbe.consider("(and (eq what '#{$judge}') (exists since) (exists when))") do |f|
+    Jp.incremate(f, __dir__, 'some', avoid_duplicate: true, pause:, max_per_fact: limit)
+  end
+rescue StandardError => e
+  $loog.warn("[#{$judge}] Quality-of-service judge failed: #{e.class}: #{e.message}")
 end
 Fbe.octo.print_trace!

--- a/judges/quantity-of-deliverables/quantity-of-deliverables.rb
+++ b/judges/quantity-of-deliverables/quantity-of-deliverables.rb
@@ -10,8 +10,12 @@ require_relative '../../lib/cover_qo'
 require_relative '../../lib/incremate'
 
 days = Fbe.pmp.scope.qod_days
-Jp.cover_qo(days)
-Fbe.consider("(and (eq what '#{$judge}') (exists since) (exists when))") do |f|
-  Jp.incremate(f, __dir__, 'total', avoid_duplicate: true)
+begin
+  Jp.cover_qo(days)
+  Fbe.consider("(and (eq what '#{$judge}') (exists since) (exists when))") do |f|
+    Jp.incremate(f, __dir__, 'total', avoid_duplicate: true)
+  end
+rescue StandardError => e
+  $loog.warn("[#{$judge}] Quantity-of-deliverables judge failed: #{e.class}: #{e.message}")
 end
 Fbe.octo.print_trace!


### PR DESCRIPTION
Closes #1680

Add top-level `rescue StandardError` wrappers to three judges to prevent unhandled exceptions from crashing the judge process:

- `dimensions-of-terrain`: wraps the query/insert/incremate block
- `quality-of-service`: wraps the cover/consider/incremate block
- `quantity-of-deliverables`: wraps the cover/consider/incremate block

All exceptions are logged via `$loog.warn` with the judge name, exception class, and message, allowing the cycle to continue with other judges.