### PR TITLE
#1682: fix Forbidden retried for every fact in erase-repository

### DIFF
--- a/judges/erase-repository/erase-repository.rb
+++ b/judges/erase-repository/erase-repository.rb
@@ -27,6 +27,7 @@ Fbe.fb.query('(and (eq where "github") (exists repository) (absent stale))').eac
       "[#{$judge}] Access forbidden to GitHub repository ##{r} " \
       "(transient, will retry next cycle): #{e.class}: #{e.message}"
     )
+    good[r] = true
   end
 end
 

--- a/test/judges/test-erase-repository.rb
+++ b/test/judges/test-erase-repository.rb
@@ -93,4 +93,25 @@ class TestEraseRepository < Jp::Test
     assert_equal(0, fb.query('(exists stale)').each.to_a.size)
     assert_equal(1, fb.query('(and (eq where "github") (exists repository) (absent stale))').each.to_a.size)
   end
+
+  def test_forbidden_repository_skipped_on_subsequent_facts
+    WebMock.disable_net_connect!
+    stub_request(:get, 'https://api.github.com/rate_limit').to_return(
+      { body: '{"rate":{"remaining":222}}', headers: { 'X-RateLimit-Remaining' => '222' } }
+    )
+    stub_github('https://api.github.com/repositories/403999', body: '', status: 403)
+    fb = Factbase.new
+    fb.insert.then do |f|
+      f._id = 1
+      f.where = 'github'
+      f.repository = 403_999
+    end
+    fb.insert.then do |f|
+      f._id = 2
+      f.where = 'github'
+      f.repository = 403_999
+    end
+    load_it('erase-repository', fb)
+    assert_requested(:get, 'https://api.github.com/repositories/403999', times: 1)
+  end
 end


### PR DESCRIPTION
Closes #1682

In `erase-repository`, when `Octokit::Forbidden` is rescued, `good[r]` was not set to `true`. This caused every subsequent fact in the same run to attempt the same forbidden repository and fail again with the same error. Adding `good[r] = true` marks the repository as processed so the judge moves on, logging the warning once per cycle.