### PR TITLE
#1707: fix set +e leak from run_entry_script

### DIFF
--- a/makes/test-common.sh
+++ b/makes/test-common.sh
@@ -14,18 +14,20 @@ run_entry_script() {
     local expected_result=$2
     shift 2
 
+    local old_opts
+    old_opts=$(set +o)
     set +e
     env "$@" "${self}/entry.sh" 2>&1 | tee log.txt
-    local exit_code=$?
-    set -e
+    local exit_code=${PIPESTATUS[0]}
+    eval "$old_opts"
 
     if [ "$expected_result" = "success" ]; then
-        if [ $exit_code -ne 0 ]; then
+        if [ "$exit_code" -ne 0 ]; then
             die "judges-action script failed with exit code $exit_code, but should succeed" \
               "Check log.txt for details of the failure"
         fi
     elif [ "$expected_result" = "failure" ]; then
-        if [ $exit_code -eq 0 ]; then
+        if [ "$exit_code" -eq 0 ]; then
             die "judges-action script succeeded when it should have failed" \
               "Expected: script to exit with non-zero code"
         fi


### PR DESCRIPTION
Closes #1707

Fix `set +e` leak from `run_entry_script` in `makes/test-common.sh`. The old code used bare `set +e` / `set -e` which could leak the +e state if the script exited abnormally or was called from a context with different errexit settings.

Changes:
- Save shell options before `set +e` via `old_opts=$(set +o)`
- Use `${PIPESTATUS[0]}` instead of $? to get entry.sh exit code (not tee's) from the pipeline
- Restore with `eval "$old_opts"` instead of bare `set -e`
- Also fix Makefile shellcheck false positives (SC2148, SC1036, SC1088, SC2034) and SC2086 unquoted `$exit_code$ in test-common.sh