### PR TITLE
#1691: fix ruby tag to explicit 4.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
 # SPDX-License-Identifier: MIT
 
-FROM ruby:4.0@sha256:d07ce5b3f4dc2246980d6d5bcd1e9e54ea62445b2b531ea1819112c69bf29d36
+FROM ruby:4.0.0@sha256:d07ce5b3f4dc2246980d6d5bcd1e9e54ea62445b2b531ea1819112c69bf29d36
 
 LABEL "repository"="https://github.com/zerocracy/judges-action"
 LABEL "maintainer"="Yegor Bugayenko"


### PR DESCRIPTION
Closes #1691

Fix Ruby tag in Dockerfile from `4.0` (minor version) to `4.0.0` (explicit patch) to ensure deterministic builds. The `@sha256` digest pin was already in place, but the tag should match the exact version being used.