### PR TITLE
#1705: warn about cross-repo rultor asset

### DIFF
--- a/.rultor.yml
+++ b/.rultor.yml
@@ -5,6 +5,7 @@
 docker:
   image: yegor256/ruby
 assets:
+  # WARNING: cross-repo asset reference — supply chain risk (trusted from yegor256/home)
   docker-password: yegor256/home#assets/docker-password
 install: |
   sudo apt-get -y update


### PR DESCRIPTION
Closes #1705

Add WARNING comment above the `docker-password` asset in .rultor.yml noting the cross-repo asset reference as a supply chain risk. Asset is fetched from `yegor256/home` repo.