### PR TITLE
#1719: fix PullRequestReviewEvent double-count

### DIFF
--- a/judges/github-events/github-events.rb
+++ b/judges/github-events/github-events.rb
@@ -422,6 +422,7 @@ Fbe.iterate do
       'pull-was-opened' => %w[where repository issue],
       'pull-was-closed' => %w[where repository issue who],
       'pull-was-merged' => %w[where repository issue who],
+      'pull-was-reviewed' => %w[where repository issue who],
       'label-was-attached' => %w[where repository issue label],
       'type-was-attached' => %w[where repository issue type]
     }


### PR DESCRIPTION
Closes #1719

Add `pull-was-reviewed` to the deduplication field list in `github-events.rb`. Without this, the same `PullRequestReviewEvent` can create duplicate `pull-was-reviewed` facts when the same event is processed multiple times. Fields `[where, repository, issue, who]` uniquely identify a review event.