### PR TITLE
#1645 replace RuntimeError with warn+next in issue-was-closed

### DIFF
--- a/judges/issue-was-closed/issue-was-closed.rb
+++ b/judges/issue-was-closed/issue-was-closed.rb
@@ -69,7 +69,10 @@ Fbe.iterate do
           n.issue = issue
           n.what = $judge
         end
-      raise(RuntimeError, "Issue #{repo}##{issue} already closed") if nn.nil?
+      if nn.nil?
+        $loog.warn("Issue #{repo}##{issue} already closed")
+        next issue
+      end
       nn.when = json[:closed_at] ? Time.parse(json[:closed_at].iso8601) : Time.now
       who = json.dig(:closed_by, :id)
       if who


### PR DESCRIPTION
Replaces `raise RuntimeError` in `issue-was-closed.rb` with `warn` + `next issue` when an issue is already closed, preventing the judge from crashing.

Closes #1645