### PR TITLE
#1732 nil guard for issue[:created_at] in some_triage_time

### DIFF
--- a/judges/quality-of-service/some_triage_time.rb
+++ b/judges/quality-of-service/some_triage_time.rb
@@ -45,6 +45,7 @@ def some_triage_time(fact)
         "
       ).each.min_by(&:when)
       next unless ff
+      next unless issue[:created_at]
       delta = ff.when - issue[:created_at]
       next if delta < threshold
       times << delta


### PR DESCRIPTION
Adds `next unless issue[:created_at]` before arithmetic in `some_triage_time.rb`.

Closes #1732