### PR TITLE
#1699: enable cancel-in-progress to save runner minutes

### DIFF
--- a/.github/workflows/zerocracy.yml
+++ b/.github/workflows/zerocracy.yml
@@ -10,7 +10,7 @@ run-name: zerocracy run #${{ github.run_id }}
   workflow_dispatch:
 concurrency:
   group: zerocracy
-  cancel-in-progress: false
+  cancel-in-progress: true
 permissions:
   contents: write
   actions: write


### PR DESCRIPTION
Closes #1699

Enable `cancel-in-progress: true` for the zerocracy workflow concurrency group. When a new run is triggered for the same group (e.g., due to multiple pushes), the in-progress run is cancelled automatically, saving runner minutes. Previously with `false`, both runs would execute simultaneously.