### PR TITLE
#1859: rescue Octokit errors around repo_name_by_id in milestone-was-set

### DIFF
--- a/judges/milestone-was-set/milestone-was-set.rb
+++ b/judges/milestone-was-set/milestone-was-set.rb
@@ -17,7 +17,20 @@ Fbe.consider(
     (absent stale)
     (absent tombstone))'
 ) do |f|
-  repo = Fbe.octo.repo_name_by_id(f.repository)
+  repo =
+    begin
+      Fbe.octo.repo_name_by_id(f.repository)
+    rescue Octokit::NotFound, Octokit::Deprecated => e
+      $loog.info("Failed to find repository #{f.repository}: #{e.message}")
+      f.stale = 'repository'
+      next
+    rescue Octokit::Forbidden => e
+      $loog.warn(
+        "[#{$judge}] Access forbidden to repository #{f.repository} " \
+        "(transient, will retry next cycle): #{e.class}: #{e.message}"
+      )
+      next
+    end
   milestones =
     begin
       Fbe.octo.list_milestones(repo, state: 'all')

--- a/test/judges/test-milestone-was-set.rb
+++ b/test/judges/test-milestone-was-set.rb
@@ -125,6 +125,30 @@ class TestMilestoneWasSet < Jp::Test
     assert_empty(fb.query("(eq what 'milestone-was-set')").each.to_a)
   end
 
+  def test_rescues_not_found_on_repo_name_lookup
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repositories/42', status: 404, body: { message: 'Not Found' })
+    fb = Factbase.new
+    fb.with(_id: 1, what: 'issue-was-opened', repository: 42, issue: 44, where: 'github')
+    load_it('milestone-was-set', fb)
+    assert_empty(fb.query("(eq what 'milestone-was-set')").each.to_a)
+    assert(fb.one?(repository: 42, stale: 'repository'))
+  end
+
+  def test_rescues_forbidden_on_repo_name_lookup
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github(
+      'https://api.github.com/repositories/42',
+      status: 403, body: { message: 'Resource not accessible by integration' }
+    )
+    fb = Factbase.new
+    fb.with(_id: 1, what: 'issue-was-opened', repository: 42, issue: 44, where: 'github')
+    load_it('milestone-was-set', fb)
+    assert_empty(fb.query("(eq what 'milestone-was-set')").each.to_a)
+  end
+
   def test_rescues_forbidden_on_milestones_list
     WebMock.disable_net_connect!
     rate_limit_up


### PR DESCRIPTION
Closes #1859

`judges/milestone-was-set/milestone-was-set.rb:20` called `Fbe.octo.repo_name_by_id(f.repository)` with no rescue, two lines before a properly-guarded `Fbe.octo.list_milestones(repo, ...)` call. If the repository was deleted or transferred, this raised `Octokit::NotFound` (or `Octokit::Forbidden`) unguarded, aborting `Fbe.consider` and dropping every remaining matching fact for the rest of that judge cycle.

This file was missed when issue #1483 enumerated the 20 affected files and fixed them with the standard two-branch rescue pattern.

Fix: wrap `repo_name_by_id` in the same two-branch rescue already used by `judges/add-review-comments/add-review-comments.rb` (the closest structural match, same `Fbe.consider(...) do |f|` shape): `Octokit::NotFound, Octokit::Deprecated` logs info and marks `f.stale = 'repository'`, `Octokit::Forbidden` logs warn with the "transient, will retry next cycle" message, both `next`.

Added two tests stubbing 404 and 403 on the `repo_name_by_id` lookup itself (`/repositories/42`), asserting the judge no longer crashes and no milestone facts are created.

Verified:
- All 8 tests in `test/judges/test-milestone-was-set.rb` pass (6 existing + 2 new).
- rubocop clean on both changed files.
