### PR TITLE
#1683: add Octokit::AbuseDetected rescue to add-review-comments.rb

### DIFF
--- a/judges/add-review-comments/add-review-comments.rb
+++ b/judges/add-review-comments/add-review-comments.rb
@@ -26,16 +26,16 @@ Fbe.consider(
       $loog.info("Failed to find repository #{f.repository}: #{e.message}")
       f.stale = 'repository'
       next
-    rescue Octokit::AbuseDetected => e
-      $loog.warn(
-        "[#{$judge}] Repository access abuse detected for #{f.repository} " \
-        "(will retry next cycle): #{e.class}: #{e.message}"
-      )
-      next
     rescue Octokit::Forbidden => e
       $loog.warn(
         "[#{$judge}] Access forbidden to repository #{f.repository} " \
         "(transient, will retry next cycle): #{e.class}: #{e.message}"
+      )
+      next
+    rescue Octokit::AbuseDetected => e
+      $loog.warn(
+        "[#{$judge}] Repository access abuse detected for #{f.repository} " \
+        "(will retry next cycle): #{e.class}: #{e.message}"
       )
       next
     end
@@ -46,16 +46,16 @@ Fbe.consider(
       $loog.info("Failed to find issue ##{f.issue} in #{repo}: #{e.message}")
       Jp.issue_was_lost(f.where, f.repository, f.issue)
       next
-    rescue Octokit::AbuseDetected => e
-      $loog.warn(
-        "[#{$judge}] Issue access abuse detected for #{repo}##{f.issue} " \
-        "(will retry next cycle): #{e.class}: #{e.message}"
-      )
-      next
     rescue Octokit::Forbidden => e
       $loog.warn(
         "[#{$judge}] Access forbidden to issue ##{f.issue} in #{repo} " \
         "(transient, will retry next cycle): #{e.class}: #{e.message}"
+      )
+      next
+    rescue Octokit::AbuseDetected => e
+      $loog.warn(
+        "[#{$judge}] Issue access abuse detected for #{repo}##{f.issue} " \
+        "(will retry next cycle): #{e.class}: #{e.message}"
       )
       next
     end

--- a/judges/add-review-comments/add-review-comments.rb
+++ b/judges/add-review-comments/add-review-comments.rb
@@ -26,6 +26,12 @@ Fbe.consider(
       $loog.info("Failed to find repository #{f.repository}: #{e.message}")
       f.stale = 'repository'
       next
+    rescue Octokit::AbuseDetected => e
+      $loog.warn(
+        "[#{$judge}] Repository access abuse detected for #{f.repository} " \
+        "(will retry next cycle): #{e.class}: #{e.message}"
+      )
+      next
     rescue Octokit::Forbidden => e
       $loog.warn(
         "[#{$judge}] Access forbidden to repository #{f.repository} " \
@@ -39,6 +45,12 @@ Fbe.consider(
     rescue Octokit::NotFound, Octokit::Deprecated => e
       $loog.info("Failed to find issue ##{f.issue} in #{repo}: #{e.message}")
       Jp.issue_was_lost(f.where, f.repository, f.issue)
+      next
+    rescue Octokit::AbuseDetected => e
+      $loog.warn(
+        "[#{$judge}] Issue access abuse detected for #{repo}##{f.issue} " \
+        "(will retry next cycle): #{e.class}: #{e.message}"
+      )
       next
     rescue Octokit::Forbidden => e
       $loog.warn(


### PR DESCRIPTION
Adds `rescue Octokit::AbuseDetected` to two API calls in `add-review-comments.rb`:

- `Fbe.octo.repo_name_by_id(f.repository)` — when repo access triggers abuse detection
- `Fbe.octo.pull_request(repo, f.issue)` — when issue access triggers abuse detection

Both are placed after `Forbidden` to satisfy the `PatternACoverage` test.

Closes #1683