### PR TITLE
#1701: remove cron schedule to prevent silent title overwrites

### DIFF
--- a/.github/workflows/titles.yml
+++ b/.github/workflows/titles.yml
@@ -4,8 +4,6 @@
 # yamllint disable rule:line-length
 name: titles
 'on':
-  schedule:
-    - cron: '0 * * * *'
   issues:
     types: [opened]
 jobs:


### PR DESCRIPTION
Closes #1701

Remove hourly cron schedule (`0 * * * *`) from `titles.yml`. The cron trigger was silently overwriting issue title updates made by other processes. The workflow now only runs on `issues: [opened]` events as intended.

**Note:** The `cancel-in-progress` change previously in this branch was removed as it belongs to #1699 (PR #1791).