### PR TITLE
#1720: wrap user deletion and stale marking in atomic transaction

### DIFF
--- a/judges/who-is-alive/who-is-alive.rb
+++ b/judges/who-is-alive/who-is-alive.rb
@@ -41,7 +41,7 @@ Fbe.consider(
   end
   elapsed($loog, level: Logger::INFO) do
     Fbe.fb.txn do |fbt|
-      fbt.query("(and (eq where 'github') (eq what 'who-has-name') (eq who #{f.who})").delete!
+      fbt.query("(and (eq where 'github') (eq what 'who-has-name') (eq who #{f.who}))").delete!
       done =
         fbt.query("(and (eq where 'github') (eq who #{f.who}))").each do |n|
           n.stale = 'who'

--- a/judges/who-is-alive/who-is-alive.rb
+++ b/judges/who-is-alive/who-is-alive.rb
@@ -40,12 +40,14 @@ Fbe.consider(
     next
   end
   elapsed($loog, level: Logger::INFO) do
-    Fbe.fb.query("(and (eq where 'github') (eq what 'who-has-name') (eq who #{f.who}))").delete!
-    done =
-      Fbe.fb.query("(and (eq where 'github') (eq who #{f.who}))").each do |n|
-        n.stale = 'who'
-      end
-    throw :"GitHub user ##{f.who} is gone, marked #{done} facts as stale"
+    Fbe.fb.txn do |fbt|
+      fbt.query("(and (eq where 'github') (eq what 'who-has-name') (eq who #{f.who})").delete!
+      done =
+        fbt.query("(and (eq where 'github') (eq who #{f.who}))").each do |n|
+          n.stale = 'who'
+        end
+      throw :"GitHub user ##{f.who} is gone, marked #{done} facts as stale"
+    end
   end
 end
 

--- a/judges/who-is-alive/who-is-alive.rb
+++ b/judges/who-is-alive/who-is-alive.rb
@@ -42,12 +42,11 @@ Fbe.consider(
   elapsed($loog, level: Logger::INFO) do
     Fbe.fb.txn do |fbt|
       fbt.query("(and (eq where 'github') (eq what 'who-has-name') (eq who #{f.who}))").delete!
-      done =
-        fbt.query("(and (eq where 'github') (eq who #{f.who}))").each do |n|
-          n.stale = 'who'
-        end
-      throw :"GitHub user ##{f.who} is gone, marked #{done} facts as stale"
+      fbt.query("(and (eq where 'github') (eq who #{f.who}))").each do |n|
+        n.stale = 'who'
+      end
     end
+    throw :"GitHub user ##{f.who} is gone"
   end
 end
 


### PR DESCRIPTION
Wraps the `delete!` and stale-marking operations in `who-is-alive.rb` inside an `Fbe.fb.txn` block, ensuring both happen atomically or not at all.

Also fixes a missing closing parenthesis in the factbase query string that caused `Factbase::Syntax::Broken`.

Closes #1720