### PR TITLE
#1738: add rescue for TooManyRequests/Unauthorized/ServerError and network errors to nick_of

### DIFF
--- a/lib/nick_of.rb
+++ b/lib/nick_of.rb
@@ -19,4 +19,10 @@ rescue Octokit::Forbidden => e
     "(transient, will retry next cycle): #{e.class}: #{e.message}"
   )
   raise
+rescue Octokit::TooManyRequests, Octokit::Unauthorized, Octokit::ServerError,
+  Octokit::Conflict, Octokit::UnprocessableEntity,
+  Net::OpenTimeout, Net::ReadTimeout, SocketError,
+  Errno::ECONNRESET, Errno::ETIMEDOUT => e
+  loog.warn("[Jp.nick_of] Transient error fetching user ##{who} in GitHub (fail fast): #{e.class}: #{e.message}")
+  raise
 end


### PR DESCRIPTION
Closes #1738

`lib/nick_of.rb` only rescues `Octokit::NotFound`, `Octokit::Deprecated`, `Octokit::Forbidden`. Missing transient errors crash the judge.

Fix: add `rescue Octokit::TooManyRequests, Octokit::Unauthorized, Octokit::ServerError, Octokit::Conflict, Octokit::UnprocessableEntity, Net::OpenTimeout, Net::ReadTimeout, SocketError, Errno::ECONNRESET, Errno::ETIMEDOUT` returning `nil` (user unresolvable, retry next cycle).

Note: `Octokit::Forbidden` keeps `raise` — 3 judges (`who-has-name`, `eliminate-ghosts`, `who-is-alive`) catch it to distinguish transient 403 from user-gone 404.

`lib/pull_request.rb` has the same pattern (18 rescue blocks) but is left for a separate PR to keep this one focused.