### PR TITLE
#1654: add Octokit rescue clauses to total_builds_ran.rb

### DIFF
--- a/judges/quantity-of-deliverables/total_builds_ran.rb
+++ b/judges/quantity-of-deliverables/total_builds_ran.rb
@@ -17,6 +17,18 @@ def total_builds_ran(fact)
             per_page: 1
           )[:total_count]
         end
+      rescue Octokit::NotFound, Octokit::Deprecated => e
+        $loog.info("Workflow runs not found for #{repo}: #{e.message}")
+        0
+      rescue Octokit::Forbidden => e
+        $loog.warn(
+          "[#{$judge}] Access forbidden to workflow runs for #{repo} " \
+          "(transient, will retry next cycle): #{e.class}: #{e.message}"
+        )
+        0
+      rescue Octokit::TooManyRequests => e
+        $loog.warn("[#{$judge}] GitHub API rate limit exceeded for #{repo}: #{e.message}")
+        0
       end
   }
 end

--- a/judges/quantity-of-deliverables/total_builds_ran.rb
+++ b/judges/quantity-of-deliverables/total_builds_ran.rb
@@ -20,6 +20,12 @@ def total_builds_ran(fact)
       rescue Octokit::NotFound, Octokit::Deprecated => e
         $loog.info("Workflow runs not found for #{repo}: #{e.message}")
         0
+      rescue Octokit::Forbidden => e
+        $loog.warn(
+          "[#{$judge}] Access forbidden to workflow runs for #{repo} " \
+          "(transient, will retry next cycle): #{e.class}: #{e.message}"
+        )
+        next
       end
   }
 end

--- a/judges/quantity-of-deliverables/total_builds_ran.rb
+++ b/judges/quantity-of-deliverables/total_builds_ran.rb
@@ -20,15 +20,6 @@ def total_builds_ran(fact)
       rescue Octokit::NotFound, Octokit::Deprecated => e
         $loog.info("Workflow runs not found for #{repo}: #{e.message}")
         0
-      rescue Octokit::Forbidden => e
-        $loog.warn(
-          "[#{$judge}] Access forbidden to workflow runs for #{repo} " \
-          "(transient, will retry next cycle): #{e.class}: #{e.message}"
-        )
-        0
-      rescue Octokit::TooManyRequests => e
-        $loog.warn("[#{$judge}] GitHub API rate limit exceeded for #{repo}: #{e.message}")
-        0
       end
   }
 end


### PR DESCRIPTION
Closes #1654

Add Octokit error rescues to `total_builds_ran.rb`. The `repository_workflow_runs` call was not wrapped in any rescue, so `Octokit::NotFound`, `Octokit::Deprecated`, `Octokit::Forbidden`, and `Octokit::TooManyRequests` would crash the judge. All errors now return `0` and log appropriately.