### PR TITLE
#1715: add cleanup trap for temp files in entry.sh

### DIFF
--- a/entry.sh
+++ b/entry.sh
@@ -143,6 +143,7 @@ ${JUDGES} "${gopts[@]}" eval \
 
 if [ "$(printenv "INPUT_DRY-RUN" || echo 'false')" == 'true' ]; then
     ALL_JUDGES=$(mktemp -d)
+    trap 'rm -rf "$ALL_JUDGES"' EXIT INT TERM
     options+=("--no-expect-judges")
 else
     ALL_JUDGES=${SELF}/judges


### PR DESCRIPTION
Closes #1715

When `INPUT_DRY-RUN=true`, `entry.sh` creates a temp directory via `mktemp -d` for `ALL_JUDGES` but never cleans it up on exit. Add a `trap` to remove the temp directory on `EXIT`, `INT`, and `TERM` to prevent temp file leaks.