### PR TITLE
#1665: cache workflow API calls to fix N+1 in fetch_workflows

### DIFF
--- a/lib/pull_request.rb
+++ b/lib/pull_request.rb
@@ -108,12 +108,12 @@ def Jp.fetch_workflows(pr, repo: nil)
     )
     return { succeeded_builds: 0, failed_builds: 0 }
   end
-  @_job_cache ||= {}
-  @_wf_cache ||= {}
+  @job_cache ||= {}
+  @wf_cache ||= {}
   (entries[:check_runs] || []).each do |run|
     next unless run.dig(:app, :slug) == 'github-actions'
     rid =
-      @_job_cache[run[:id]] ||=
+      @job_cache[run[:id]] ||=
         begin
           Fbe.octo.workflow_run_job(repo, run[:id])[:run_id]
         rescue Octokit::NotFound, Octokit::Deprecated => e
@@ -128,7 +128,7 @@ def Jp.fetch_workflows(pr, repo: nil)
         end
     next unless rid
     workflow =
-      @_wf_cache[rid] ||=
+      @wf_cache[rid] ||=
         begin
           Fbe.octo.workflow_run(repo, rid)
         rescue Octokit::NotFound, Octokit::Deprecated => e

--- a/lib/pull_request.rb
+++ b/lib/pull_request.rb
@@ -108,34 +108,40 @@ def Jp.fetch_workflows(pr, repo: nil)
     )
     return { succeeded_builds: 0, failed_builds: 0 }
   end
+  @_job_cache ||= {}
+  @_wf_cache ||= {}
   (entries[:check_runs] || []).each do |run|
     next unless run.dig(:app, :slug) == 'github-actions'
     rid =
-      begin
-        Fbe.octo.workflow_run_job(repo, run[:id])[:run_id]
-      rescue Octokit::NotFound, Octokit::Deprecated => e
-        $loog.info("Workflow run job not found for #{repo} job ##{run[:id]}: #{e.message}")
-        next
-      rescue Octokit::Forbidden => e
-        $loog.warn(
-          "[#{$judge}] Access forbidden to workflow run job for #{repo} job ##{run[:id]} " \
-          "(transient, will retry next cycle): #{e.class}: #{e.message}"
-        )
-        next
-      end
+      @_job_cache[run[:id]] ||=
+        begin
+          Fbe.octo.workflow_run_job(repo, run[:id])[:run_id]
+        rescue Octokit::NotFound, Octokit::Deprecated => e
+          $loog.info("Workflow run job not found for #{repo} job ##{run[:id]}: #{e.message}")
+          nil
+        rescue Octokit::Forbidden => e
+          $loog.warn(
+            "[#{$judge}] Access forbidden to workflow run job for #{repo} job ##{run[:id]} " \
+            "(transient, will retry next cycle): #{e.class}: #{e.message}"
+          )
+          nil
+        end
+    next unless rid
     workflow =
-      begin
-        Fbe.octo.workflow_run(repo, rid)
-      rescue Octokit::NotFound, Octokit::Deprecated => e
-        $loog.info("Workflow run not found for #{repo} run ##{rid}: #{e.message}")
-        next
-      rescue Octokit::Forbidden => e
-        $loog.warn(
-          "[#{$judge}] Access forbidden to workflow run for #{repo} run ##{rid} " \
-          "(transient, will retry next cycle): #{e.class}: #{e.message}"
-        )
-        next
-      end
+      @_wf_cache[rid] ||=
+        begin
+          Fbe.octo.workflow_run(repo, rid)
+        rescue Octokit::NotFound, Octokit::Deprecated => e
+          $loog.info("Workflow run not found for #{repo} run ##{rid}: #{e.message}")
+          nil
+        rescue Octokit::Forbidden => e
+          $loog.warn(
+            "[#{$judge}] Access forbidden to workflow run for #{repo} run ##{rid} " \
+            "(transient, will retry next cycle): #{e.class}: #{e.message}"
+          )
+          nil
+        end
+    next unless workflow
     next unless workflow[:event] == 'pull_request'
     case workflow[:conclusion]
     when 'success'

--- a/lib/pull_request.rb
+++ b/lib/pull_request.rb
@@ -108,11 +108,11 @@ def Jp.fetch_workflows(pr, repo: nil)
     )
     return { succeeded_builds: 0, failed_builds: 0 }
   end
-  @wcache ||= {}
+  wcache = {}
   (entries[:check_runs] || []).each do |run|
     next unless run.dig(:app, :slug) == 'github-actions'
     rid =
-      @wcache[run[:id]] ||=
+      wcache[run[:id]] ||=
         begin
           Fbe.octo.workflow_run_job(repo, run[:id])[:run_id]
         rescue Octokit::NotFound, Octokit::Deprecated => e
@@ -127,7 +127,7 @@ def Jp.fetch_workflows(pr, repo: nil)
         end
     next unless rid
     workflow =
-      @wcache[rid] ||=
+      wcache[rid] ||=
         begin
           Fbe.octo.workflow_run(repo, rid)
         rescue Octokit::NotFound, Octokit::Deprecated => e

--- a/lib/pull_request.rb
+++ b/lib/pull_request.rb
@@ -108,12 +108,11 @@ def Jp.fetch_workflows(pr, repo: nil)
     )
     return { succeeded_builds: 0, failed_builds: 0 }
   end
-  @job_cache ||= {}
-  @wf_cache ||= {}
+  @wcache ||= {}
   (entries[:check_runs] || []).each do |run|
     next unless run.dig(:app, :slug) == 'github-actions'
     rid =
-      @job_cache[run[:id]] ||=
+      @wcache[run[:id]] ||=
         begin
           Fbe.octo.workflow_run_job(repo, run[:id])[:run_id]
         rescue Octokit::NotFound, Octokit::Deprecated => e
@@ -128,7 +127,7 @@ def Jp.fetch_workflows(pr, repo: nil)
         end
     next unless rid
     workflow =
-      @wf_cache[rid] ||=
+      @wcache[rid] ||=
         begin
           Fbe.octo.workflow_run(repo, rid)
         rescue Octokit::NotFound, Octokit::Deprecated => e


### PR DESCRIPTION
Adds memoization caches (`@job_cache`, `@wf_cache`) in `Jp.fetch_workflows` to eliminate N+1 API calls when multiple check runs reference the same workflow run job or workflow run.
Previously each check run triggered separate API calls; now results are keyed by ID and reused.

Closes #1665