### PR TITLE
#1698: warn about zerocracy/* wildcard in zerocracy.yml

### DIFF
--- a/.github/workflows/zerocracy.yml
+++ b/.github/workflows/zerocracy.yml
@@ -26,6 +26,7 @@ jobs:
           token: ${{ secrets.ZEROCRACY_TOKEN }}
           github-token: ${{ secrets.PAT }}
           repositories: yegor256/judges,yegor256/factbase,zerocracy/*,yegor256/0rsk
+          # WARNING: zerocracy/* wildcard covers ALL org repos — review when adding new repos
           factbase: zerocracy.fb
           timeout: 15
           lifetime: 20


### PR DESCRIPTION
Closes #1698

Add WARNING comment above the `repositories` line in zerocracy.yml to remind that `zerocracy/*` wildcard covers ALL repos in the organization. Review when adding new repos.