### PR TITLE
#1669: replace Dir[].shuffle with sort for determinism

### DIFF
--- a/lib/incremate.rb
+++ b/lib/incremate.rb
@@ -17,7 +17,7 @@ def Jp.incremate(
   epoch: $epoch || Time.now, kickoff: $kickoff || Time.now
 )
   evaluated = 0
-  Dir[File.join(dir, "#{prefix}_*.rb")].sort.each do |rb|
+  Dir[File.join(dir, "#{prefix}_*.rb")].each do |rb|
     n = File.basename(rb).gsub(/\.rb$/, '')
     if fact[n]
       $loog.debug("#{n} is here: #{fact[n].first}")

--- a/lib/incremate.rb
+++ b/lib/incremate.rb
@@ -17,7 +17,7 @@ def Jp.incremate(
   epoch: $epoch || Time.now, kickoff: $kickoff || Time.now
 )
   evaluated = 0
-  Dir[File.join(dir, "#{prefix}_*.rb")].shuffle.each do |rb|
+  Dir[File.join(dir, "#{prefix}_*.rb")].sort.each do |rb|
     n = File.basename(rb).gsub(/\.rb$/, '')
     if fact[n]
       $loog.debug("#{n} is here: #{fact[n].first}")


### PR DESCRIPTION
Closes #1669

`Dir[].shuffle` in `Jp.incremate` makes judge evaluation order non-deterministic, which is harmful for reproducibility and testing.

Replace `.shuffle` with bare `Dir[]` — Ruby's `Dir.glob` /`Dir[]` already returns results in sorted order since Ruby 3.0+, so no explicit sorting is needed.

This guarantees deterministic evaluation order across runs with the same input data.