### PR TITLE
#1673: prevent JSON.pretty_generate from masking original error

### DIFF
--- a/lib/supervision.rb
+++ b/lib/supervision.rb
@@ -12,7 +12,12 @@ rescue StandardError => e
   begin
     info = JSON.pretty_generate(context)
   rescue StandardError => je
-    info = "Failed to serialize context: #{je.message}\n#{context.inspect}"
+    info =
+      begin
+        "Failed to serialize context: #{je.message}\n#{context.inspect}"
+      rescue StandardError
+        "Failed to serialize context: #{je.message}"
+      end
   end
   loog.error("Additional context for '#{e.class}: #{e.message}':\n#{info}")
   raise


### PR DESCRIPTION
Closes #1673

When `JSON.pretty_generate(context)` raises (e.g. due to non-serializable values like symbols or objects), the rescue falls back to `context.inspect`. But `#inspect` can also raise on malformed objects. The second `StandardError` rescue ensures we always get a usable error message rather than crashing during error reporting, which would mask the original exception.