### PR TITLE
#1723: fix N+1 repo_id_by_name calls in some_triage_time

### DIFF
--- a/judges/quality-of-service/some_triage_time.rb
+++ b/judges/quality-of-service/some_triage_time.rb
@@ -16,20 +16,20 @@ def some_triage_time(fact)
     return {} if Fbe.octo.off_quota?
     found = Jp.qosearch("repo:#{repo} type:issue created:#{fact.since.utc.iso8601}..#{fact.when.utc.iso8601}")
     return {} if found.nil?
+    rid =
+      begin
+        Fbe.octo.repo_id_by_name(repo)
+      rescue Octokit::NotFound, Octokit::Deprecated => e
+        $loog.info("Repository #{repo} not found: #{e.message}")
+        next
+      rescue Octokit::Forbidden => e
+        $loog.warn(
+          "[#{$judge}] Access forbidden to #{repo} " \
+          "(transient, will retry next cycle): #{e.class}: #{e.message}"
+        )
+        next
+      end
     found[:items].each do |issue|
-      rid = # rubocop:disable Elegant/NoRedundantVariable
-        begin
-          Fbe.octo.repo_id_by_name(repo)
-        rescue Octokit::NotFound, Octokit::Deprecated => e
-          $loog.info("Repository #{repo} not found: #{e.message}")
-          next
-        rescue Octokit::Forbidden => e
-          $loog.warn(
-            "[#{$judge}] Access forbidden to #{repo} " \
-            "(transient, will retry next cycle): #{e.class}: #{e.message}"
-          )
-          next
-        end
       ff = Fbe.fb.query(
         "
         (and


### PR DESCRIPTION
Closes #1723

Fix N+1 `repo_id_by_name` calls in `some_triage_time`. The previous code called `Fbe.octo.repo_id_by_name(repo)` inside the `found[:items].each` loop, making one API call per issue found in search results. Moved it before the loop so it's called once per fact.

Also removes the now-unnecessary `# rubocop:disable Elegant/NoRedundantVariable` comment that was suppressing a false positive when `rid` was defined but only used inside the each block.