### PR TITLE
#1651: fix memory exhaustion in find-missing-issues

### DIFF
--- a/judges/code-was-reviewed/code-was-reviewed.rb
+++ b/judges/code-was-reviewed/code-was-reviewed.rb
@@ -46,7 +46,7 @@ Fbe.consider(
     end
   reviews =
     begin
-      Fbe.octo.pull_request_reviews(repo, f.issue, per_page: 100)
+      Fbe.octo.pull_request_reviews(repo, f.issue)
     rescue Octokit::NotFound, Octokit::Deprecated => e
       $loog.info("The pull request ##{f.issue} doesn't exist in #{repo}: #{e.message}")
       Jp.issue_was_lost(f.where, f.repository, f.issue)

--- a/judges/code-was-reviewed/code-was-reviewed.rb
+++ b/judges/code-was-reviewed/code-was-reviewed.rb
@@ -46,7 +46,7 @@ Fbe.consider(
     end
   reviews =
     begin
-      Fbe.octo.pull_request_reviews(repo, f.issue)
+      Fbe.octo.pull_request_reviews(repo, f.issue, per_page: 100)
     rescue Octokit::NotFound, Octokit::Deprecated => e
       $loog.info("The pull request ##{f.issue} doesn't exist in #{repo}: #{e.message}")
       Jp.issue_was_lost(f.where, f.repository, f.issue)

--- a/judges/find-missing-issues/find-missing-issues.rb
+++ b/judges/find-missing-issues/find-missing-issues.rb
@@ -19,17 +19,17 @@ ts = Fbe::Tombstone.new
 
 Fbe.consider('(and (eq where "github") (exists repository) (unique repository))') do |r|
   repo = Fbe.octo.repo_name_by_id(r.repository)
-  issues = Fbe.fb.query(
+  issue_numbers = Fbe.fb.query(
     "(and (eq repository #{r.repository}) (exists issue) (eq where 'github') (unique issue))"
   ).each.map(&:issue)
-  issues.uniq!
-  issues.sort!
-  next if issues.empty?
-  must = (issues.min..issues.max).to_a
-  missing = must - issues
+  issue_numbers.uniq!
+  issue_numbers.sort!
+  next if issue_numbers.empty?
+  existing = issue_numbers.to_set
   added = []
   checked = []
-  missing.each do |i|
+  (issue_numbers.min..issue_numbers.max).each do |i|
+    next if existing.include?(i)
     next if ts.has?('github', r.repository, i)
     json =
       begin
@@ -91,12 +91,13 @@ Fbe.consider('(and (eq where "github") (exists repository) (unique repository))'
     added << i
     break if added.size > 16
   end
-  if missing.empty?
+  if (issue_numbers.max - issue_numbers.min + 1) == issue_numbers.size
     $loog.info("No missing issues in #{repo}")
   else
+    missing_count = (issue_numbers.max - issue_numbers.min + 1) - issue_numbers.size
     $loog.info(
       [
-        "Checked #{checked.size} out of #{missing.count} missing issues",
+        "Checked #{checked.size} out of #{missing_count} missing issues",
         "in #{repo}, #{added.count} facts added:",
         added.joined(max: 8)
       ].join(' ')

--- a/judges/find-missing-issues/find-missing-issues.rb
+++ b/judges/find-missing-issues/find-missing-issues.rb
@@ -19,16 +19,16 @@ ts = Fbe::Tombstone.new
 
 Fbe.consider('(and (eq where "github") (exists repository) (unique repository))') do |r|
   repo = Fbe.octo.repo_name_by_id(r.repository)
-  issue_numbers = Fbe.fb.query(
+  issues = Fbe.fb.query(
     "(and (eq repository #{r.repository}) (exists issue) (eq where 'github') (unique issue))"
   ).each.map(&:issue)
-  issue_numbers.uniq!
-  issue_numbers.sort!
-  next if issue_numbers.empty?
-  existing = issue_numbers.to_set
+  issues.uniq!
+  issues.sort!
+  next if issues.empty?
+  existing = issues.to_set
   added = []
   checked = []
-  (issue_numbers.min..issue_numbers.max).each do |i|
+  (issues.min..issues.max).each do |i|
     next if existing.include?(i)
     next if ts.has?('github', r.repository, i)
     json =
@@ -91,13 +91,13 @@ Fbe.consider('(and (eq where "github") (exists repository) (unique repository))'
     added << i
     break if added.size > 16
   end
-  if (issue_numbers.max - issue_numbers.min + 1) == issue_numbers.size
+  if (issues.max - issues.min + 1) == issues.size
     $loog.info("No missing issues in #{repo}")
   else
-    missing_count = (issue_numbers.max - issue_numbers.min + 1) - issue_numbers.size
+    missed = (issues.max - issues.min + 1) - issues.size
     $loog.info(
       [
-        "Checked #{checked.size} out of #{missing_count} missing issues",
+        "Checked #{checked.size} out of #{missed} missing issues",
         "in #{repo}, #{added.count} facts added:",
         added.joined(max: 8)
       ].join(' ')


### PR DESCRIPTION
Replaces the array-based missing issue detection in `find-missing-issues.rb` with a `Set`-based streaming iteration to avoid memory exhaustion on repositories with sparse issue numbers.

Previously built `must = (min..max).to_a` and `missing = must - issues`, constructing large arrays for gaps. Now iterates the range and checks membership via `Set#include?`.

Also fixes the log message variables to comply with `Elegant/GoodVariableName` (no underscores).

Closes #1651