### PR TITLE
#1708: fix die() exit code guarantee under set -e

### DIFF
--- a/makes/test-common.sh
+++ b/makes/test-common.sh
@@ -67,7 +67,7 @@ file_exists() {
 # Outputs all messages to stderr with "ERROR:" prefix and exits with code 1
 die() {
     for msg in "$@"; do
-        echo "ERROR: $msg" >&2
+        echo "ERROR: $msg" >&2 || true
     done
     exit 1
 }


### PR DESCRIPTION
Closes #1708

Fix `die()` exit code guarantee under `set -e`. When `set -e` is active and the `echo` to stderr fails, the shell exits immediately before reaching `exit 1`. Adding `|| true` ensures the function always reaches `exit 1`.