### PR TITLE
Record assignees of the issues a merged pull closes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -55,6 +55,8 @@ Elegant/GoodMethodName:
     - count_appreciated_comments
     - fetch_workflows
     - count_suggestions
+    - closing_issues
+    - fill_hijacks
     - stub_event
     - stub_workflow_runs
     - insert_label_was_attached_fact

--- a/judges/fix-missing-hijacks/fix-missing-hijacks.rb
+++ b/judges/fix-missing-hijacks/fix-missing-hijacks.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+# SPDX-License-Identifier: MIT
+
+require 'fbe/consider'
+require 'fbe/github_graph'
+require 'fbe/issue'
+require 'fbe/octo'
+require 'octokit'
+require_relative '../../lib/closing_issues'
+require_relative '../../lib/issue_was_lost'
+
+Fbe.consider(
+  "(and
+    (absent hijacks)
+    (eq what 'pull-was-merged')
+    (exists issue)
+    (exists repository)
+    (absent stale)
+    (absent tombstone)
+    (absent done)
+    (eq where 'github'))"
+) do |f|
+  repo = Fbe.octo.repo_name_by_id(f.repository)
+  json =
+    begin
+      Fbe.octo.pull_request(repo, f.issue)
+    rescue Octokit::NotFound, Octokit::Deprecated => e
+      $loog.info("#{Fbe.issue(f)} doesn't exist in #{repo}: #{e.message}")
+      Jp.issue_was_lost(f.where, f.repository, f.issue)
+      next
+    rescue Octokit::Forbidden => e
+      $loog.warn(
+        "[#{$judge}] Access forbidden to #{Fbe.issue(f)} in #{repo} " \
+        "(transient, will retry next cycle): #{e.class}: #{e.message}"
+      )
+      next
+    end
+  closing = Jp.closing_issues(repo, f.issue)
+  if closing.nil?
+    $loog.warn(
+      "[#{$judge}] The closing issues of #{Fbe.issue(f)} are unknown " \
+      '(transient, will retry next cycle)'
+    )
+    next
+  end
+  Jp.fill_hijacks(f, closing, json.dig(:user, :id))
+  $loog.info("Hijacking is judged in #{Fbe.issue(f)}: #{f.hijacks}")
+end
+
+Fbe.octo.print_trace!

--- a/judges/fix-missing-hijacks/found-hijacks.yml
+++ b/judges/fix-missing-hijacks/found-hijacks.yml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+# SPDX-License-Identifier: MIT
+---
+options:
+  testing: true
+input:
+  -
+    what: pull-was-merged
+    where: github
+    repository: 695
+    issue: 142
+expected:
+  - /fb[count(f)=1]
+  - /fb/f[hijacks='0' and not(assignee)]

--- a/judges/pull-was-merged/counts-hijacks-of-merged-pull.yml
+++ b/judges/pull-was-merged/counts-hijacks-of-merged-pull.yml
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+# SPDX-License-Identifier: MIT
+---
+options:
+  testing: true
+  repositories: foo/bar
+input:
+  -
+    _id: 1
+    what: pull-was-opened
+    where: github
+    issue: 142
+    repository: 680
+    who: 4444
+    when: 2025-05-27T23:54:44Z
+expected:
+  - /fb[count(f)=2]
+  - /fb/f[what='pull-was-merged' and hijacks='0' and not(assignee)]

--- a/judges/pull-was-merged/pull-was-merged.rb
+++ b/judges/pull-was-merged/pull-was-merged.rb
@@ -13,6 +13,7 @@ require 'fbe/overwrite'
 require 'fbe/who'
 require 'octokit'
 require 'tago'
+require_relative '../../lib/closing_issues'
 require_relative '../../lib/fill_fact'
 require_relative '../../lib/issue_was_lost'
 require_relative '../../lib/pull_request'
@@ -121,11 +122,20 @@ Fbe.iterate do
         )
         next issue
       end
+    merged = !json[:merged_at].nil?
+    closing = merged ? Jp.closing_issues(repo, issue) : {}
+    if closing.nil?
+      $loog.warn(
+        "[#{$judge}] The closing issues of pull ##{issue} in #{repo} are unknown " \
+        '(transient, will retry next cycle)'
+      )
+      next issue
+    end
     Fbe.fb.txn do |fbt|
       nn =
         Fbe.if_absent(fb: fbt) do |n|
           n.issue = issue
-          n.what = "pull-was-#{json[:merged_at].nil? ? 'closed' : 'merged'}"
+          n.what = "pull-was-#{merged ? 'merged' : 'closed'}"
           n.repository = repository
           n.where = 'github'
         end
@@ -144,6 +154,12 @@ Fbe.iterate do
         nn.stale = 'who'
       end
       nn.suggestions = Jp.count_suggestions(repo, issue, json.dig(:user, :id), reviews)
+      if merged
+        Jp.fill_hijacks(nn, closing, json.dig(:user, :id))
+        if nn.hijacks.positive?
+          $loog.info("The pull #{Fbe.issue(nn)} closes #{nn.hijacks} issue(s) assigned to somebody else")
+        end
+      end
       nn.when = json[:closed_at] ? Time.parse(json[:closed_at].iso8601) : Time.now
       review = reviews.first
       nn.review = review[:submitted_at] if review

--- a/judges/pull-was-merged/pull-was-merged.rb
+++ b/judges/pull-was-merged/pull-was-merged.rb
@@ -126,10 +126,9 @@ Fbe.iterate do
     closing = merged ? Jp.closing_issues(repo, issue) : {}
     if closing.nil?
       $loog.warn(
-        "[#{$judge}] The closing issues of pull ##{issue} in #{repo} are unknown " \
-        '(transient, will retry next cycle)'
+        "[#{$judge}] The closing issues of pull ##{issue} in #{repo} are unknown, " \
+        'the hijacking of this pull stays unjudged until the next cycle'
       )
-      next issue
     end
     Fbe.fb.txn do |fbt|
       nn =
@@ -154,7 +153,7 @@ Fbe.iterate do
         nn.stale = 'who'
       end
       nn.suggestions = Jp.count_suggestions(repo, issue, json.dig(:user, :id), reviews)
-      if merged
+      if merged && !closing.nil?
         Jp.fill_hijacks(nn, closing, json.dig(:user, :id))
         if nn.hijacks.positive?
           $loog.info("The pull #{Fbe.issue(nn)} closes #{nn.hijacks} issue(s) assigned to somebody else")

--- a/lib/closing_issues.rb
+++ b/lib/closing_issues.rb
@@ -58,5 +58,5 @@ end
 
 def Jp.fill_hijacks(fact, closing, author)
   closing.values.reduce(Set.new, :merge).each { |who| fact.assignee = who }
-  fact.hijacks = closing.count { |_, whos| !whos.empty? && !whos.include?(author) }
+  fact.hijacks = closing.count { |_, assignees| !assignees.empty? && !assignees.include?(author) }
 end

--- a/lib/closing_issues.rb
+++ b/lib/closing_issues.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+# SPDX-License-Identifier: MIT
+
+require 'fbe/github_graph'
+require 'fbe/octo'
+require_relative 'jp'
+
+def Jp.closing_issues(repo, number)
+  org, name = repo.split('/')
+  issues = {}
+  cursor = nil
+  loop do
+    page =
+      Fbe.github_graph.query(
+        <<~GRAPHQL
+          {
+            repository(owner: "#{org}", name: "#{name}") {
+              pullRequest(number: #{number}) {
+                closingIssuesReferences(first: 100#{%(, after: "#{cursor}") if cursor}) {
+                  pageInfo {
+                    hasNextPage
+                    endCursor
+                  }
+                  nodes {
+                    number
+                    assignees(first: 100) {
+                      nodes {
+                        databaseId
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        GRAPHQL
+      )&.to_h&.dig('repository', 'pullRequest', 'closingIssuesReferences')
+    break if page.nil? || page['nodes'].nil?
+    page['nodes'].each do |node|
+      issues[node['number']] = node.dig('assignees', 'nodes').to_a.filter_map { |a| a['databaseId'] }
+    end
+    break unless page.dig('pageInfo', 'hasNextPage')
+    cursor = page.dig('pageInfo', 'endCursor')
+  end
+  issues
+rescue GraphQL::Client::Error, Octokit::NotFound, Octokit::Deprecated => e
+  $loog.info("The closing issues of #{repo}##{number} are not available: #{e.message}")
+  nil
+rescue Octokit::Forbidden => e
+  $loog.warn(
+    "[#{$judge}] Access forbidden to the closing issues of #{repo}##{number} " \
+    "(transient, will retry next cycle): #{e.class}: #{e.message}"
+  )
+  nil
+end
+
+def Jp.fill_hijacks(fact, closing, author)
+  closing.values.reduce(Set.new, :merge).each { |who| fact.assignee = who }
+  fact.hijacks = closing.count { |_, whos| !whos.empty? && !whos.include?(author) }
+end

--- a/test/judges/test-fix-missing-hijacks.rb
+++ b/test/judges/test-fix-missing-hijacks.rb
@@ -1,0 +1,168 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+# SPDX-License-Identifier: MIT
+
+require 'factbase'
+require 'fbe/github_graph'
+require_relative '../test__helper'
+
+class TestFixMissingHijacks < Jp::Test
+  using SmartFactbase
+
+  def test_counts_hijacks_of_old_merged_pull
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_merged_pull(44)
+    fb = Factbase.new
+    fb.with(_id: 1, what: 'pull-was-merged', repository: 42, issue: 44, where: 'github')
+    Fbe.stub(:github_graph, stub_closing_issues({ 40 => [7_001] })) do
+      load_it('fix-missing-hijacks', fb)
+      assert(
+        fb.one?(issue: 44, what: 'pull-was-merged', assignee: 7_001, hijacks: 1),
+        'an old merged pull that hijacked an issue stays unjudged'
+      )
+    end
+  end
+
+  def test_counts_no_hijacks_of_clean_old_merged_pull
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_merged_pull(44)
+    fb = Factbase.new
+    fb.with(_id: 1, what: 'pull-was-merged', repository: 42, issue: 44, where: 'github')
+    Fbe.stub(:github_graph, stub_closing_issues({ 40 => [421] })) do
+      load_it('fix-missing-hijacks', fb)
+      assert(
+        fb.one?(issue: 44, what: 'pull-was-merged', hijacks: 0),
+        'an old merged pull that closed its own author issue is left without a hijack count'
+      )
+    end
+  end
+
+  def test_leaves_alone_pull_that_was_already_judged
+    WebMock.disable_net_connect!
+    rate_limit_up
+    fb = Factbase.new
+    fb.with(_id: 1, what: 'pull-was-merged', repository: 42, issue: 44, where: 'github', hijacks: 3)
+    Fbe.stub(:github_graph, stub_closing_issues({ 40 => [7_001] })) do
+      load_it('fix-missing-hijacks', fb)
+      assert(
+        fb.one?(issue: 44, what: 'pull-was-merged', hijacks: 3),
+        'a pull that already knows its hijacks is judged again'
+      )
+    end
+  end
+
+  def test_leaves_alone_pull_that_was_closed_without_merging
+    WebMock.disable_net_connect!
+    rate_limit_up
+    fb = Factbase.new
+    fb.with(_id: 1, what: 'pull-was-closed', repository: 42, issue: 44, where: 'github')
+    Fbe.stub(:github_graph, stub_closing_issues({ 40 => [7_001] })) do
+      load_it('fix-missing-hijacks', fb)
+      refute_includes(
+        fb.pick(issue: 44, what: 'pull-was-closed').all_properties,
+        'hijacks',
+        'a pull that was closed without merging is judged for hijacking'
+      )
+    end
+  end
+
+  def test_retries_later_when_closing_issues_cannot_be_read
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_merged_pull(44)
+    fb = Factbase.new
+    fb.with(_id: 1, what: 'pull-was-merged', repository: 42, issue: 44, where: 'github')
+    graph =
+      Class.new(Fbe::Graph::Fake) do
+        define_method(:query) do |_qry|
+          raise(Octokit::Forbidden.new(method: :get, url: 'https://api.github.com', status: 403, body: 'Forbidden'))
+        end
+      end.new
+    Fbe.stub(:github_graph, graph) do
+      load_it('fix-missing-hijacks', fb)
+      refute_includes(
+        fb.pick(issue: 44, what: 'pull-was-merged').all_properties,
+        'hijacks',
+        'a pull with unreadable closing issues is judged as clean'
+      )
+    end
+  end
+
+  def test_retries_later_when_pull_is_forbidden
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repositories/42', body: { id: 42, full_name: 'foo/foo' })
+    stub_github('https://api.github.com/repos/foo/foo', body: { id: 42, full_name: 'foo/foo' })
+    stub_github(
+      'https://api.github.com/repos/foo/foo/pulls/44',
+      status: 403, body: { message: 'Resource not accessible by integration' }
+    )
+    fb = Factbase.new
+    fb.with(_id: 1, what: 'pull-was-merged', repository: 42, issue: 44, where: 'github')
+    Fbe.stub(:github_graph, stub_closing_issues({ 40 => [7_001] })) do
+      load_it('fix-missing-hijacks', fb)
+      refute_includes(
+        fb.pick(issue: 44, what: 'pull-was-merged').all_properties,
+        'stale',
+        'a forbidden pull is marked stale instead of being retried next cycle'
+      )
+    end
+  end
+
+  def test_stales_pull_that_does_not_exist_anymore
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repositories/42', body: { id: 42, full_name: 'foo/foo' })
+    stub_github('https://api.github.com/repos/foo/foo', body: { id: 42, full_name: 'foo/foo' })
+    stub_github('https://api.github.com/repos/foo/foo/pulls/44', status: 404, body: { message: 'Not Found' })
+    fb = Factbase.new
+    fb.with(_id: 1, what: 'pull-was-merged', repository: 42, issue: 44, where: 'github')
+    Fbe.stub(:github_graph, stub_closing_issues({ 40 => [7_001] })) do
+      load_it('fix-missing-hijacks', fb)
+      assert(
+        fb.one?(what: 'pull-was-merged', repository: 42, issue: 44, where: 'github', stale: 'issue'),
+        'a pull that vanished from GitHub is not marked as stale'
+      )
+    end
+  end
+
+  private
+
+  def stub_closing_issues(issues)
+    Class.new(Fbe::Graph::Fake) do
+      define_method(:query) do |qry|
+        next {} unless qry.include?('closingIssuesReferences')
+        {
+          'repository' => {
+            'pullRequest' => {
+              'closingIssuesReferences' => {
+                'pageInfo' => { 'hasNextPage' => false, 'endCursor' => nil },
+                'nodes' => issues.map do |number, ids|
+                  { 'number' => number, 'assignees' => { 'nodes' => ids.map { |id| { 'databaseId' => id } } } }
+                end
+              }
+            }
+          }
+        }
+      end
+    end.new
+  end
+
+  def stub_merged_pull(issue)
+    stub_github('https://api.github.com/repositories/42', body: { id: 42, full_name: 'foo/foo' })
+    stub_github('https://api.github.com/repos/foo/foo', body: { id: 42, full_name: 'foo/foo' })
+    stub_github(
+      "https://api.github.com/repos/foo/foo/pulls/#{issue}",
+      body: {
+        id: 50, number: issue, user: { id: 421, login: 'user' }, state: 'closed',
+        merged_at: Time.parse('2025-09-30 18:00:00 UTC'),
+        closed_at: Time.parse('2025-09-30 18:00:00 UTC'),
+        head: { ref: '40', sha: 'aa123' },
+        base: { repo: { id: 42, full_name: 'foo/foo' } }
+      }
+    )
+  end
+end

--- a/test/judges/test-pull-was-merged.rb
+++ b/test/judges/test-pull-was-merged.rb
@@ -436,7 +436,162 @@ class TestPullWasMerged < Jp::Test
     assert(fb.none?(issue: 44, what: 'pull-was-merged'))
   end
 
+  def test_records_hijack_when_closed_issue_belongs_to_another_user
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_pull_was_merged_success(44)
+    fb = Factbase.new
+    fb.with(_id: 1, what: 'pull-was-opened', repository: 42, issue: 44, where: 'github')
+    Fbe.stub(:github_graph, stub_closing_issues({ 40 => [7_001] })) do
+      load_it('pull-was-merged', fb)
+      assert(
+        fb.one?(issue: 44, what: 'pull-was-merged', repository: 42, where: 'github', assignee: 7_001, hijacks: 1),
+        'the hijacked issue and its assignee are not recorded on the merged pull'
+      )
+    end
+  end
+
+  def test_records_every_assignee_of_every_hijacked_issue
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_pull_was_merged_success(44)
+    fb = Factbase.new
+    fb.with(_id: 1, what: 'pull-was-opened', repository: 42, issue: 44, where: 'github')
+    Fbe.stub(:github_graph, stub_closing_issues({ 40 => [7_001], 41 => [7_002, 7_003] })) do
+      load_it('pull-was-merged', fb)
+      assert_equal(
+        [7_001, 7_002, 7_003],
+        fb.pick(issue: 44, what: 'pull-was-merged')['assignee'],
+        'the assignees of both hijacked issues are not all recorded'
+      )
+    end
+  end
+
+  def test_forgives_pull_that_closes_issue_assigned_to_its_own_author
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_pull_was_merged_success(44)
+    fb = Factbase.new
+    fb.with(_id: 1, what: 'pull-was-opened', repository: 42, issue: 44, where: 'github')
+    Fbe.stub(:github_graph, stub_closing_issues({ 40 => [7_001, 421] })) do
+      load_it('pull-was-merged', fb)
+      assert(
+        fb.one?(issue: 44, what: 'pull-was-merged', repository: 42, where: 'github', hijacks: 0),
+        'an author who is among the assignees is punished anyway'
+      )
+    end
+  end
+
+  def test_forgives_pull_that_closes_issue_assigned_to_nobody
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_pull_was_merged_success(44)
+    fb = Factbase.new
+    fb.with(_id: 1, what: 'pull-was-opened', repository: 42, issue: 44, where: 'github')
+    Fbe.stub(:github_graph, stub_closing_issues({ 40 => [] })) do
+      load_it('pull-was-merged', fb)
+      assert(
+        fb.one?(issue: 44, what: 'pull-was-merged', repository: 42, where: 'github', hijacks: 0),
+        'an unassigned issue is treated as a hijack'
+      )
+    end
+  end
+
+  def test_leaves_assignee_absent_when_closed_issue_has_none
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_pull_was_merged_success(44)
+    fb = Factbase.new
+    fb.with(_id: 1, what: 'pull-was-opened', repository: 42, issue: 44, where: 'github')
+    Fbe.stub(:github_graph, stub_closing_issues({ 40 => [] })) do
+      load_it('pull-was-merged', fb)
+      refute_includes(
+        fb.pick(issue: 44, what: 'pull-was-merged').all_properties,
+        'assignee',
+        'an assignee is invented for an issue that has none'
+      )
+    end
+  end
+
+  def test_counts_no_hijacks_when_pull_closes_no_issue
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_pull_was_merged_success(44)
+    fb = Factbase.new
+    fb.with(_id: 1, what: 'pull-was-opened', repository: 42, issue: 44, where: 'github')
+    Fbe.stub(:github_graph, Fbe::Graph::Fake.new) do
+      load_it('pull-was-merged', fb)
+      assert(
+        fb.one?(issue: 44, what: 'pull-was-merged', repository: 42, where: 'github', hijacks: 0),
+        'a pull request that closes nothing is not counted as clean'
+      )
+    end
+  end
+
+  def test_skips_merged_pull_when_closing_issues_cannot_be_read
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_pull_was_merged_success(44)
+    fb = Factbase.new
+    fb.with(_id: 1, what: 'pull-was-opened', repository: 42, issue: 44, where: 'github')
+    graph =
+      Class.new(Fbe::Graph::Fake) do
+        define_method(:query) do |qry|
+          next {} unless qry.include?('closingIssuesReferences')
+          raise(Octokit::Forbidden.new(method: :get, url: 'https://api.github.com', status: 403, body: 'Forbidden'))
+        end
+      end.new
+    Fbe.stub(:github_graph, graph) do
+      load_it('pull-was-merged', fb)
+      assert(
+        fb.none?(issue: 44, what: 'pull-was-merged'),
+        'a merged pull with unreadable closing issues is recorded without a hijack count'
+      )
+    end
+  end
+
+  def test_ignores_closing_issues_of_pull_that_was_not_merged
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_pull_was_merged_base(44, merged: false)
+    stub_pull_was_merged_issue(44)
+    stub_github('https://api.github.com/repos/foo/foo/pulls/44/reviews?per_page=100', body: [])
+    stub_github('https://api.github.com/repos/foo/foo/pulls/44/comments?per_page=100', body: [])
+    stub_github('https://api.github.com/repos/foo/foo/issues/44/comments?per_page=100', body: [])
+    stub_github('https://api.github.com/repos/foo/foo/commits/aa123/check-runs?per_page=100', body: { check_runs: [] })
+    fb = Factbase.new
+    fb.with(_id: 1, what: 'pull-was-opened', repository: 42, issue: 44, where: 'github')
+    Fbe.stub(:github_graph, stub_closing_issues({ 40 => [7_001] })) do
+      load_it('pull-was-merged', fb)
+      refute_includes(
+        fb.pick(issue: 44, what: 'pull-was-closed').all_properties,
+        'hijacks',
+        'a pull request that was closed without merging is judged for hijacking'
+      )
+    end
+  end
+
   private
+
+  def stub_closing_issues(issues)
+    Class.new(Fbe::Graph::Fake) do
+      define_method(:query) do |qry|
+        next {} unless qry.include?('closingIssuesReferences')
+        {
+          'repository' => {
+            'pullRequest' => {
+              'closingIssuesReferences' => {
+                'pageInfo' => { 'hasNextPage' => false, 'endCursor' => nil },
+                'nodes' => issues.map do |number, ids|
+                  { 'number' => number, 'assignees' => { 'nodes' => ids.map { |id| { 'databaseId' => id } } } }
+                end
+              }
+            }
+          }
+        }
+      end
+    end.new
+  end
 
   def stub_pull_was_merged_success(issue)
     stub_pull_was_merged_base(issue)
@@ -447,14 +602,14 @@ class TestPullWasMerged < Jp::Test
     stub_github('https://api.github.com/repos/foo/foo/commits/aa123/check-runs?per_page=100', body: { check_runs: [] })
   end
 
-  def stub_pull_was_merged_base(issue)
+  def stub_pull_was_merged_base(issue, merged: true)
     stub_github('https://api.github.com/repositories/42', body: { id: 42, full_name: 'foo/foo' })
     stub_github('https://api.github.com/repos/foo/foo', body: { id: 42, name: 'foo', full_name: 'foo/foo' })
     stub_github(
       "https://api.github.com/repos/foo/foo/pulls/#{issue}",
       body: {
         id: 50, number: issue, user: { id: 421, login: 'user' }, state: 'closed',
-        merged_at: Time.parse('2025-09-30 18:00:00 UTC'),
+        merged_at: merged ? Time.parse('2025-09-30 18:00:00 UTC') : nil,
         closed_at: Time.parse('2025-09-30 18:00:00 UTC'),
         created_at: Time.parse('2025-09-30 15:35:30 UTC'),
         additions: 12, deletions: 5, changed_files: 1,

--- a/test/judges/test-pull-was-merged.rb
+++ b/test/judges/test-pull-was-merged.rb
@@ -528,24 +528,33 @@ class TestPullWasMerged < Jp::Test
     end
   end
 
-  def test_skips_merged_pull_when_closing_issues_cannot_be_read
+  def test_records_merged_pull_when_closing_issues_cannot_be_read
     WebMock.disable_net_connect!
     rate_limit_up
     stub_pull_was_merged_success(44)
     fb = Factbase.new
     fb.with(_id: 1, what: 'pull-was-opened', repository: 42, issue: 44, where: 'github')
-    graph =
-      Class.new(Fbe::Graph::Fake) do
-        define_method(:query) do |qry|
-          next {} unless qry.include?('closingIssuesReferences')
-          raise(Octokit::Forbidden.new(method: :get, url: 'https://api.github.com', status: 403, body: 'Forbidden'))
-        end
-      end.new
-    Fbe.stub(:github_graph, graph) do
+    Fbe.stub(:github_graph, stub_broken_closing_issues) do
       load_it('pull-was-merged', fb)
       assert(
-        fb.none?(issue: 44, what: 'pull-was-merged'),
-        'a merged pull with unreadable closing issues is recorded without a hijack count'
+        fb.one?(issue: 44, what: 'pull-was-merged', repository: 42, where: 'github'),
+        'a merged pull is forgotten only because its closing issues are unreadable'
+      )
+    end
+  end
+
+  def test_leaves_hijacks_unknown_when_closing_issues_cannot_be_read
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_pull_was_merged_success(44)
+    fb = Factbase.new
+    fb.with(_id: 1, what: 'pull-was-opened', repository: 42, issue: 44, where: 'github')
+    Fbe.stub(:github_graph, stub_broken_closing_issues) do
+      load_it('pull-was-merged', fb)
+      refute_includes(
+        fb.pick(issue: 44, what: 'pull-was-merged').all_properties,
+        'hijacks',
+        'a merged pull with unreadable closing issues is guessed to be clean'
       )
     end
   end
@@ -572,6 +581,15 @@ class TestPullWasMerged < Jp::Test
   end
 
   private
+
+  def stub_broken_closing_issues
+    Class.new(Fbe::Graph::Fake) do
+      define_method(:query) do |qry|
+        next {} unless qry.include?('closingIssuesReferences')
+        raise(Octokit::Forbidden.new(method: :get, url: 'https://api.github.com', status: 403, body: 'Forbidden'))
+      end
+    end.new
+  end
 
   def stub_closing_issues(issues)
     Class.new(Fbe::Graph::Fake) do

--- a/test/lib/test_closing_issues.rb
+++ b/test/lib/test_closing_issues.rb
@@ -1,0 +1,160 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+# SPDX-License-Identifier: MIT
+
+require 'factbase'
+require 'fbe/github_graph'
+require_relative '../../lib/closing_issues'
+require_relative '../test__helper'
+
+class TestClosingIssues < Jp::Test
+  def test_collects_assignees_of_every_closed_issue
+    $loog = Loog::NULL
+    graph =
+      Class.new(Fbe::Graph::Fake) do
+        define_method(:query) do |_qry|
+          {
+            'repository' => {
+              'pullRequest' => {
+                'closingIssuesReferences' => {
+                  'pageInfo' => { 'hasNextPage' => false, 'endCursor' => nil },
+                  'nodes' => [
+                    { 'number' => 8_211, 'assignees' => { 'nodes' => [{ 'databaseId' => 90_223 }] } },
+                    { 'number' => 8_212, 'assignees' => { 'nodes' => [] } }
+                  ]
+                }
+              }
+            }
+          }
+        end
+      end.new
+    Fbe.stub(:github_graph, graph) do
+      assert_equal(
+        { 8_211 => [90_223], 8_212 => [] },
+        Jp.closing_issues('zerocracy/foo', 7_142),
+        'assignees of the closed issues dont reach the caller'
+      )
+    end
+  end
+
+  def test_collects_many_assignees_of_one_closed_issue
+    $loog = Loog::NULL
+    graph =
+      Class.new(Fbe::Graph::Fake) do
+        define_method(:query) do |_qry|
+          {
+            'repository' => {
+              'pullRequest' => {
+                'closingIssuesReferences' => {
+                  'pageInfo' => { 'hasNextPage' => false, 'endCursor' => nil },
+                  'nodes' => [
+                    {
+                      'number' => 511,
+                      'assignees' => { 'nodes' => [{ 'databaseId' => 62 }, { 'databaseId' => 4_009 }] }
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        end
+      end.new
+    Fbe.stub(:github_graph, graph) do
+      assert_equal(
+        { 511 => [62, 4_009] },
+        Jp.closing_issues('zerocracy/foo', 512),
+        'both assignees of one closed issue are not collected'
+      )
+    end
+  end
+
+  def test_walks_through_every_page_of_closed_issues
+    $loog = Loog::NULL
+    graph =
+      Class.new(Fbe::Graph::Fake) do
+        define_method(:query) do |qry|
+          nodes =
+            if qry.include?('after: "cur-77"')
+              [{ 'number' => 78, 'assignees' => { 'nodes' => [{ 'databaseId' => 22 }] } }]
+            else
+              [{ 'number' => 77, 'assignees' => { 'nodes' => [{ 'databaseId' => 21 }] } }]
+            end
+          {
+            'repository' => {
+              'pullRequest' => {
+                'closingIssuesReferences' => {
+                  'pageInfo' => {
+                    'hasNextPage' => !qry.include?('after: "cur-77"'),
+                    'endCursor' => 'cur-77'
+                  },
+                  'nodes' => nodes
+                }
+              }
+            }
+          }
+        end
+      end.new
+    Fbe.stub(:github_graph, graph) do
+      assert_equal(
+        { 77 => [21], 78 => [22] },
+        Jp.closing_issues('zerocracy/foo', 79),
+        'the second page of closed issues is not fetched'
+      )
+    end
+  end
+
+  def test_finds_nothing_when_pull_closes_no_issue
+    $loog = Loog::NULL
+    Fbe.stub(:github_graph, Fbe::Graph::Fake.new) do
+      assert_empty(
+        Jp.closing_issues('zerocracy/foo', 4_242),
+        'a pull request that closes nothing does not yield an empty hash'
+      )
+    end
+  end
+
+  def test_cannot_read_closing_issues_when_access_is_forbidden
+    $loog = Loog::NULL
+    graph =
+      Class.new(Fbe::Graph::Fake) do
+        define_method(:query) do |_qry|
+          raise(Octokit::Forbidden.new(method: :get, url: 'https://api.github.com', status: 403, body: 'Forbidden'))
+        end
+      end.new
+    Fbe.stub(:github_graph, graph) do
+      assert_nil(Jp.closing_issues('zerocracy/foo', 313), 'a forbidden pull request is not reported as unknown')
+    end
+  end
+
+  def test_cannot_read_closing_issues_when_graph_breaks
+    $loog = Loog::NULL
+    graph =
+      Class.new(Fbe::Graph::Fake) do
+        define_method(:query) do |_qry|
+          raise(GraphQL::Client::Error, 'GraphQL is down')
+        end
+      end.new
+    Fbe.stub(:github_graph, graph) do
+      assert_nil(Jp.closing_issues('zerocracy/foo', 909), 'a broken GraphQL call is not reported as unknown')
+    end
+  end
+
+  def test_marks_every_assignee_of_every_closed_issue
+    fact = Factbase.new.insert
+    Jp.fill_hijacks(fact, { 71 => [800], 72 => [801, 802] }, 4_242)
+    assert_equal([800, 801, 802], fact['assignee'], 'not all assignees of the closed issues are marked')
+  end
+
+  def test_counts_one_hijack_per_issue_assigned_to_somebody_else
+    fact = Factbase.new.insert
+    Jp.fill_hijacks(fact, { 71 => [800], 72 => [801], 73 => [] }, 4_242)
+    assert_equal(2, fact.hijacks, 'the issues taken from other people are miscounted')
+  end
+
+  def test_counts_no_hijack_when_the_author_is_among_the_assignees
+    fact = Factbase.new.insert
+    Jp.fill_hijacks(fact, { 71 => [800, 4_242] }, 4_242)
+    assert_equal(0, fact.hijacks, 'an author assigned together with somebody else is punished anyway')
+  end
+end


### PR DESCRIPTION
Closes #1878.

Right now a merged pull request says nothing about the issues it closes, so nothing downstream can tell an honest contribution from one that took over somebody else's assigned ticket. Both get the same 4-24 points.

This adds two properties to `pull-was-merged`. The `assignee` property holds the ids of everybody currently assigned to the closed issues — multi-valued, the way the maintainer asked for it. The `hijacks` property counts the closed issues whose assignees exist but do not include the author of the pull:

```ruby
def Jp.fill_hijacks(fact, closing, author)
  closing.values.reduce(Set.new, :merge).each { |who| fact.assignee = who }
  fact.hijacks = closing.count { |_, whos| !whos.empty? && !whos.include?(author) }
end
```

The count exists because `assignee` alone cannot drive a decision: the award DSL has no array operator, a scalar read of a multi-valued property silently collapses to its first element, and `who` on this fact is the merger rather than the author. `hijacks` is always written on a merged pull, zero when clean, so a bylaw can name it without `to_val` raising "Unknown name". Assignees come straight from GraphQL `closingIssuesReferences`, which also works for issues living in another repository.

`judges/fix-missing-hijacks` backfills both properties into factbases written before this change. When GitHub refuses to answer, the judge writes nothing and retries next cycle rather than recording a merged pull as clean.

The punishment itself is a follow-up in `zerocracy/fbe`: `assets/bylaws/code-contribution-was-rewarded.fe.liquid` needs to declare `hijacks` as an input and zero out the total in a block appended after the existing cap-and-floor, otherwise that floor lifts the payout back to 4.
