### PR TITLE
#1726: add transient error rescue to Jp.qosearch

### DIFF
--- a/lib/qos_search.rb
+++ b/lib/qos_search.rb
@@ -52,4 +52,9 @@ rescue Octokit::TooManyRequests => e
   @offquota = true
   $loog.warn("[#{$judge}] GitHub Search API quota exhausted, stopping search calls: #{e.message}")
   nil
+rescue Octokit::ServerError,
+  Net::OpenTimeout, Net::ReadTimeout, SocketError,
+  Errno::ECONNRESET, Errno::ETIMEDOUT => e
+  $loog.warn("[#{$judge}] Transient error in search API call (will retry next cycle): #{e.class}: #{e.message}")
+  nil
 end


### PR DESCRIPTION
Closes #1726

`Jp.qosearch` only rescues `Octokit::TooManyRequests`. Other transient errors (`Octokit::ServerError`, network timeouts) propagate to callers which don't rescue them either.

Fix: add `rescue Octokit::ServerError, Net::OpenTimeout, Net::ReadTimeout, SocketError, Errno::ECONNRESET, Errno::ETIMEDOUT` returning `nil`. All callers already handle `nil` from `Jp.qosearch` (they `return {}` on nil).