### PR TITLE
#1675: add allowlist validation and public_send in fill_fact_by_hash

### DIFF
--- a/lib/fill_fact.rb
+++ b/lib/fill_fact.rb
@@ -5,9 +5,14 @@
 
 require_relative 'jp'
 
+Jp::FILL_FACT_FORBIDDEN = %w[all_properties method_missing].freeze
+
 def Jp.fill_fact_by_hash(fact, hash)
   hash.each do |prop, value|
     raise(ArgumentError, "Invalid property name: #{prop.inspect}") unless /^[a-z][a-z_0-9]*$/i.match?(prop.to_s)
-    fact.__send__(:"#{prop}=", value)
+    if Jp::FILL_FACT_FORBIDDEN.include?(prop.to_s)
+      raise(ArgumentError, "Forbidden property name: #{prop.inspect} (conflicts with fact API)")
+    end
+    fact.public_send(:"#{prop}=", value)
   end
 end


### PR DESCRIPTION
Closes #1675

Two changes to `Jp.fill_fact_by_hash`:

1. **Allowlist validation**: rejects property names that conflict with factbase fact API methods (`all_properties`, `method_missing`). Defined as `Jp::FILL_FACT_FORBIDDEN` constant (following existing pattern of `Jp::SEARCH_WINDOW_SECONDS` in `qos_search.rb`).

2. **Use `public_send` instead of `__send__`**: `public_send` only calls public methods. Since fact properties are set through the public `method_missing` interface (factbase facts have no `foo=` setters — they use `method_missing` for dynamic properties), this is the correct visibility level and prevents any latent risk of calling private/internal methods.

Note: the existing format validation (`/^[a-z][a-z_0-9]*$/i`) is kept — it already rejects names with special characters, underscores prefix, or numeric prefix.