### PR TITLE
#1648 nil guards for additions and deletions across judges

### DIFF
--- a/judges/code-was-reviewed/code-was-reviewed.rb
+++ b/judges/code-was-reviewed/code-was-reviewed.rb
@@ -71,7 +71,7 @@ Fbe.consider(
         end
       next if n.nil?
       n.when = review[:submitted_at]
-      n.hoc = pr[:additions] + pr[:deletions]
+      n.hoc = (pr[:additions] || 0) + (pr[:deletions] || 0)
       n.author = pr.dig(:user, :id)
       n.comments =
         begin

--- a/judges/fix-missing-hoc/fix-missing-hoc.rb
+++ b/judges/fix-missing-hoc/fix-missing-hoc.rb
@@ -36,7 +36,7 @@ Fbe.consider(
       )
       next
     end
-  f.hoc = json[:additions] + json[:deletions]
+  f.hoc = (json[:additions] || 0) + (json[:deletions] || 0)
   $loog.info("Hoc found for #{Fbe.issue(f)}: #{f.hoc}")
 end
 

--- a/judges/github-events/github-events.rb
+++ b/judges/github-events/github-events.rb
@@ -287,8 +287,8 @@ Fbe.iterate do
         end
         skip(json) unless json.dig(:payload, :review, :state) == 'approved'
         fact.what = 'pull-was-reviewed'
-        fact.hoc = pull[:additions] + pull[:deletions]
-        fact.comments = pull[:comments] + pull[:review_comments]
+        fact.hoc = (pull[:additions] || 0) + (pull[:deletions] || 0)
+        fact.comments = (pull[:comments] || 0) + (pull[:review_comments] || 0)
         fact.review_comments = pull[:review_comments]
         fact.commits = pull[:commits]
         fact.files = pull[:changed_files]

--- a/judges/pull-was-merged/pull-was-merged.rb
+++ b/judges/pull-was-merged/pull-was-merged.rb
@@ -106,7 +106,7 @@ Fbe.iterate do
           n.where = 'github'
         end
       raise(RuntimeError, "Pull already merged in #{repo}##{issue}") if nn.nil?
-      nn.hoc = json[:additions] + json[:deletions]
+      nn.hoc = (json[:additions] || 0) + (json[:deletions] || 0)
       nn.files = json[:changed_files] if json[:changed_files]
       nn.branch = json[:head][:ref]
       Jp.fill_fact_by_hash(nn, Jp.comments_info(json))

--- a/judges/quality-of-service/some_pull_hoc_size.rb
+++ b/judges/quality-of-service/some_pull_hoc_size.rb
@@ -28,7 +28,7 @@ def some_pull_hoc_size(fact)
           )
           next
         end
-      hocs << (pull[:additions] + pull[:deletions])
+      hocs << ((pull[:additions] || 0) + (pull[:deletions] || 0))
       files << pull[:changed_files]
     end
   end


### PR DESCRIPTION
Adds `|| 0` guards on `pull[:additions] + pull[:deletions]` across 5 judges to prevent crashes when API returns nil.

Closes #1648