### PR TITLE
#1692: fix REUSE.toml copyright

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -30,5 +30,5 @@ path = [
     ".shellcheckrc",
 ]
 precedence = "override"
-SPDX-FileCopyrightText = "Copyright (c) 2025 Yegor Bugayenko"
+SPDX-FileCopyrightText = "Copyright (c) 2024-2026 Zerocracy"
 SPDX-License-Identifier = "MIT"


### PR DESCRIPTION
Closes #1692

Fix the copyright annotation in `REUSE.toml` for config files (those listed under the path glob). The original entry used `Copyright (c) 2025 Yegor Bugayenko`, which was outdated — all other files in the project use `Copyright (c) 2024-2026 Zerocracy`.