### PR TITLE
Forget the closure of a reopened pull request

### DIFF
--- a/judges/fix-wrong-closures/fix-wrong-closures.rb
+++ b/judges/fix-wrong-closures/fix-wrong-closures.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+# SPDX-License-Identifier: MIT
+
+require 'fbe/issue'
+require 'fbe/iterate'
+require 'fbe/octo'
+require 'octokit'
+require_relative '../../lib/issue_was_lost'
+
+Fbe.iterate do
+  as 'closures_were_checked'
+  sort_by 'issue'
+  by "
+    (and
+      (eq repository $repository)
+      (gt issue $before)
+      (eq what 'pull-was-closed')
+      (eq where 'github')
+      (unique issue)
+      (absent stale)
+      (absent tombstone)
+      (absent done))"
+  repeats 50
+  over do |repository, issue|
+    repo = Fbe.octo.repo_name_by_id(repository)
+    json =
+      begin
+        Fbe.octo.pull_request(repo, issue)
+      rescue Octokit::NotFound, Octokit::Deprecated => e
+        $loog.info("The pull ##{issue} doesn't exist in #{repo}: #{e.message}")
+        Jp.issue_was_lost('github', repository, issue)
+        next issue
+      rescue Octokit::Forbidden => e
+        $loog.warn(
+          "[#{$judge}] Access forbidden to pull ##{issue} in #{repo} " \
+          "(transient, will retry next cycle): #{e.class}: #{e.message}"
+        )
+        next issue
+      rescue Octokit::TooManyRequests, Octokit::Unauthorized, Octokit::ServerError,
+        Net::OpenTimeout, Net::ReadTimeout, SocketError,
+        Errno::ECONNRESET, Errno::ETIMEDOUT => e
+        $loog.warn(
+          "[#{$judge}] Transient error fetching pull ##{issue} in #{repo} " \
+          "(will retry next cycle): #{e.class}: #{e.message}"
+        )
+        next issue
+      end
+    next issue if json[:merged_at].nil? && json[:state] != 'open'
+    Fbe.fb.query(
+      "(and
+        (eq where 'github')
+        (eq repository #{repository})
+        (eq issue #{issue})
+        (eq what 'pull-was-closed'))"
+    ).delete!
+    $loog.info(
+      "The closure of #{repo}##{issue} is wrong, it is " \
+      "#{json[:merged_at].nil? ? 'open' : 'merged'} now, forgotten"
+    )
+    issue
+  end
+end
+
+Fbe.octo.print_trace!

--- a/judges/fix-wrong-closures/forgets-many-pulls.yml
+++ b/judges/fix-wrong-closures/forgets-many-pulls.yml
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+# SPDX-License-Identifier: MIT
+---
+options:
+  testing: true
+  repositories: foo/bar
+input:
+  -
+    _id: 1
+    what: pull-was-closed
+    where: github
+    issue: 94
+    repository: 680
+    who: 4444
+    when: 2025-05-27T23:54:44Z
+  -
+    _id: 2
+    what: pull-was-closed
+    where: github
+    issue: 172
+    repository: 680
+    who: 4444
+    when: 2025-05-28T23:54:44Z
+expected:
+  - /fb[count(f)=0]

--- a/judges/fix-wrong-closures/forgets-merged-pull.yml
+++ b/judges/fix-wrong-closures/forgets-merged-pull.yml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+# SPDX-License-Identifier: MIT
+---
+options:
+  testing: true
+  repositories: foo/bar
+input:
+  -
+    _id: 1
+    what: pull-was-closed
+    where: github
+    issue: 94
+    repository: 680
+    who: 4444
+    when: 2025-05-27T23:54:44Z
+expected:
+  - /fb[count(f)=0]

--- a/judges/fix-wrong-closures/keeps-closed-pull.yml
+++ b/judges/fix-wrong-closures/keeps-closed-pull.yml
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+# SPDX-License-Identifier: MIT
+---
+options:
+  testing: true
+  repositories: foo/bar
+input:
+  -
+    _id: 1
+    what: pull-was-closed
+    where: github
+    issue: 29
+    repository: 680
+    who: 4444
+    when: 2025-05-27T23:54:44Z
+expected:
+  - /fb[count(f)=1]
+  - /fb/f[what='pull-was-closed' and issue=29]

--- a/judges/github-events/github-events.rb
+++ b/judges/github-events/github-events.rb
@@ -262,6 +262,16 @@ Fbe.iterate do
           "with #{fact.hoc} HoC and #{fact.comments} comments."
         skip(json) if seen?(fact)
         $loog.debug("PR #{Fbe.issue(fact)} closed by #{Fbe.who(fact)}")
+      when 'reopened'
+        Fbe.fb.query(
+          "(and
+            (eq where 'github')
+            (eq repository #{fact.repository})
+            (eq issue #{fact.issue})
+            (eq what 'pull-was-closed'))"
+        ).delete!
+        $loog.info("The pull #{Fbe.issue(fact)} was reopened, its closure is forgotten")
+        skip(json)
       else
         skip(json)
       end

--- a/test/judges/test-fix-wrong-closures.rb
+++ b/test/judges/test-fix-wrong-closures.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+# SPDX-License-Identifier: MIT
+
+require 'factbase'
+require_relative '../test__helper'
+
+class TestFixWrongClosures < Jp::Test
+  using SmartFactbase
+
+  def test_forgets_the_closure_of_a_merged_pull
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repos/foo/foo', body: { id: 42, full_name: 'foo/foo' })
+    stub_github('https://api.github.com/repositories/42', body: { id: 42, full_name: 'foo/foo' })
+    stub_github(
+      'https://api.github.com/repos/foo/foo/pulls/55',
+      body: {
+        id: 50, number: 55, state: 'closed', merged: true,
+        merged_at: Time.parse('2025-09-30 18:00:00 UTC'),
+        head: { ref: '55', sha: 'aa123' }
+      }
+    )
+    fb = Factbase.new
+    fb.with(_id: 1, what: 'pull-was-closed', where: 'github', repository: 42, issue: 55, who: 44)
+    load_it('fix-wrong-closures', fb)
+    assert(
+      fb.none?(what: 'pull-was-closed', where: 'github', repository: 42, issue: 55),
+      'The closure of a merged pull cannot survive'
+    )
+  end
+
+  def test_forgets_the_closure_of_a_reopened_pull
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repos/foo/foo', body: { id: 42, full_name: 'foo/foo' })
+    stub_github('https://api.github.com/repositories/42', body: { id: 42, full_name: 'foo/foo' })
+    stub_github(
+      'https://api.github.com/repos/foo/foo/pulls/56',
+      body: {
+        id: 51, number: 56, state: 'open', merged: false, merged_at: nil,
+        head: { ref: '56', sha: 'bb456' }
+      }
+    )
+    fb = Factbase.new
+    fb.with(_id: 1, what: 'pull-was-closed', where: 'github', repository: 42, issue: 56, who: 44)
+    load_it('fix-wrong-closures', fb)
+    assert(
+      fb.none?(what: 'pull-was-closed', where: 'github', repository: 42, issue: 56),
+      'The closure of a reopened pull cannot survive'
+    )
+  end
+
+  def test_keeps_the_closure_of_a_pull_that_stays_closed
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repos/foo/foo', body: { id: 42, full_name: 'foo/foo' })
+    stub_github('https://api.github.com/repositories/42', body: { id: 42, full_name: 'foo/foo' })
+    stub_github(
+      'https://api.github.com/repos/foo/foo/pulls/57',
+      body: {
+        id: 52, number: 57, state: 'closed', merged: false, merged_at: nil,
+        head: { ref: '57', sha: 'cc789' }
+      }
+    )
+    fb = Factbase.new
+    fb.with(_id: 1, what: 'pull-was-closed', where: 'github', repository: 42, issue: 57, who: 44)
+    load_it('fix-wrong-closures', fb)
+    assert(
+      fb.one?(what: 'pull-was-closed', where: 'github', repository: 42, issue: 57),
+      'The closure of a pull that stays closed cannot be forgotten'
+    )
+  end
+end

--- a/test/judges/test-github-events.rb
+++ b/test/judges/test-github-events.rb
@@ -1861,6 +1861,76 @@ class TestGithubEvents < Jp::Test
     assert_equal(1, fb.query('(eq what "pull-was-closed")').each.to_a.size)
   end
 
+  def test_reopened_pull_drops_its_stale_closure
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github(
+      'https://api.github.com/repos/foo/foo',
+      body: { id: 42, name: 'foo', full_name: 'foo/foo', default_branch: 'master' }
+    )
+    stub_github(
+      'https://api.github.com/repositories/42',
+      body: { id: 42, name: 'foo', full_name: 'foo/foo', default_branch: 'master' }
+    )
+    stub_github(
+      'https://api.github.com/repositories/42/events?per_page=100',
+      body: [
+        {
+          id: '11128',
+          type: 'PullRequestEvent',
+          actor: { id: 45, login: 'user' },
+          repo: { id: 42, name: 'foo/foo' },
+          payload: {
+            action: 'reopened', number: 456,
+            pull_request: { number: 456, head: { ref: '487', sha: '5c955da3b5a' } }
+          },
+          created_at: '2025-06-27 19:00:05 UTC'
+        }
+      ]
+    )
+    stub_github('https://api.github.com/user/45', body: { id: 45, login: 'user' })
+    fb = Factbase.new
+    fb.with(what: 'pull-was-closed', where: 'github', repository: 42, issue: 456, who: 45)
+    load_it('github-events', fb)
+    assert(
+      fb.none?(what: 'pull-was-closed', where: 'github', repository: 42, issue: 456),
+      'The closure of a reopened pull cannot stay in the factbase'
+    )
+  end
+
+  def test_reopened_pull_leaves_no_event_fact
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github(
+      'https://api.github.com/repos/foo/foo',
+      body: { id: 42, name: 'foo', full_name: 'foo/foo', default_branch: 'master' }
+    )
+    stub_github(
+      'https://api.github.com/repositories/42',
+      body: { id: 42, name: 'foo', full_name: 'foo/foo', default_branch: 'master' }
+    )
+    stub_github(
+      'https://api.github.com/repositories/42/events?per_page=100',
+      body: [
+        {
+          id: '11129',
+          type: 'PullRequestEvent',
+          actor: { id: 45, login: 'user' },
+          repo: { id: 42, name: 'foo/foo' },
+          payload: {
+            action: 'reopened', number: 456,
+            pull_request: { number: 456, head: { ref: '487', sha: '5c955da3b5a' } }
+          },
+          created_at: '2025-06-27 19:00:05 UTC'
+        }
+      ]
+    )
+    stub_github('https://api.github.com/user/45', body: { id: 45, login: 'user' })
+    fb = Factbase.new
+    load_it('github-events', fb)
+    assert(fb.none?(event_id: 11_129), 'A reopening event cannot leave a fact behind')
+  end
+
   def test_adds_created_issue_comment_event
     skip('This type of event is not needed now')
     WebMock.disable_net_connect!


### PR DESCRIPTION
This adds a `reopened` branch to the `PullRequestEvent` case in `github-events.rb`. When a pull request comes back to life, the `pull-was-closed` fact recorded for its earlier closure is deleted.

Contributors often close and reopen a pull request to re-trigger CI. The scan catches the closure, sees `merged_at` as nil, and writes `pull-was-closed`. Nothing ever withdrew it, and `pull-was-merged` skips any issue that already carries a closure, so once the pull was really merged there was no path left to notice. The author never got `code-was-contributed` and never got paid, while the reviewer did, since reviews do not depend on the merge fact. In the `objectionary` factbase this affects 43 merged pull requests, 39 of them in `objectionary/eo`, and every one of them had been reopened.

The deletion goes through `Fbe.fb` rather than the transaction handle, because the reopening event itself is rolled back and a taped delete would be discarded with it. Two tests cover the change: the closure disappears, and the reopening still leaves no fact of its own. The historical facts already in the factbase are not repaired by this and will need a separate pass.

Closes #1883
