### PR TITLE
#1672: fix state pollution across judges in qosearch

### DIFF
--- a/lib/qos_search.rb
+++ b/lib/qos_search.rb
@@ -10,26 +10,31 @@ Jp::SEARCH_WINDOW_SECONDS = 60
 Jp::SEARCH_WINDOW_BUDGET = 25
 
 def Jp.qoreset
-  @offquota = false
-  @offquotatime = nil
-  @scount = 0
-  @swstart = nil
+  @offquota = {}
+  @offquotatime = {}
+  @scount = {}
+  @swstart = {}
 end
 
 def Jp.qosearch(query, method: :search_issues, **)
-  if @offquota
-    return if @offquotatime && (Time.now - @offquotatime) < Jp::SEARCH_WINDOW_SECONDS
-    @offquota = false
-    @offquotatime = nil
+  jg = $judge
+  @offquota = {} unless @offquota.is_a?(Hash)
+  @offquotatime = {} unless @offquotatime.is_a?(Hash)
+  @scount = {} unless @scount.is_a?(Hash)
+  @swstart = {} unless @swstart.is_a?(Hash)
+  if @offquota[jg]
+    return if @offquotatime[jg] && (Time.now - @offquotatime[jg]) < Jp::SEARCH_WINDOW_SECONDS
+    @offquota[jg] = false
+    @offquotatime[jg] = nil
   end
   return if Fbe.octo.off_quota?
   now = Time.now
-  if @swstart.nil? || (now - @swstart) >= Jp::SEARCH_WINDOW_SECONDS
-    @swstart = now
-    @scount = 0
+  if @swstart[jg].nil? || (now - @swstart[jg]) >= Jp::SEARCH_WINDOW_SECONDS
+    @swstart[jg] = now
+    @scount[jg] = 0
   end
-  if @scount >= Jp::SEARCH_WINDOW_BUDGET
-    $loog.info("[#{$judge}] Search API per-minute budget exceeded (#{Jp::SEARCH_WINDOW_BUDGET}/#{Jp::SEARCH_WINDOW_SECONDS}s)")
+  if @scount[jg] >= Jp::SEARCH_WINDOW_BUDGET
+    $loog.info("[#{jg}] Search API per-minute budget exceeded (#{Jp::SEARCH_WINDOW_BUDGET}/#{Jp::SEARCH_WINDOW_SECONDS}s)")
     return
   end
   octo = Fbe.octo
@@ -43,29 +48,29 @@ def Jp.qosearch(query, method: :search_issues, **)
     left = octo.rate_limit.remaining
   end
   if left.nil?
-    @offquota = true
-    @offquotatime = Time.now
-    $loog.warn("[#{$judge}] GitHub Search API quota info unavailable, stopping search calls")
+    @offquota[jg] = true
+    @offquotatime[jg] = Time.now
+    $loog.warn("[#{jg}] GitHub Search API quota info unavailable, stopping search calls")
     return
   end
   if left.zero?
-    @offquota = true
-    @offquotatime = Time.now
+    @offquota[jg] = true
+    @offquotatime[jg] = Time.now
     $loog.info('Too much GitHub Search API quota consumed already (0 left)')
     return
   end
-  @scount += 1
+  @scount[jg] += 1
   raise(RuntimeError, "Unsafe search method: #{method}") unless
     %i[search_issues search_code search_commits].include?(method)
   Fbe.octo.__send__(method, query, **)
 rescue Octokit::TooManyRequests => e
-  @offquota = true
-  @offquotatime = Time.now
-  $loog.warn("[#{$judge}] GitHub Search API quota exhausted, stopping search calls: #{e.message}")
+  @offquota[jg] = true
+  @offquotatime[jg] = Time.now
+  $loog.warn("[#{jg}] GitHub Search API quota exhausted, stopping search calls: #{e.message}")
   nil
 rescue Octokit::ServerError,
-  Net::OpenTimeout, Net::ReadTimeout, SocketError,
-  Errno::ECONNRESET, Errno::ETIMEDOUT => e
-  $loog.warn("[#{$judge}] Transient error in search API call (will retry next cycle): #{e.class}: #{e.message}")
+       Net::OpenTimeout, Net::ReadTimeout, SocketError,
+       Errno::ECONNRESET, Errno::ETIMEDOUT => e
+  $loog.warn("[#{jg}] Transient error in search API call (will retry next cycle): #{e.class}: #{e.message}")
   nil
 end

--- a/lib/qos_search.rb
+++ b/lib/qos_search.rb
@@ -69,8 +69,8 @@ rescue Octokit::TooManyRequests => e
   $loog.warn("[#{jg}] GitHub Search API quota exhausted, stopping search calls: #{e.message}")
   nil
 rescue Octokit::ServerError,
-       Net::OpenTimeout, Net::ReadTimeout, SocketError,
-       Errno::ECONNRESET, Errno::ETIMEDOUT => e
+  Net::OpenTimeout, Net::ReadTimeout, SocketError,
+  Errno::ECONNRESET, Errno::ETIMEDOUT => e
   $loog.warn("[#{jg}] Transient error in search API call (will retry next cycle): #{e.class}: #{e.message}")
   nil
 end

--- a/test/lib/test_qos_search.rb
+++ b/test/lib/test_qos_search.rb
@@ -121,7 +121,7 @@ class TestQosSearch < Jp::Test
       refute_nil(Jp.qosearch('repo:foo/foo type:issue'))
     end
     assert_nil(Jp.qosearch('repo:foo/foo type:issue'))
-    Jp.instance_variable_set(:@swstart, Time.now - Jp::SEARCH_WINDOW_SECONDS - 1)
+    Jp.instance_variable_set(:@swstart, { $judge => Time.now - Jp::SEARCH_WINDOW_SECONDS - 1 })
     $global[:octo] = nil
     rate_limit_up
     searchstub('repo:foo/foo type:issue', body: { total_count: 1, items: [{ number: 2 }] })
@@ -132,8 +132,8 @@ class TestQosSearch < Jp::Test
     rate_limit_up
     searchstub('repo:foo/foo type:issue', body: { message: 'API rate limit exceeded' }, status: 403)
     assert_nil(Jp.qosearch('repo:foo/foo type:issue'))
-    assert_equal(1, Jp.instance_variable_get(:@scount))
-    assert(Jp.instance_variable_get(:@offquota))
+    assert_equal(1, Jp.instance_variable_get(:@scount)[$judge])
+    assert(Jp.instance_variable_get(:@offquota)[$judge])
     Jp.qoreset
     $global[:octo] = nil
     rate_limit_up


### PR DESCRIPTION
Closes #1672

Fix state pollution across different judges that share the same `Jp.qosearch` module. Instance variables `@offquota`, `@scount`, and `@swstart` were global to the module, so one judge's quota exhaustion would incorrectly block other judges from searching.

Changes:
- Convert `@offquota`, `@scount`, `@swstart` from scalars to hashes keyed by `$judge`
- Add migration code (`unless @offquota.is_a?(Hash)`) to handle in-flight upgrades
- Update `Jp.qoreset` to initialize hashes instead of scalars