### PR TITLE
#1721: fetch issue comments count once per PR instead of once per review

### DIFF
--- a/judges/code-was-reviewed/code-was-reviewed.rb
+++ b/judges/code-was-reviewed/code-was-reviewed.rb
@@ -74,6 +74,7 @@ Fbe.consider(
       )
       next
     end
+  count = nil
   reviews.each do |review|
     next if review.dig(:user, :id) == pr.dig(:user, :id)
     Fbe.fb.txn do |fbt|
@@ -89,7 +90,7 @@ Fbe.consider(
       n.when = review[:submitted_at]
       n.hoc = pr[:additions] + pr[:deletions]
       n.author = pr.dig(:user, :id)
-      n.comments =
+      count ||=
         begin
           Fbe.octo.issue_comments(repo, f.issue).count
         rescue Octokit::NotFound, Octokit::Deprecated => e
@@ -110,6 +111,7 @@ Fbe.consider(
           )
           0
         end
+      n.comments = count
       n.review_comments =
         begin
           Fbe.octo.pull_request_review_comments(repo, f.issue, review[:id]).count

--- a/test/judges/test-code-was-reviewed.rb
+++ b/test/judges/test-code-was-reviewed.rb
@@ -87,8 +87,7 @@ class TestCodeWasReviewed < Jp::Test
         { id: 61_002, user: { id: 423, login: 'user3' }, submitted_at: Time.parse('2025-09-02 11:00:00 UTC') }
       ]
     )
-    comments_stub =
-      stub_github('https://api.github.com/repos/foo/foo/issues/60/comments?per_page=100', body: [])
+    stub = stub_github('https://api.github.com/repos/foo/foo/issues/60/comments?per_page=100', body: [])
     stub_github('https://api.github.com/repos/foo/foo/pulls/60/reviews/61001/comments?per_page=100', body: [])
     stub_github('https://api.github.com/repos/foo/foo/pulls/60/reviews/61002/comments?per_page=100', body: [])
     stub_github('https://api.github.com/user/421', body: { id: 421, login: 'user1' })
@@ -97,9 +96,7 @@ class TestCodeWasReviewed < Jp::Test
     fb = Factbase.new
     fb.with(_id: 1, what: 'pull-was-closed', repository: 42, issue: 60, where: 'github')
     load_it('code-was-reviewed', fb)
-    assert_requested(
-      comments_stub, times: 1
-    )
+    assert_requested(stub, times: 1)
   end
 
   def test_rescues_not_found_on_pull_request_lookup

--- a/test/judges/test-code-was-reviewed.rb
+++ b/test/judges/test-code-was-reviewed.rb
@@ -69,6 +69,39 @@ class TestCodeWasReviewed < Jp::Test
     )
   end
 
+  def test_fetches_issue_comments_once_for_multiple_reviews
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repositories/42', body: { id: 42, full_name: 'foo/foo' })
+    stub_github(
+      'https://api.github.com/repos/foo/foo/pulls/60',
+      body: {
+        id: 60, number: 60, user: { id: 421, login: 'user' },
+        created_at: Time.parse('2025-09-01 15:35:30 UTC'), additions: 1, deletions: 1
+      }
+    )
+    stub_github(
+      'https://api.github.com/repos/foo/foo/pulls/60/reviews?per_page=100',
+      body: [
+        { id: 61_001, user: { id: 422, login: 'user2' }, submitted_at: Time.parse('2025-09-02 10:00:00 UTC') },
+        { id: 61_002, user: { id: 423, login: 'user3' }, submitted_at: Time.parse('2025-09-02 11:00:00 UTC') }
+      ]
+    )
+    comments_stub =
+      stub_github('https://api.github.com/repos/foo/foo/issues/60/comments?per_page=100', body: [])
+    stub_github('https://api.github.com/repos/foo/foo/pulls/60/reviews/61001/comments?per_page=100', body: [])
+    stub_github('https://api.github.com/repos/foo/foo/pulls/60/reviews/61002/comments?per_page=100', body: [])
+    stub_github('https://api.github.com/user/421', body: { id: 421, login: 'user1' })
+    stub_github('https://api.github.com/user/422', body: { id: 422, login: 'user2' })
+    stub_github('https://api.github.com/user/423', body: { id: 423, login: 'user3' })
+    fb = Factbase.new
+    fb.with(_id: 1, what: 'pull-was-closed', repository: 42, issue: 60, where: 'github')
+    load_it('code-was-reviewed', fb)
+    assert_requested(
+      comments_stub, times: 1
+    )
+  end
+
   def test_rescues_not_found_on_pull_request_lookup
     WebMock.disable_net_connect!
     rate_limit_up


### PR DESCRIPTION
Closes #1721.

`judges/code-was-reviewed/code-was-reviewed.rb` fetched `Fbe.octo.issue_comments(repo, f.issue).count` inside the `reviews.each` loop, once per review — but the result doesn't depend on the review at all (it's a property of the PR, not the individual review). For a PR with N new reviews in one judge cycle, this refetched the exact same issue-comments count N times instead of once, on top of the necessarily-per-review `pull_request_review_comments` call.

Fix: hoisted the fetch into a memoized `count` local (`count ||= ...`) computed once per PR, reused for every review's `n.comments` assignment. `Fbe.if_absent`'s `next if n.nil?` guard still gates whether the fetch happens at all (already-recorded reviews skip it, same as before) — only the *redundant repeat* for multiple *new* reviews on the same PR is eliminated.

Added `test_fetches_issue_comments_once_for_multiple_reviews`, stubbing a PR with 2 new reviews and asserting the `issues/60/comments` endpoint is hit exactly once (`assert_requested(..., times: 1)`) instead of twice.

Note: I wasn't able to run the test suite locally due to an unrelated native-gem/Ruby-version mismatch in my environment (`openssl` gem compiled against a stale `libruby`). I verified the change via `ruby -c` (syntax OK) and `rubocop` (no new violations vs. the pre-existing baseline — confirmed by diffing rubocop output before/after on the unmodified file) and by tracing through the logic by hand.
