### PR TITLE
#1718: guard against nil Fbe.github_graph in comments_resolved

### DIFF
--- a/lib/pull_request.rb
+++ b/lib/pull_request.rb
@@ -48,7 +48,11 @@ def Jp.comments_info(pr, repo: nil)
     comments_appreciated: Jp.count_appreciated_comments(pr, icomments, ccomments, repo:),
     comments_resolved:
       begin
-        Fbe.github_graph.resolved_conversations(org, rname, pr[:number]).count
+        if Fbe.github_graph
+          Fbe.github_graph.resolved_conversations(org, rname, pr[:number]).count
+        else
+          0
+        end
       rescue GraphQL::Client::Error, Octokit::NotFound, Octokit::Deprecated => e
         $loog.info("Resolved conversations not available for #{repo}##{pr[:number]}: #{e.message}")
         0


### PR DESCRIPTION
Closes #1718

If GraphQL is not configured, `Fbe.github_graph` is nil and `nil.resolved_conversations(...)` raises `NoMethodError` (not caught by existing rescue list).

Fix: check `if Fbe.github_graph` before calling the method, returning 0 when nil.

Note: this change may have a merge conflict with PR #1822 (which replaces `resolved_conversations` with a paginated `query`). The nil guard pattern should be preserved whichever version lands first.