### PR TITLE
#1643: gracefully skip duplicate facts instead of raising RuntimeError

### DIFF
--- a/judges/issue-was-closed/issue-was-closed.rb
+++ b/judges/issue-was-closed/issue-was-closed.rb
@@ -69,7 +69,10 @@ Fbe.iterate do
           n.issue = issue
           n.what = $judge
         end
-      raise(RuntimeError, "Issue #{repo}##{issue} already closed") if nn.nil?
+      if nn.nil?
+        $loog.warn("Issue #{repo}##{issue} already closed, skipping duplicate")
+        next issue
+      end
       nn.when = json[:closed_at] ? Time.parse(json[:closed_at].iso8601) : Time.now
       who = json.dig(:closed_by, :id)
       if who

--- a/judges/pull-was-merged/pull-was-merged.rb
+++ b/judges/pull-was-merged/pull-was-merged.rb
@@ -105,7 +105,10 @@ Fbe.iterate do
           n.repository = repository
           n.where = 'github'
         end
-      raise(RuntimeError, "Pull already merged in #{repo}##{issue}") if nn.nil?
+      if nn.nil?
+        $loog.warn("Pull already merged in #{repo}##{issue}, skipping duplicate")
+        next issue
+      end
       nn.hoc = json[:additions] + json[:deletions]
       nn.files = json[:changed_files] if json[:changed_files]
       nn.branch = json[:head][:ref]

--- a/judges/type-was-attached/type-was-attached.rb
+++ b/judges/type-was-attached/type-was-attached.rb
@@ -83,7 +83,10 @@ Fbe.iterate do
             n.repository = repository
             n.where = 'github'
           end
-        raise(RuntimeError, "Type already attached to #{repo}##{issue}") if nn.nil?
+        if nn.nil?
+          $loog.warn("Type already attached to #{repo}##{issue}, skipping duplicate")
+          next
+        end
         who = tee.dig('actor', 'id')
         if who
           nn.who = who


### PR DESCRIPTION
Closes #1643

In `pull-was-merged.rb`, `type-was-attached.rb`, and `issue-was-closed.rb`, the pattern:

```ruby
Fbe.if_absent(fb: fbt) do |n|
  ...
end
raise(RuntimeError, "...") if nn.nil?
```

.. raises an exception when `Fbe.if_absent` returns `nil` (meaning the fact already exists). The `raise` propagates out of `Fbe.iterate`'s `over` block and kills the entire iteration cycle, skipping all remaining repos/issues.

Fix: replace `raise` with a warn log + `next`/`next issue` to gracefully skip the duplicate and continue processing. This is consistent with how other nearby `if_absent` duplicates are already handled (e.g., `issue-was-closed.rb:106-108`).