### PR TITLE
#1646: guard Integer(pull.dig(:user, :id)) against nil on deleted PR author

### DIFF
--- a/judges/github-events/github-events.rb
+++ b/judges/github-events/github-events.rb
@@ -276,7 +276,7 @@ Fbe.iterate do
             )
             skip(json)
           end
-        skip(json) if Integer(pull.dig(:user, :id)) == fact.who
+        skip(json) if pull.dig(:user, :id)&.then { |id| Integer(id) } == fact.who
         if Fbe.fb.query(
           "(and (eq repository #{fact.repository}) " \
           '(eq what "pull-was-reviewed") ' \


### PR DESCRIPTION
Closes #1646

On `PullRequestReviewEvent`, line 279 reads:

```ruby
skip(json) if Integer(pull.dig(:user, :id)) == fact.who
```

If the PR author's GitHub account was deleted, `:user` is nil and `Integer(nil)` raises `TypeError: can't convert nil into Integer`. This crashes the judge mid-iteration and skips all remaining repos.

Fix: use `&.to_i` instead of `Integer()`. `nil&.to_i` returns `nil`, and `nil == fact.who` is `false`, so we don't skip and continue processing. The `pull-was-merged.rb` case (`Integer(actor[:id])` at line 115) is already guarded by `if actor` on line 117.