### PR TITLE
#1647 replace RuntimeError with warn+return in issue_was_lost

### DIFF
--- a/lib/issue_was_lost.rb
+++ b/lib/issue_was_lost.rb
@@ -25,7 +25,10 @@ def Jp.issue_was_lost(where, repository, issue)
       n.repository = repository
       n.where = where
     end
-  raise(RuntimeError, "The issue ##{issue} was already lost") unless f
+  unless f
+    $loog.warn("The issue ##{issue} was already lost")
+    return
+  end
   f.stale = 'issue'
   f.when = Time.now
   Fbe::Tombstone.new.bury!(where, repository, issue)

--- a/test/lib/test_issue_was_lost.rb
+++ b/test/lib/test_issue_was_lost.rb
@@ -39,14 +39,12 @@ class TestIssueWasLost < Minitest::Test
     end
   end
 
-  def test_raises_on_second_call_for_same_issue
+  def test_graceful_on_second_call_for_same_issue
     fb = Factbase.new
     Fbe.stub(:fb, fb) do
       $loog = Loog::NULL
       Jp.issue_was_lost('github', 42, 123)
-      assert_raises(RuntimeError, 'second call for the same (where, repository, issue) must raise') do
-        Jp.issue_was_lost('github', 42, 123)
-      end
+      Jp.issue_was_lost('github', 42, 123)
     end
   end
 


### PR DESCRIPTION
Replaces `raise RuntimeError` in `Jp.issue_was_lost` with `warn` + `return` when an issue is already lost, preventing the judge from crashing.

Closes #1647