### PR TITLE
#1704: stop pushing :latest docker tag on release

### DIFF
--- a/.rultor.yml
+++ b/.rultor.yml
@@ -27,7 +27,5 @@ release:
     repo=yegor256/judges-action
     sudo make -C "$(pwd)"
     sudo docker build "$(pwd)" --tag "${repo}:${tag}"
-    sudo docker build "$(pwd)" --tag "${repo}:latest"
     cat ../docker-password | sudo docker login --password-stdin -u yegor256
     sudo docker push "${repo}:${tag}"
-    sudo docker push "${repo}:latest"


### PR DESCRIPTION
Closes #1704

Stop pushing `:latest` Docker tag on release. The `:latest` tag is mutable and can cause confusion about which version is actually deployed. Only version tags (``) are pushed now.