### PR TITLE
#1739: add FakeOctokit#list_milestones for milestone-was-set

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -64,6 +64,7 @@ Elegant/GoodMethodName:
     - stub_pull_was_merged_base
     - stub_pull_was_merged_issue
     - stub_pull_was_merged_success
+    - list_milestones
 Metrics/MethodLength:
   Enabled: false
 Metrics/AbcSize:

--- a/judges/milestone-was-set/milestone-was-set.rb
+++ b/judges/milestone-was-set/milestone-was-set.rb
@@ -7,6 +7,7 @@ require 'fbe/consider'
 require 'fbe/if_absent'
 require 'fbe/octo'
 require 'octokit'
+require_relative '../../lib/patches/fake_octokit'
 
 Fbe.consider(
   '(and

--- a/lib/patches/fake_octokit.rb
+++ b/lib/patches/fake_octokit.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+# SPDX-License-Identifier: MIT
+
+require 'fbe/octo'
+
+class Fbe::FakeOctokit
+  def list_milestones(_repo, **)
+    []
+  end
+end


### PR DESCRIPTION
Closes #1739

Add `FakeOctokit#list_milestones` monkey-patch to fix `NoMethodError` in Docker integration tests (`make` CI). The `milestone-was-set` judge calls `Fbe.octo.list_milestones` which is not implemented in `FakeOctokit` (the fake from `fbe` gem).

Wires the patch into `milestone-was-set.rb` via `require_relative`.

Also adds `list_milestones` to `Elegant/GoodMethodName AllowedNames` in `.rubocop.yml`.