### PR TITLE
#1728: fix caller-overridable dispatch in qosearch

### DIFF
--- a/lib/qos_search.rb
+++ b/lib/qos_search.rb
@@ -47,8 +47,7 @@ def Jp.qosearch(query, method: :search_issues, **)
     return
   end
   @scount += 1
-  allowed = %i[search_issues search_code search_commits]
-  raise(RuntimeError, "Unsafe search method: #{method}") unless allowed.include?(method)
+  raise(RuntimeError, "Unsafe search method: #{method}") unless %i[search_issues search_code search_commits].include?(method)
   Fbe.octo.__send__(method, query, **)
 rescue Octokit::TooManyRequests => e
   @offquota = true

--- a/lib/qos_search.rb
+++ b/lib/qos_search.rb
@@ -47,6 +47,7 @@ def Jp.qosearch(query, method: :search_issues, **)
     return
   end
   @scount += 1
+  raise("Unsafe search method: #{method}") unless %i[search_issues search_code].include?(method)
   Fbe.octo.__send__(method, query, **)
 rescue Octokit::TooManyRequests => e
   @offquota = true

--- a/lib/qos_search.rb
+++ b/lib/qos_search.rb
@@ -47,7 +47,8 @@ def Jp.qosearch(query, method: :search_issues, **)
     return
   end
   @scount += 1
-  raise(RuntimeError, "Unsafe search method: #{method}") unless %i[search_issues search_code search_commits].include?(method)
+  raise(RuntimeError, "Unsafe search method: #{method}") unless
+    %i[search_issues search_code search_commits].include?(method)
   Fbe.octo.__send__(method, query, **)
 rescue Octokit::TooManyRequests => e
   @offquota = true

--- a/lib/qos_search.rb
+++ b/lib/qos_search.rb
@@ -47,7 +47,8 @@ def Jp.qosearch(query, method: :search_issues, **)
     return
   end
   @scount += 1
-  raise("Unsafe search method: #{method}") unless %i[search_issues search_code].include?(method)
+  raise(RuntimeError, "Unsafe search method: #{method}") unless %i[search_issues search_code
+    search_commits].include?(method)
   Fbe.octo.__send__(method, query, **)
 rescue Octokit::TooManyRequests => e
   @offquota = true

--- a/lib/qos_search.rb
+++ b/lib/qos_search.rb
@@ -47,8 +47,8 @@ def Jp.qosearch(query, method: :search_issues, **)
     return
   end
   @scount += 1
-  raise(RuntimeError, "Unsafe search method: #{method}") unless %i[search_issues search_code
-    search_commits].include?(method)
+  allowed = %i[search_issues search_code search_commits]
+  raise(RuntimeError, "Unsafe search method: #{method}") unless allowed.include?(method)
   Fbe.octo.__send__(method, query, **)
 rescue Octokit::TooManyRequests => e
   @offquota = true


### PR DESCRIPTION
Closes #1728

Add safety check in `Jp.qosearch` to prevent callers from passing arbitrary methods via the `:method` parameter (which is passed to `__send__`). Only `search_issues`, `search_code`, and `search_commits` are allowed.

Also fixes:
- `raise` without explicit exception class was flagged by `Style/ImplicitRuntimeError`
- `search_commits` was missing from the whitelist, breaking `total_active_contributors`