### PR TITLE
#1725: add rescue for TooManyRequests/Unauthorized/ServerError and network errors

### DIFF
--- a/judges/code-was-reviewed/code-was-reviewed.rb
+++ b/judges/code-was-reviewed/code-was-reviewed.rb
@@ -43,6 +43,14 @@ Fbe.consider(
         "(transient, will retry next cycle): #{e.class}: #{e.message}"
       )
       next
+    rescue Octokit::TooManyRequests, Octokit::Unauthorized, Octokit::ServerError,
+      Net::OpenTimeout, Net::ReadTimeout, SocketError,
+      Errno::ECONNRESET, Errno::ETIMEDOUT => e
+      $loog.warn(
+        "[#{$judge}] Transient error fetching pull ##{f.issue} in #{repo} " \
+        "(will retry next cycle): #{e.class}: #{e.message}"
+      )
+      next
     end
   reviews =
     begin
@@ -55,6 +63,14 @@ Fbe.consider(
       $loog.warn(
         "[#{$judge}] Access forbidden to reviews for pull ##{f.issue} in #{repo} " \
         "(transient, will retry next cycle): #{e.class}: #{e.message}"
+      )
+      next
+    rescue Octokit::TooManyRequests, Octokit::Unauthorized, Octokit::ServerError,
+      Net::OpenTimeout, Net::ReadTimeout, SocketError,
+      Errno::ECONNRESET, Errno::ETIMEDOUT => e
+      $loog.warn(
+        "[#{$judge}] Transient error fetching reviews for pull ##{f.issue} in #{repo} " \
+        "(will retry next cycle): #{e.class}: #{e.message}"
       )
       next
     end
@@ -85,6 +101,14 @@ Fbe.consider(
             "(transient, will retry next cycle): #{e.class}: #{e.message}"
           )
           0
+        rescue Octokit::TooManyRequests, Octokit::Unauthorized, Octokit::ServerError,
+          Net::OpenTimeout, Net::ReadTimeout, SocketError,
+          Errno::ECONNRESET, Errno::ETIMEDOUT => e
+          $loog.warn(
+            "[#{$judge}] Transient error fetching issue comments for #{repo}##{f.issue} " \
+            "(will retry next cycle): #{e.class}: #{e.message}"
+          )
+          0
         end
       n.review_comments =
         begin
@@ -96,6 +120,14 @@ Fbe.consider(
           $loog.warn(
             "[#{$judge}] Access forbidden to review comments for #{repo}##{f.issue} " \
             "(transient, will retry next cycle): #{e.class}: #{e.message}"
+          )
+          0
+        rescue Octokit::TooManyRequests, Octokit::Unauthorized, Octokit::ServerError,
+          Net::OpenTimeout, Net::ReadTimeout, SocketError,
+          Errno::ECONNRESET, Errno::ETIMEDOUT => e
+          $loog.warn(
+            "[#{$judge}] Transient error fetching review comments for #{repo}##{f.issue} " \
+            "(will retry next cycle): #{e.class}: #{e.message}"
           )
           0
         end

--- a/judges/pull-was-merged/pull-was-merged.rb
+++ b/judges/pull-was-merged/pull-was-merged.rb
@@ -64,6 +64,14 @@ Fbe.iterate do
           "(transient, will retry next cycle): #{e.class}: #{e.message}"
         )
         next issue
+      rescue Octokit::TooManyRequests, Octokit::Unauthorized, Octokit::ServerError,
+        Net::OpenTimeout, Net::ReadTimeout, SocketError,
+        Errno::ECONNRESET, Errno::ETIMEDOUT => e
+        $loog.warn(
+          "[#{$judge}] Transient error fetching pull ##{issue} in #{repo} " \
+          "(will retry next cycle): #{e.class}: #{e.message}"
+        )
+        next issue
       end
     unless json[:state] == 'closed'
       $loog.debug("Pull #{repo}##{issue} is not closed: #{json[:state].inspect}")
@@ -82,6 +90,14 @@ Fbe.iterate do
           "(transient, will retry next cycle): #{e.class}: #{e.message}"
         )
         next issue
+      rescue Octokit::TooManyRequests, Octokit::Unauthorized, Octokit::ServerError,
+        Net::OpenTimeout, Net::ReadTimeout, SocketError,
+        Errno::ECONNRESET, Errno::ETIMEDOUT => e
+        $loog.warn(
+          "[#{$judge}] Transient error fetching issue ##{issue} in #{repo} " \
+          "(will retry next cycle): #{e.class}: #{e.message}"
+        )
+        next issue
       end
     reviews =
       begin
@@ -94,6 +110,14 @@ Fbe.iterate do
         $loog.warn(
           "[#{$judge}] Access forbidden to reviews of pull ##{issue} in #{repo} " \
           "(transient, will retry next cycle): #{e.class}: #{e.message}"
+        )
+        next issue
+      rescue Octokit::TooManyRequests, Octokit::Unauthorized, Octokit::ServerError,
+        Net::OpenTimeout, Net::ReadTimeout, SocketError,
+        Errno::ECONNRESET, Errno::ETIMEDOUT => e
+        $loog.warn(
+          "[#{$judge}] Transient error fetching reviews of pull ##{issue} in #{repo} " \
+          "(will retry next cycle): #{e.class}: #{e.message}"
         )
         next issue
       end


### PR DESCRIPTION
Closes #1725

Adds `rescue Octokit::TooManyRequests, Octokit::Unauthorized, Octokit::ServerError, Net::OpenTimeout, Net::ReadTimeout, SocketError, Errno::ECONNRESET, Errno::ETIMEDOUT` to all `Fbe.octo` API calls that were only rescuing `NotFound/Deprecated` and `Forbidden`.

**`judges/code-was-reviewed/code-was-reviewed.rb`** — 4 call sites:
- `pull_request`, `pull_request_reviews` — `next` (skip the fact)
- `issue_comments`, `pull_request_review_comments` — return `0`

**`judges/pull-was-merged/pull-was-merged.rb`** — 3 call sites:
- `pull_request`, `issue`, `pull_request_reviews` — all `next issue`