### PR TITLE
#1659: remove unconditional skip(json) that killed all IssueCommentEvent facts

### DIFF
--- a/judges/github-events/github-events.rb
+++ b/judges/github-events/github-events.rb
@@ -316,7 +316,6 @@ Fbe.iterate do
       end
       skip(json) if seen?(fact)
     when 'IssueCommentEvent'
-      skip(json)
       fact.issue = json[:payload][:issue][:number]
       case json[:payload][:action]
       when 'created'


### PR DESCRIPTION
Closes #1659

In `github-events.rb`, the `IssueCommentEvent` handler starts with:

```ruby
skip(json)
```

This calls `raise(Factbase::Rollback)` which rolls back the transaction before any fact is created. Lines 320–333 (`fact.issue = ...`, `fact.what = comment-was-posted`, etc.) were dead code.

Fix: remove the unconditional `skip(json)`. The `else` branch inside the `case` (line 331–332) already handles non-`created` actions (edited, deleted) by calling `skip(json)` conditionally.

A `seen?(fact)` check is intentionally not added here — unlike IssuesEvent (one open/close per issue), multiple comments can be posted on the same issue, and `seen?` would incorrectly skip follow-up comments.