### PR TITLE
#1697: remove unused actions: write permission from zerocracy.yml

### DIFF
--- a/.github/workflows/zerocracy.yml
+++ b/.github/workflows/zerocracy.yml
@@ -13,7 +13,6 @@ concurrency:
   cancel-in-progress: false
 permissions:
   contents: write
-  actions: write
 jobs:
   zerocracy:
     if: github.repository_owner == 'zerocracy'


### PR DESCRIPTION
Closes #1697

Remove unused `actions: write` permission from `.github/workflows/zerocracy.yml`. The zerocracy workflow doesn't use any Actions API endpoints that require write-level actions permissions. Keeping it grants unnecessary broad access.