### PR TITLE
Trim option values without xargs in entry.sh

### DIFF
--- a/entries/keeps-quotes-in-options.sh
+++ b/entries/keeps-quotes-in-options.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+# SPDX-License-Identifier: MIT
+
+set -e -o pipefail
+
+SELF=$1
+
+source "${SELF}/makes/setup-test-env.sh"
+source "${SELF}/makes/test-common.sh"
+setup_test_env "${SELF}" name
+
+opts=$(cat << 'EOF'
+  x99=it's a\path
+EOF
+)
+
+run_entry_script "${SELF}" success \
+  "GITHUB_WORKSPACE=$(pwd)" \
+  "INPUT_FACTBASE=${name}.fb" \
+  "INPUT_CYCLES=1" \
+  "INPUT_REPOSITORIES=yegor256/factbase" \
+  "INPUT_OPTIONS=${opts}" \
+  "INPUT_VERBOSE=false" \
+  "INPUT_TOKEN=something" \
+  "INPUT_DRY-RUN=true" \
+  "INPUT_GITHUB-TOKEN=THETOKEN"
+
+log_contains \
+  " --option=x99=it's a\path" \
+  "This indicates quotes and backslashes in option values are mangled by the entry script"

--- a/entry.sh
+++ b/entry.sh
@@ -105,7 +105,8 @@ VITALS_URL="https://${GITHUB_REPOSITORY_OWNER}.github.io/${GITHUB_REPO_NAME}/${n
 
 declare -a options=()
 while IFS= read -r o; do
-    s=$(echo "${o}" | xargs)
+    s="${o#"${o%%[![:space:]]*}"}"
+    s="${s%"${s##*[![:space:]]}"}"
     if [ "${s}" = "" ]; then
         continue
     fi


### PR DESCRIPTION
The k=v pairs coming in through `options` are trimmed with bash parameter
expansion now, instead of being piped through `xargs`.

`xargs` reads quotes and backslashes as syntax, not as data, which makes it the
wrong tool for stripping whitespace. An option value with an apostrophe in it,
say `pattern=don't`, made `xargs` bail out with "unterminated quote", and since
`entry.sh` runs under `set -e`, that took down the entire run rather than the
one pair. A value with a backslash lost it without a word. The new
`entries/keeps-quotes-in-options.sh` passes `x99=it's a\path` and checks that
the value reaches `judges` intact; it fails on master with the same
"unterminated quote" error.

While reading that block I noticed `k` and `v` are still cut with `echo` and
`cut`, which is safe for the values we handle today but is worth simplifying to
`${s%%=*}` and `${s#*=}` at some point. Left alone here to keep the change to
the reported bug.

Closes #1685
