### PR TITLE
#1688: add missing judges/ and lib/ dependencies to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ verify:
 	e2=$$(cat target/entry.exit)
 	test "$${e2}" = "0"
 
-target/docker-image.txt: Makefile Dockerfile entry.sh Gemfile Gemfile.lock
+target/docker-image.txt: Makefile Dockerfile entry.sh Gemfile Gemfile.lock $(wildcard lib/*.rb) $(wildcard judges/*/*.rb)
 	mkdir -p "$$(dirname $@)"
 	docker build -t judges-action "$$(pwd)"
 	docker build -t judges-action -q "$$(pwd)" > "$@"


### PR DESCRIPTION
Closes #1688

Add missing source file dependencies to the `target/docker-image.txt` target in the Makefile. Previously only `Makefile`, `Dockerfile`, `entry.sh`, `Gemfile`, and `Gemfile.lock` triggered a rebuild, but changes to `lib/*.rb` or `judges/*/*.rb` were not tracked, causing stale Docker images to be used in CI.