### PR TITLE
#1664: add reactions cache to reduce N+1 API calls

### DIFF
--- a/lib/pull_request.rb
+++ b/lib/pull_request.rb
@@ -64,9 +64,11 @@ end
 
 def Jp.count_appreciated_comments(pr, issue_comments, code_comments, repo: nil)
   repo = pr.dig(:base, :repo, :full_name) if repo.nil?
+  @_reactions ||= {}
   issue_comments.sum do |comment|
-    Fbe.octo.issue_comment_reactions(repo, comment[:id])
-      .count { |reaction| reaction.dig(:user, :id) != comment.dig(:user, :id) }
+    @_reactions[comment[:id]] ||=
+      Fbe.octo.issue_comment_reactions(repo, comment[:id])
+        .count { |reaction| reaction.dig(:user, :id) != comment.dig(:user, :id) }
   rescue Octokit::NotFound, Octokit::Deprecated => e
     $loog.info("Issue comment ##{comment[:id]} reactions don't exist in #{repo}: #{e.message}")
     0
@@ -77,8 +79,9 @@ def Jp.count_appreciated_comments(pr, issue_comments, code_comments, repo: nil)
     )
     0
   end + code_comments.sum do |comment|
-    Fbe.octo.pull_request_review_comment_reactions(repo, comment[:id])
-      .count { |reaction| reaction.dig(:user, :id) != comment.dig(:user, :id) }
+    @_reactions[comment[:id]] ||=
+      Fbe.octo.pull_request_review_comment_reactions(repo, comment[:id])
+        .count { |reaction| reaction.dig(:user, :id) != comment.dig(:user, :id) }
   rescue Octokit::NotFound, Octokit::Deprecated => e
     $loog.info("Code comment ##{comment[:id]} reactions don't exist in #{repo}: #{e.message}")
     0

--- a/lib/pull_request.rb
+++ b/lib/pull_request.rb
@@ -64,9 +64,9 @@ end
 
 def Jp.count_appreciated_comments(pr, issue_comments, code_comments, repo: nil)
   repo = pr.dig(:base, :repo, :full_name) if repo.nil?
-  @_reactions ||= {}
+  @reactions ||= {}
   issue_comments.sum do |comment|
-    @_reactions[comment[:id]] ||=
+    @reactions[comment[:id]] ||=
       Fbe.octo.issue_comment_reactions(repo, comment[:id])
         .count { |reaction| reaction.dig(:user, :id) != comment.dig(:user, :id) }
   rescue Octokit::NotFound, Octokit::Deprecated => e
@@ -79,7 +79,7 @@ def Jp.count_appreciated_comments(pr, issue_comments, code_comments, repo: nil)
     )
     0
   end + code_comments.sum do |comment|
-    @_reactions[comment[:id]] ||=
+    @reactions[comment[:id]] ||=
       Fbe.octo.pull_request_review_comment_reactions(repo, comment[:id])
         .count { |reaction| reaction.dig(:user, :id) != comment.dig(:user, :id) }
   rescue Octokit::NotFound, Octokit::Deprecated => e


### PR DESCRIPTION
Adds an instance variable cache (`@reactions`) in `Jp.count_appreciated_comments` to avoid N+1 API calls when the same comment reactions are looked up multiple times for the same pull request.

The cache is keyed by comment ID and memoizes the result of `issue_comment_reactions` and `pull_request_review_comment_reactions`.

Closes #1664