### PR TITLE
#1722: add rescue for TooManyRequests/Unauthorized/ServerError to fix-missing judges

### DIFF
--- a/judges/fix-missing-branch/fix-missing-branch.rb
+++ b/judges/fix-missing-branch/fix-missing-branch.rb
@@ -35,6 +35,12 @@ Fbe.consider(
         "(transient, will retry next cycle): #{e.class}: #{e.message}"
       )
       next
+    rescue Octokit::TooManyRequests, Octokit::Unauthorized, Octokit::ServerError => e
+      $loog.warn(
+        "[#{$judge}] Transient error fetching #{Fbe.issue(f)} in #{repo} " \
+        "(will retry next cycle): #{e.class}: #{e.message}"
+      )
+      next
     end
   ref = json.dig(:head, :ref)
   if ref.nil?

--- a/judges/fix-missing-comments/fix-missing-comments.rb
+++ b/judges/fix-missing-comments/fix-missing-comments.rb
@@ -37,6 +37,12 @@ Fbe.consider(
         "(transient, will retry next cycle): #{e.class}: #{e.message}"
       )
       next
+    rescue Octokit::TooManyRequests, Octokit::Unauthorized, Octokit::ServerError => e
+      $loog.warn(
+        "[#{$judge}] Transient error fetching #{Fbe.issue(f)} in #{repo} " \
+        "(will retry next cycle): #{e.class}: #{e.message}"
+      )
+      next
     end
   Jp.fill_fact_by_hash(f, Jp.comments_info(json, repo:))
   $loog.info("Comments found for #{Fbe.issue(f)}: #{f.comments}")

--- a/judges/fix-missing-hoc/fix-missing-hoc.rb
+++ b/judges/fix-missing-hoc/fix-missing-hoc.rb
@@ -35,6 +35,12 @@ Fbe.consider(
         "(transient, will retry next cycle): #{e.class}: #{e.message}"
       )
       next
+    rescue Octokit::TooManyRequests, Octokit::Unauthorized, Octokit::ServerError => e
+      $loog.warn(
+        "[#{$judge}] Transient error fetching #{Fbe.issue(f)} in #{repo} " \
+        "(will retry next cycle): #{e.class}: #{e.message}"
+      )
+      next
     end
   f.hoc = json[:additions] + json[:deletions]
   $loog.info("Hoc found for #{Fbe.issue(f)}: #{f.hoc}")

--- a/lib/pull_request.rb
+++ b/lib/pull_request.rb
@@ -48,7 +48,11 @@ def Jp.comments_info(pr, repo: nil)
     comments_appreciated: Jp.count_appreciated_comments(pr, icomments, ccomments, repo:),
     comments_resolved:
       begin
-        Fbe.github_graph.resolved_conversations(org, rname, pr[:number]).count
+        if Fbe.github_graph
+          Fbe.github_graph.resolved_conversations(org, rname, pr[:number]).count
+        else
+          0
+        end
       rescue GraphQL::Client::Error, Octokit::NotFound, Octokit::Deprecated => e
         $loog.info("Resolved conversations not available for #{repo}##{pr[:number]}: #{e.message}")
         0


### PR DESCRIPTION
Closes #1722

All three `fix-missing-*` judges call `Fbe.octo.pull_request` with only `NotFound/Deprecated` and `Forbidden` rescues. Missing `TooManyRequests`, `Unauthorized`, and `ServerError` cause crashes on transient errors.

Files fixed:
- `judges/fix-missing-hoc/fix-missing-hoc.rb`
- `judges/fix-missing-branch/fix-missing-branch.rb`
- `judges/fix-missing-comments/fix-missing-comments.rb`

Each adds a new rescue block logging a warn and skipping to the next fact via `next`.