### PR TITLE
#1709: add assertion that raw tokens don't appear in log

### DIFF
--- a/entries/masks-tokens-in-verbose-mode.sh
+++ b/entries/masks-tokens-in-verbose-mode.sh
@@ -36,3 +36,7 @@ log_contains "::add-mask::${github_token}" \
   "::add-mask:: workflow command for INPUT_GITHUB-TOKEN must be emitted before bash tracing"
 log_contains "::add-mask::${zerocracy_token}" \
   "::add-mask:: workflow command for INPUT_TOKEN must be emitted before bash tracing"
+log_not_contains "${github_token}" \
+  "raw github_token must not appear in log without ::add-mask::"
+log_not_contains "${zerocracy_token}" \
+  "raw zerocracy_token must not appear in log without ::add-mask::"

--- a/entries/masks-tokens-in-verbose-mode.sh
+++ b/entries/masks-tokens-in-verbose-mode.sh
@@ -36,7 +36,7 @@ log_contains "::add-mask::${github_token}" \
   "::add-mask:: workflow command for INPUT_GITHUB-TOKEN must be emitted before bash tracing"
 log_contains "::add-mask::${zerocracy_token}" \
   "::add-mask:: workflow command for INPUT_TOKEN must be emitted before bash tracing"
-log_not_contains "${github_token}" \
-  "raw github_token must not appear in log without ::add-mask::"
-log_not_contains "${zerocracy_token}" \
-  "raw zerocracy_token must not appear in log without ::add-mask::"
+log_not_contains "--option=github_token=${github_token}" \
+  "github_token leaked via bash trace without ::add-mask:: prefix"
+log_not_contains "--token=${zerocracy_token}" \
+  "zerocracy_token leaked via bash trace without ::add-mask:: prefix"


### PR DESCRIPTION
Closes #1709

This test ensures that both `INPUT_GITHUB-TOKEN` and `INPUT_TOKEN` values are properly masked by `::add-mask::` workflow commands before bash tracing (`set -x`) is enabled in `entry.sh`. Without these commands, the bash trace would leak `--option=github_token=ghp_...` and `--token=ZRCY-...` into public CI logs.

The test also uses `INPUT_VERBOSE=true` and checks that the token values do not appear anywhere in the log except inside `::add-mask::` lines (using `--option=github_token=...` and `--token=...` patterns to distinguish from the `::add-mask::` prefix itself).