### PR TITLE
#1857: use next 0 instead of bare next in total_builds_ran

### DIFF
--- a/judges/quantity-of-deliverables/total_builds_ran.rb
+++ b/judges/quantity-of-deliverables/total_builds_ran.rb
@@ -25,7 +25,7 @@ def total_builds_ran(fact)
           "[#{$judge}] Access forbidden to workflow runs for #{repo} " \
           "(transient, will retry next cycle): #{e.class}: #{e.message}"
         )
-        next
+        next 0
       end
   }
 end

--- a/test/judges/test-quantity-of-deliverables.rb
+++ b/test/judges/test-quantity-of-deliverables.rb
@@ -370,6 +370,26 @@ class TestQuantityOfDeliverables < Jp::Test
     end
   end
 
+  def test_total_builds_ran_skips_forbidden
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github(
+      'https://api.github.com/repos/foo/blocked/actions/runs?created=2025-10-01..2025-10-06&per_page=1',
+      status: 403, body: { message: 'Forbidden' }
+    )
+    fact = Object.new
+    fact.define_singleton_method(:since) { Time.parse('2025-10-01 00:00:00 UTC') }
+    fact.define_singleton_method(:when) { Time.parse('2025-10-06 00:00:00 UTC') }
+    $judge = 'quantity-of-deliverables'
+    $loog = Loog::NULL
+    $global = {}
+    $options = Judges::Options.new({ 'repositories' => 'foo/foo' })
+    Fbe.stub(:unmask_repos, ['foo/blocked']) do
+      load(File.join(__dir__, '../../judges/quantity-of-deliverables/total_builds_ran.rb'))
+      assert_equal({ total_builds_ran: 0 }, total_builds_ran(fact))
+    end
+  end
+
   def test_quantity_of_deliverables_fix_gap
     WebMock.disable_net_connect!
     rate_limit_up


### PR DESCRIPTION
Closes #1857

`judges/quantity-of-deliverables/total_builds_ran.rb`'s `Octokit::Forbidden` rescue branch used a bare `next` inside a `.sum` block. `next` with no value returns `nil` for that iteration, and `Enumerable#sum` then raises `TypeError: nil can't be coerced into Integer` when adding `nil` to the running total, crashing the whole judge on a 403 instead of degrading gracefully like the sibling `NotFound`/`Deprecated` branch (which correctly returns `0`).

Fix: `next 0` instead of bare `next`, matching the sibling branch.

Added a test that stubs a 403 on the workflow-runs endpoint and asserts `total_builds_ran` no longer crashes and returns `0` for the forbidden repo.

Verified:
- New test passes.
- rubocop clean on both changed files.
