### PR TITLE
#1724 nil guard for time arithmetic in code-was-reviewed

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -64,6 +64,7 @@ Elegant/GoodMethodName:
     - stub_pull_was_merged_base
     - stub_pull_was_merged_issue
     - stub_pull_was_merged_success
+    - list_milestones
 Metrics/MethodLength:
   Enabled: false
 Metrics/AbcSize:

--- a/judges/code-was-reviewed/code-was-reviewed.rb
+++ b/judges/code-was-reviewed/code-was-reviewed.rb
@@ -99,7 +99,7 @@ Fbe.consider(
           )
           0
         end
-      n.seconds = Integer(review[:submitted_at] - pr[:created_at]) if pr[:created_at] && review[:submitted_at]
+      n.seconds = Integer(review[:submitted_at] - pr[:created_at])
       n.details =
         "The pull request #{Fbe.issue(n)} with #{n.hoc} HoC " \
         "created by #{Fbe.who(n, :author)} was reviewed by #{Fbe.who(n)} " \

--- a/judges/code-was-reviewed/code-was-reviewed.rb
+++ b/judges/code-was-reviewed/code-was-reviewed.rb
@@ -99,7 +99,7 @@ Fbe.consider(
           )
           0
         end
-      n.seconds = Integer(review[:submitted_at] - pr[:created_at])
+      n.seconds = Integer(review[:submitted_at] - pr[:created_at]) if pr[:created_at] && review[:submitted_at]
       n.details =
         "The pull request #{Fbe.issue(n)} with #{n.hoc} HoC " \
         "created by #{Fbe.who(n, :author)} was reviewed by #{Fbe.who(n)} " \

--- a/judges/milestone-was-set/milestone-was-set.rb
+++ b/judges/milestone-was-set/milestone-was-set.rb
@@ -7,6 +7,7 @@ require 'fbe/consider'
 require 'fbe/if_absent'
 require 'fbe/octo'
 require 'octokit'
+require_relative '../../lib/patches/fake_octokit'
 
 Fbe.consider(
   '(and

--- a/lib/patches/fake_octokit.rb
+++ b/lib/patches/fake_octokit.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+# SPDX-License-Identifier: MIT
+
+if Object.const_defined?('Fbe::FakeOctokit')
+  Fbe::FakeOctokit.class_eval do
+    def list_milestones(_repo, state: 'open')
+      $loog.info("FakeOctokit#list_milestones(#{_repo}, state: #{state}) called — returning []")
+      []
+    end
+  end
+end

--- a/lib/patches/fake_octokit.rb
+++ b/lib/patches/fake_octokit.rb
@@ -5,8 +5,8 @@
 
 if Object.const_defined?('Fbe::FakeOctokit')
   Fbe::FakeOctokit.class_eval do
-    def list_milestones(repo, state: 'open')
-      $loog.info("FakeOctokit#list_milestones(#{repo}, state: #{state}) called — returning []")
+    def list_milestones(repo, _options = {})
+      $loog.info("FakeOctokit#list_milestones(#{repo}) called — returning []")
       []
     end
   end

--- a/lib/patches/fake_octokit.rb
+++ b/lib/patches/fake_octokit.rb
@@ -5,8 +5,8 @@
 
 if Object.const_defined?('Fbe::FakeOctokit')
   Fbe::FakeOctokit.class_eval do
-    def list_milestones(_repo, state: 'open')
-      $loog.info("FakeOctokit#list_milestones(#{_repo}, state: #{state}) called — returning []")
+    def list_milestones(repo, state: 'open')
+      $loog.info("FakeOctokit#list_milestones(#{repo}, state: #{state}) called — returning []")
       []
     end
   end


### PR DESCRIPTION
Closes #1724

Add nil guard for time arithmetic in `code-was-reviewed.rb`: `n.seconds = Integer(review[:submitted_at] - pr[:created_at])` can crash with `NoMethodError` when either timestamp is nil (e.g. missing data from API). Only compute seconds when both timestamps are present.

Also adds `lib/patches/fake_octokit.rb` — a monkey-patch for `Fbe::FakeOctokit#list_milestones` needed by the `milestone-was-set` judge when running tests with `--disable live` (Docker integration test). The `fbe` gem's `FakeOctokit` is missing this method. Can be removed once `fbe` adds it upstream.