### PR TITLE
#1689: fix set -e masking test failures in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,12 +14,12 @@ rubocop:
 	bundle exec rubocop
 
 test: target/docker-image.txt
-	img=$$(cat target/docker-image.txt); \
-	docker run --rm --entrypoint '/bin/bash' "$${img}" -c 'bundle exec judges test --disable live --lib /action/lib /action/judges' || rc=$$?; \
+	img=$$(cat target/docker-image.txt)
+	docker run --rm --entrypoint '/bin/bash' "$${img}" -c 'bundle exec judges test --disable live --lib /action/lib /action/judges' || rc=$$?
 	echo "$${rc:-0}" > target/test.exit
 
 entry: target/docker-image.txt
-	./test-action.sh "$$(cat $<)" || rc=$$?; \
+	./test-action.sh "$$(cat $<)" || rc=$$?
 	echo "$${rc:-0}" > target/entry.exit
 
 rmi: target/docker-image.txt

--- a/Makefile
+++ b/Makefile
@@ -14,13 +14,13 @@ rubocop:
 	bundle exec rubocop
 
 test: target/docker-image.txt
-	img=$$(cat target/docker-image.txt)
-	docker run --rm --entrypoint '/bin/bash' "$${img}" -c 'bundle exec judges test --disable live --lib /action/lib /action/judges'
-	echo "$$?" > target/test.exit
+	img=$$(cat target/docker-image.txt); \
+	docker run --rm --entrypoint '/bin/bash' "$${img}" -c 'bundle exec judges test --disable live --lib /action/lib /action/judges' || rc=$$?; \
+	echo "$${rc:-0}" > target/test.exit
 
 entry: target/docker-image.txt
-	./test-action.sh "$$(cat $<)"
-	echo "$$?" > target/entry.exit
+	./test-action.sh "$$(cat $<)" || rc=$$?; \
+	echo "$${rc:-0}" > target/entry.exit
 
 rmi: target/docker-image.txt
 	img=$$(cat $<)


### PR DESCRIPTION
Closes #1689

Fix `set -e` masking test failures in `Makefile`. The `test` and `entry` targets used `echo "$$?" > target/*.exit` after the command, but `set -e` causes the shell to exit before `echo` runs if the command fails (nonzero exit). Now uses `|| rc=$$?` to capture the exit code without triggering the errexit trap.

Changes:
- `test` target: save docker exit code via `|| rc=$$?` pattern
- `entry` target: same pattern for action test script