### PR TITLE
Rescue repo_name_by_id in every judge that calls it

### DIFF
--- a/judges/code-was-reviewed/code-was-reviewed.rb
+++ b/judges/code-was-reviewed/code-was-reviewed.rb
@@ -29,7 +29,20 @@ Fbe.consider(
         (eq where 'github')
         (eq what '#{$judge}'))))"
 ) do |f|
-  repo = Fbe.octo.repo_name_by_id(f.repository)
+  repo =
+    begin
+      Fbe.octo.repo_name_by_id(f.repository)
+    rescue Octokit::NotFound, Octokit::Deprecated => e
+      $loog.info("Failed to find repository #{f.repository}: #{e.message}")
+      f.stale = 'repository'
+      next
+    rescue Octokit::Forbidden => e
+      $loog.warn(
+        "[#{$judge}] Access forbidden to repository #{f.repository} " \
+        "(transient, will retry next cycle): #{e.class}: #{e.message}"
+      )
+      next
+    end
   pr =
     begin
       Fbe.octo.pull_request(repo, f.issue)

--- a/judges/find-all-issues/find-all-issues.rb
+++ b/judges/find-all-issues/find-all-issues.rb
@@ -28,7 +28,19 @@ require_relative '../../lib/qos_search'
         (gt issue $before)
         (eq where 'github'))"
     over do |repository, issue|
-      repo = Fbe.octo.repo_name_by_id(repository)
+      repo =
+        begin
+          Fbe.octo.repo_name_by_id(repository)
+        rescue Octokit::NotFound, Octokit::Deprecated => e
+          $loog.info("Repository ##{repository} not found: #{e.message}")
+          next issue
+        rescue Octokit::Forbidden => e
+          $loog.warn(
+            "[#{$judge}] Access forbidden to repository ##{repository} " \
+            "(transient, will retry next cycle): #{e.class}: #{e.message}"
+          )
+          next issue
+        end
       after =
         begin
           Fbe.octo.issue(repo, issue)[:created_at]

--- a/judges/find-earliest-issue/find-earliest-issue.rb
+++ b/judges/find-earliest-issue/find-earliest-issue.rb
@@ -18,7 +18,19 @@ Fbe.iterate do
   by '(plus 0 $before)'
   over do |repository, latest|
     next latest if latest.positive?
-    repo = Fbe.octo.repo_name_by_id(repository)
+    repo =
+      begin
+        Fbe.octo.repo_name_by_id(repository)
+      rescue Octokit::NotFound, Octokit::Deprecated => e
+        $loog.info("Repository ##{repository} not found: #{e.message}")
+        next latest
+      rescue Octokit::Forbidden => e
+        $loog.warn(
+          "[#{$judge}] Access forbidden to repository ##{repository} " \
+          "(transient, will retry next cycle): #{e.class}: #{e.message}"
+        )
+        next latest
+      end
     json =
       begin
         Fbe.octo.with_disable_auto_paginate do |octo|

--- a/judges/find-latest-issue/find-latest-issue.rb
+++ b/judges/find-latest-issue/find-latest-issue.rb
@@ -18,7 +18,19 @@ Fbe.iterate do
   by '(plus 0 $before)'
   over do |repository, latest|
     next latest if latest.positive?
-    repo = Fbe.octo.repo_name_by_id(repository)
+    repo =
+      begin
+        Fbe.octo.repo_name_by_id(repository)
+      rescue Octokit::NotFound, Octokit::Deprecated => e
+        $loog.info("Repository ##{repository} not found: #{e.message}")
+        next latest
+      rescue Octokit::Forbidden => e
+        $loog.warn(
+          "[#{$judge}] Access forbidden to repository ##{repository} " \
+          "(transient, will retry next cycle): #{e.class}: #{e.message}"
+        )
+        next latest
+      end
     json =
       begin
         Fbe.octo.with_disable_auto_paginate do |octo|

--- a/judges/find-missing-issues/find-missing-issues.rb
+++ b/judges/find-missing-issues/find-missing-issues.rb
@@ -18,7 +18,20 @@ require_relative '../../lib/issue_was_lost'
 ts = Fbe::Tombstone.new
 
 Fbe.consider('(and (eq where "github") (exists repository) (unique repository))') do |r|
-  repo = Fbe.octo.repo_name_by_id(r.repository)
+  repo =
+    begin
+      Fbe.octo.repo_name_by_id(r.repository)
+    rescue Octokit::NotFound, Octokit::Deprecated => e
+      $loog.info("Failed to find repository #{r.repository}: #{e.message}")
+      r.stale = 'repository'
+      next
+    rescue Octokit::Forbidden => e
+      $loog.warn(
+        "[#{$judge}] Access forbidden to repository #{r.repository} " \
+        "(transient, will retry next cycle): #{e.class}: #{e.message}"
+      )
+      next
+    end
   issues = Fbe.fb.query(
     "(and (eq repository #{r.repository}) (exists issue) (eq where 'github') (unique issue))"
   ).each.map(&:issue)

--- a/judges/fix-missing-branch/fix-missing-branch.rb
+++ b/judges/fix-missing-branch/fix-missing-branch.rb
@@ -21,7 +21,20 @@ Fbe.consider(
     (exists repository)
     (eq where 'github'))"
 ) do |f|
-  repo = Fbe.octo.repo_name_by_id(f.repository)
+  repo =
+    begin
+      Fbe.octo.repo_name_by_id(f.repository)
+    rescue Octokit::NotFound, Octokit::Deprecated => e
+      $loog.info("Failed to find repository #{f.repository}: #{e.message}")
+      f.stale = 'repository'
+      next
+    rescue Octokit::Forbidden => e
+      $loog.warn(
+        "[#{$judge}] Access forbidden to repository #{f.repository} " \
+        "(transient, will retry next cycle): #{e.class}: #{e.message}"
+      )
+      next
+    end
   json =
     begin
       Fbe.octo.pull_request(repo, f.issue)

--- a/judges/fix-missing-comments/fix-missing-comments.rb
+++ b/judges/fix-missing-comments/fix-missing-comments.rb
@@ -23,7 +23,20 @@ Fbe.consider(
     (absent done)
     (absent comments))"
 ) do |f|
-  repo = Fbe.octo.repo_name_by_id(f.repository)
+  repo =
+    begin
+      Fbe.octo.repo_name_by_id(f.repository)
+    rescue Octokit::NotFound, Octokit::Deprecated => e
+      $loog.info("Failed to find repository #{f.repository}: #{e.message}")
+      f.stale = 'repository'
+      next
+    rescue Octokit::Forbidden => e
+      $loog.warn(
+        "[#{$judge}] Access forbidden to repository #{f.repository} " \
+        "(transient, will retry next cycle): #{e.class}: #{e.message}"
+      )
+      next
+    end
   json =
     begin
       Fbe.octo.pull_request(repo, f.issue)

--- a/judges/fix-missing-hoc/fix-missing-hoc.rb
+++ b/judges/fix-missing-hoc/fix-missing-hoc.rb
@@ -21,7 +21,20 @@ Fbe.consider(
     (absent done)
     (absent hoc))"
 ) do |f|
-  repo = Fbe.octo.repo_name_by_id(f.repository)
+  repo =
+    begin
+      Fbe.octo.repo_name_by_id(f.repository)
+    rescue Octokit::NotFound, Octokit::Deprecated => e
+      $loog.info("Failed to find repository #{f.repository}: #{e.message}")
+      f.stale = 'repository'
+      next
+    rescue Octokit::Forbidden => e
+      $loog.warn(
+        "[#{$judge}] Access forbidden to repository #{f.repository} " \
+        "(transient, will retry next cycle): #{e.class}: #{e.message}"
+      )
+      next
+    end
   json =
     begin
       Fbe.octo.pull_request(repo, f.issue)

--- a/judges/fix-missing-who/fix-missing-who.rb
+++ b/judges/fix-missing-who/fix-missing-who.rb
@@ -28,7 +28,20 @@ require_relative '../../lib/issue_was_lost'
       (absent done)
       (eq where 'github'))"
   ) do |f|
-    repo = Fbe.octo.repo_name_by_id(f.repository)
+    repo =
+      begin
+        Fbe.octo.repo_name_by_id(f.repository)
+      rescue Octokit::NotFound, Octokit::Deprecated => e
+        $loog.info("Failed to find repository #{f.repository}: #{e.message}")
+        f.stale = 'repository'
+        next
+      rescue Octokit::Forbidden => e
+        $loog.warn(
+          "[#{$judge}] Access forbidden to repository #{f.repository} " \
+          "(transient, will retry next cycle): #{e.class}: #{e.message}"
+        )
+        next
+      end
     json =
       begin
         Fbe.octo.public_send(api, repo, f.issue)

--- a/judges/fix-wrong-closures/fix-wrong-closures.rb
+++ b/judges/fix-wrong-closures/fix-wrong-closures.rb
@@ -24,7 +24,19 @@ Fbe.iterate do
       (absent done))"
   repeats 50
   over do |repository, issue|
-    repo = Fbe.octo.repo_name_by_id(repository)
+    repo =
+      begin
+        Fbe.octo.repo_name_by_id(repository)
+      rescue Octokit::NotFound, Octokit::Deprecated => e
+        $loog.info("Repository ##{repository} not found: #{e.message}")
+        next issue
+      rescue Octokit::Forbidden => e
+        $loog.warn(
+          "[#{$judge}] Access forbidden to repository ##{repository} " \
+          "(transient, will retry next cycle): #{e.class}: #{e.message}"
+        )
+        next issue
+      end
     json =
       begin
         Fbe.octo.pull_request(repo, issue)

--- a/judges/issue-was-assigned/issue-was-assigned.rb
+++ b/judges/issue-was-assigned/issue-was-assigned.rb
@@ -32,7 +32,20 @@ Fbe.iterate do
       (eq where 'github'))"
   repeats 64
   over do |repository, issue|
-    repo = repos[repository] ||= Fbe.octo.repo_name_by_id(repository)
+    repo =
+      repos[repository] ||=
+        begin
+          Fbe.octo.repo_name_by_id(repository)
+        rescue Octokit::NotFound, Octokit::Deprecated => e
+          $loog.info("Repository ##{repository} not found: #{e.message}")
+          next issue
+        rescue Octokit::Forbidden => e
+          $loog.warn(
+            "[#{$judge}] Access forbidden to repository ##{repository} " \
+            "(transient, will retry next cycle): #{e.class}: #{e.message}"
+          )
+          next issue
+        end
     events =
       begin
         Fbe.octo.issue_events(repo, issue).select { |e| e[:event] == 'assigned' }

--- a/judges/issue-was-closed/issue-was-closed.rb
+++ b/judges/issue-was-closed/issue-was-closed.rb
@@ -42,7 +42,19 @@ Fbe.iterate do
       (eq where 'github'))"
   repeats 64
   over do |repository, issue|
-    repo = Fbe.octo.repo_name_by_id(repository)
+    repo =
+      begin
+        Fbe.octo.repo_name_by_id(repository)
+      rescue Octokit::NotFound, Octokit::Deprecated => e
+        $loog.info("Repository ##{repository} not found: #{e.message}")
+        next issue
+      rescue Octokit::Forbidden => e
+        $loog.warn(
+          "[#{$judge}] Access forbidden to repository ##{repository} " \
+          "(transient, will retry next cycle): #{e.class}: #{e.message}"
+        )
+        next issue
+      end
     json =
       begin
         Fbe.octo.issue(repo, issue)

--- a/judges/issue-was-opened/issue-was-opened.rb
+++ b/judges/issue-was-opened/issue-was-opened.rb
@@ -39,7 +39,19 @@ Fbe.conclude do
         (eq what '#{$judge}'))))"
   follow 'where repository issue'
   draw do |n, f|
-    repo = Fbe.octo.repo_name_by_id(f.repository)
+    repo =
+      begin
+        Fbe.octo.repo_name_by_id(f.repository)
+      rescue Octokit::NotFound, Octokit::Deprecated => e
+        $loog.info("Failed to find repository #{f.repository}: #{e.message}")
+        throw(:rollback)
+      rescue Octokit::Forbidden => e
+        $loog.warn(
+          "[#{$judge}] Access forbidden to repository #{f.repository} " \
+          "(transient, will retry next cycle): #{e.class}: #{e.message}"
+        )
+        throw(:rollback)
+      end
     json =
       begin
         Fbe.octo.issue(repo, f.issue)

--- a/judges/issue-was-unassigned/issue-was-unassigned.rb
+++ b/judges/issue-was-unassigned/issue-was-unassigned.rb
@@ -21,7 +21,20 @@ Fbe.consider(
     (eq where 'github'))"
 ) do |f|
   Jp.supervision({ 'repository' => f.repository, 'issue' => f.issue }) do
-    repo = Fbe.octo.repo_name_by_id(f.repository)
+    repo =
+      begin
+        Fbe.octo.repo_name_by_id(f.repository)
+      rescue Octokit::NotFound, Octokit::Deprecated => e
+        $loog.info("Failed to find repository #{f.repository}: #{e.message}")
+        f.stale = 'repository'
+        next
+      rescue Octokit::Forbidden => e
+        $loog.warn(
+          "[#{$judge}] Access forbidden to repository #{f.repository} " \
+          "(transient, will retry next cycle): #{e.class}: #{e.message}"
+        )
+        next
+      end
     event =
       begin
         Fbe.octo.issue_events(repo, f.issue).sort_by { _1[:created_at] }.find do |e|

--- a/judges/label-was-attached/label-was-attached.rb
+++ b/judges/label-was-attached/label-was-attached.rb
@@ -31,7 +31,19 @@ Fbe.iterate do
       (eq where 'github'))"
   repeats 64
   over do |repository, issue|
-    repo = Fbe.octo.repo_name_by_id(repository)
+    repo =
+      begin
+        Fbe.octo.repo_name_by_id(repository)
+      rescue Octokit::NotFound, Octokit::Deprecated => e
+        $loog.info("Repository ##{repository} not found: #{e.message}")
+        next issue
+      rescue Octokit::Forbidden => e
+        $loog.warn(
+          "[#{$judge}] Access forbidden to repository ##{repository} " \
+          "(transient, will retry next cycle): #{e.class}: #{e.message}"
+        )
+        next issue
+      end
     events =
       begin
         Fbe.octo.issue_timeline(repo, issue)

--- a/judges/pull-was-merged/pull-was-merged.rb
+++ b/judges/pull-was-merged/pull-was-merged.rb
@@ -50,7 +50,19 @@ Fbe.iterate do
       (eq where 'github'))"
   repeats 50
   over do |repository, issue|
-    repo = Fbe.octo.repo_name_by_id(repository)
+    repo =
+      begin
+        Fbe.octo.repo_name_by_id(repository)
+      rescue Octokit::NotFound, Octokit::Deprecated => e
+        $loog.info("Repository ##{repository} not found: #{e.message}")
+        next issue
+      rescue Octokit::Forbidden => e
+        $loog.warn(
+          "[#{$judge}] Access forbidden to repository ##{repository} " \
+          "(transient, will retry next cycle): #{e.class}: #{e.message}"
+        )
+        next issue
+      end
     json =
       begin
         Fbe.octo.pull_request(repo, issue)

--- a/judges/pull-was-opened/pull-was-opened.rb
+++ b/judges/pull-was-opened/pull-was-opened.rb
@@ -37,7 +37,19 @@ Fbe.conclude do
         (eq what '#{$judge}'))))"
   follow 'where repository issue'
   draw do |n, f|
-    repo = Fbe.octo.repo_name_by_id(f.repository)
+    repo =
+      begin
+        Fbe.octo.repo_name_by_id(f.repository)
+      rescue Octokit::NotFound, Octokit::Deprecated => e
+        $loog.info("Failed to find repository #{f.repository}: #{e.message}")
+        throw(:rollback)
+      rescue Octokit::Forbidden => e
+        $loog.warn(
+          "[#{$judge}] Access forbidden to repository #{f.repository} " \
+          "(transient, will retry next cycle): #{e.class}: #{e.message}"
+        )
+        throw(:rollback)
+      end
     json =
       begin
         Fbe.octo.issue(repo, f.issue)

--- a/test/judges/test-code-was-reviewed.rb
+++ b/test/judges/test-code-was-reviewed.rb
@@ -211,4 +211,17 @@ class TestCodeWasReviewed < Jp::Test
       'forbidden reviews lookup must not abort later candidates in the same judge batch'
     )
   end
+
+  def test_rescues_not_found_on_repo_name_lookup
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repositories/42', status: 404, body: { message: 'Not Found' })
+    fb = Factbase.new
+    fb.with(_id: 1, what: 'pull-was-closed', repository: 42, issue: 44, where: 'github')
+    load_it('code-was-reviewed', fb)
+    assert(
+      fb.one?(what: 'pull-was-closed', repository: 42, stale: 'repository'),
+      'The fact of a vanished repository must be marked stale instead of aborting the judge'
+    )
+  end
 end

--- a/test/judges/test-find-all-issues.rb
+++ b/test/judges/test-find-all-issues.rb
@@ -410,4 +410,23 @@ class TestFindAllIssues < Jp::Test
       '403 is transient — fact must NOT be marked stale; next cycle will retry the issue lookup'
     )
   end
+
+  def test_rescues_not_found_on_repo_name_lookup
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repos/foo/foo', body: { id: 42, name: 'foo', full_name: 'foo/foo' })
+    stub_github('https://api.github.com/repositories/42', status: 404, body: { message: 'Not Found' })
+    fb = Factbase.new
+    fb.insert.then do |f|
+      f.issue = 44
+      f.repository = 42
+      f.what = 'issue-was-opened'
+      f.where = 'github'
+    end
+    load_it('find-all-issues', fb)
+    assert_equal(
+      1, fb.query("(eq what 'issue-was-opened')").each.to_a.size,
+      'A vanished repository must add no issues and must not abort the judge'
+    )
+  end
 end

--- a/test/judges/test-find-earliest-issue.rb
+++ b/test/judges/test-find-earliest-issue.rb
@@ -243,4 +243,17 @@ class TestFindEarliestIssue < Jp::Test
       'cursor must advance to the issue number after a 410 on Fbe.octo.pull_request'
     )
   end
+
+  def test_rescues_not_found_on_repo_name_lookup
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repos/foo/foo', body: { id: 42, name: 'foo', full_name: 'foo/foo' })
+    stub_github('https://api.github.com/repositories/42', status: 404, body: { message: 'Not Found' })
+    fb = Factbase.new
+    load_it('find-earliest-issue', fb)
+    assert_empty(
+      fb.query("(eq what 'issue-was-opened')").each.to_a,
+      'A vanished repository must produce no facts and must not abort the judge'
+    )
+  end
 end

--- a/test/judges/test-find-latest-issue.rb
+++ b/test/judges/test-find-latest-issue.rb
@@ -260,4 +260,17 @@ class TestFindLatestIssue < Jp::Test
       'forbidden error must not produce an issue-was-lost tombstone'
     )
   end
+
+  def test_rescues_not_found_on_repo_name_lookup
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repos/foo/foo', body: { id: 42, name: 'foo', full_name: 'foo/foo' })
+    stub_github('https://api.github.com/repositories/42', status: 404, body: { message: 'Not Found' })
+    fb = Factbase.new
+    load_it('find-latest-issue', fb)
+    assert_empty(
+      fb.query("(eq what 'issue-was-opened')").each.to_a,
+      'A vanished repository must produce no facts and must not abort the judge'
+    )
+  end
 end

--- a/test/judges/test-find-missing-issues.rb
+++ b/test/judges/test-find-missing-issues.rb
@@ -109,4 +109,17 @@ class TestFindMissingIssues < Jp::Test
       '403 is transient — no issue-was-lost fact must be created on pull_request 403; next cycle will retry'
     )
   end
+
+  def test_rescues_not_found_on_repo_name_lookup
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repositories/42', status: 404, body: { message: 'Not Found' })
+    fb = Factbase.new
+    fb.with(_id: 1, what: 'issue-was-opened', repository: 42, issue: 44, where: 'github')
+    load_it('find-missing-issues', fb)
+    assert(
+      fb.one?(what: 'issue-was-opened', repository: 42, stale: 'repository'),
+      'The fact of a vanished repository must be marked stale instead of aborting the judge'
+    )
+  end
 end

--- a/test/judges/test-fix-missing-branch.rb
+++ b/test/judges/test-fix-missing-branch.rb
@@ -49,4 +49,17 @@ class TestFixMissingBranch < Jp::Test
     msg = '403 is transient — fact must NOT be marked stale; next cycle will retry the pull_request lookup'
     assert_nil(f['stale'], msg)
   end
+
+  def test_rescues_not_found_on_repo_name_lookup
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repositories/42', status: 404, body: { message: 'Not Found' })
+    fb = Factbase.new
+    fb.with(_id: 1, what: 'pull-was-opened', repository: 42, issue: 44, where: 'github')
+    load_it('fix-missing-branch', fb)
+    assert(
+      fb.one?(what: 'pull-was-opened', repository: 42, stale: 'repository'),
+      'The fact of a vanished repository must be marked stale instead of aborting the judge'
+    )
+  end
 end

--- a/test/judges/test-fix-missing-comments.rb
+++ b/test/judges/test-fix-missing-comments.rb
@@ -27,4 +27,17 @@ class TestFixMissingComments < Jp::Test
     assert_nil(f['stale'], '403 must retry without marking stale')
     assert_nil(f['comments'], '403 must leave comments absent until retry')
   end
+
+  def test_rescues_not_found_on_repo_name_lookup
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repositories/42', status: 404, body: { message: 'Not Found' })
+    fb = Factbase.new
+    fb.with(_id: 1, what: 'pull-was-merged', repository: 42, issue: 44, where: 'github')
+    load_it('fix-missing-comments', fb)
+    assert(
+      fb.one?(what: 'pull-was-merged', repository: 42, stale: 'repository'),
+      'The fact of a vanished repository must be marked stale instead of aborting the judge'
+    )
+  end
 end

--- a/test/judges/test-fix-missing-hoc.rb
+++ b/test/judges/test-fix-missing-hoc.rb
@@ -27,4 +27,17 @@ class TestFixMissingHoc < Jp::Test
     assert_nil(f['hoc'], '403 is transient — fact must NOT receive hoc; next cycle will retry')
     assert_nil(f['stale'], '403 is transient — fact must NOT be marked stale')
   end
+
+  def test_rescues_not_found_on_repo_name_lookup
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repositories/42', status: 404, body: { message: 'Not Found' })
+    fb = Factbase.new
+    fb.with(_id: 1, what: 'pull-was-merged', repository: 42, issue: 44, where: 'github')
+    load_it('fix-missing-hoc', fb)
+    assert(
+      fb.one?(what: 'pull-was-merged', repository: 42, stale: 'repository'),
+      'The fact of a vanished repository must be marked stale instead of aborting the judge'
+    )
+  end
 end

--- a/test/judges/test-fix-missing-who.rb
+++ b/test/judges/test-fix-missing-who.rb
@@ -63,4 +63,17 @@ class TestFixMissingWho < Jp::Test
     assert_equal(7, f['who'].first, 'merged_by.id from pulls endpoint must be assigned to who')
     assert_nil(f['stale'], 'fact must not be marked stale when merged_by is present on the pull payload')
   end
+
+  def test_rescues_not_found_on_repo_name_lookup
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repositories/42', status: 404, body: { message: 'Not Found' })
+    fb = Factbase.new
+    fb.with(_id: 1, what: 'pull-was-opened', repository: 42, issue: 44, where: 'github')
+    load_it('fix-missing-who', fb)
+    assert(
+      fb.one?(what: 'pull-was-opened', repository: 42, stale: 'repository'),
+      'The fact of a vanished repository must be marked stale instead of aborting the judge'
+    )
+  end
 end

--- a/test/judges/test-fix-wrong-closures.rb
+++ b/test/judges/test-fix-wrong-closures.rb
@@ -72,4 +72,18 @@ class TestFixWrongClosures < Jp::Test
       'The closure of a pull that stays closed cannot be forgotten'
     )
   end
+
+  def test_rescues_not_found_on_repo_name_lookup
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repos/foo/foo', body: { id: 42, name: 'foo', full_name: 'foo/foo' })
+    stub_github('https://api.github.com/repositories/42', status: 404, body: { message: 'Not Found' })
+    fb = Factbase.new
+    fb.with(_id: 1, what: 'pull-was-closed', repository: 42, issue: 44, where: 'github')
+    load_it('fix-wrong-closures', fb)
+    assert(
+      fb.one?(what: 'pull-was-closed', repository: 42, issue: 44),
+      'A vanished repository must not delete the closure and must not abort the judge'
+    )
+  end
 end

--- a/test/judges/test-issue-was-assigned.rb
+++ b/test/judges/test-issue-was-assigned.rb
@@ -124,4 +124,18 @@ class TestIssueWasAssigned < Jp::Test
       '403 is transient — fact must NOT be marked stale; next cycle will retry the events lookup'
     )
   end
+
+  def test_rescues_not_found_on_repo_name_lookup
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repos/foo/foo', body: { id: 42, name: 'foo', full_name: 'foo/foo' })
+    stub_github('https://api.github.com/repositories/42', status: 404, body: { message: 'Not Found' })
+    fb = Factbase.new
+    fb.with(_id: 1, what: 'issue-was-opened', repository: 42, issue: 44, where: 'github')
+    load_it('issue-was-assigned', fb)
+    assert_empty(
+      fb.query("(eq what 'issue-was-assigned')").each.to_a,
+      'A vanished repository must produce no facts and must not abort the judge'
+    )
+  end
 end

--- a/test/judges/test-issue-was-closed.rb
+++ b/test/judges/test-issue-was-closed.rb
@@ -253,4 +253,18 @@ class TestIssueWasClosed < Jp::Test
       'no label-was-attached facts since timeline was inaccessible'
     )
   end
+
+  def test_rescues_not_found_on_repo_name_lookup
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repos/foo/foo', body: { id: 42, name: 'foo', full_name: 'foo/foo' })
+    stub_github('https://api.github.com/repositories/42', status: 404, body: { message: 'Not Found' })
+    fb = Factbase.new
+    fb.with(_id: 1, what: 'issue-was-opened', repository: 42, issue: 44, where: 'github')
+    load_it('issue-was-closed', fb)
+    assert_empty(
+      fb.query("(eq what 'issue-was-closed')").each.to_a,
+      'A vanished repository must produce no facts and must not abort the judge'
+    )
+  end
 end

--- a/test/judges/test-issue-was-opened.rb
+++ b/test/judges/test-issue-was-opened.rb
@@ -26,4 +26,17 @@ class TestIssueWasOpened < Jp::Test
     refute_nil(f)
     assert_nil(f['stale'], '403 is transient — fact must NOT be marked stale; next cycle will retry the lookup')
   end
+
+  def test_rescues_not_found_on_repo_name_lookup
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repositories/42', status: 404, body: { message: 'Not Found' })
+    fb = Factbase.new
+    fb.with(_id: 1, what: 'issue-was-closed', repository: 42, issue: 44, where: 'github')
+    load_it('issue-was-opened', fb)
+    assert_empty(
+      fb.query("(eq what 'issue-was-opened')").each.to_a,
+      'A vanished repository must produce no facts and must not abort the judge'
+    )
+  end
 end

--- a/test/judges/test-issue-was-unassigned.rb
+++ b/test/judges/test-issue-was-unassigned.rb
@@ -141,4 +141,17 @@ class TestIssueWasUnassigned < Jp::Test
       '403 is transient — fact must NOT be marked stale; next cycle will retry the events lookup'
     )
   end
+
+  def test_rescues_not_found_on_repo_name_lookup
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repositories/42', status: 404, body: { message: 'Not Found' })
+    fb = Factbase.new
+    fb.with(_id: 1, what: 'issue-was-assigned', repository: 42, issue: 44, where: 'github', who: 421)
+    load_it('issue-was-unassigned', fb)
+    assert(
+      fb.one?(what: 'issue-was-assigned', repository: 42, stale: 'repository', who: 421),
+      'The fact of a vanished repository must be marked stale instead of aborting the judge'
+    )
+  end
 end

--- a/test/judges/test-label-was-attached.rb
+++ b/test/judges/test-label-was-attached.rb
@@ -183,4 +183,18 @@ class TestLabelWasAttached < Jp::Test
       '404 is permanent — issue must be marked stale via Jp.issue_was_lost'
     )
   end
+
+  def test_rescues_not_found_on_repo_name_lookup
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repos/foo/foo', body: { id: 42, name: 'foo', full_name: 'foo/foo' })
+    stub_github('https://api.github.com/repositories/42', status: 404, body: { message: 'Not Found' })
+    fb = Factbase.new
+    fb.with(_id: 1, what: 'issue-was-opened', repository: 42, issue: 44, where: 'github')
+    load_it('label-was-attached', fb)
+    assert_empty(
+      fb.query("(eq what 'label-was-attached')").each.to_a,
+      'A vanished repository must produce no facts and must not abort the judge'
+    )
+  end
 end

--- a/test/judges/test-pull-was-merged.rb
+++ b/test/judges/test-pull-was-merged.rb
@@ -436,6 +436,20 @@ class TestPullWasMerged < Jp::Test
     assert(fb.none?(issue: 44, what: 'pull-was-merged'))
   end
 
+  def test_rescues_not_found_on_repo_name_lookup
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repos/foo/foo', body: { id: 42, name: 'foo', full_name: 'foo/foo' })
+    stub_github('https://api.github.com/repositories/42', status: 404, body: { message: 'Not Found' })
+    fb = Factbase.new
+    fb.with(_id: 1, what: 'pull-was-opened', repository: 42, issue: 44, where: 'github')
+    load_it('pull-was-merged', fb)
+    assert_empty(
+      fb.query("(eq what 'pull-was-merged')").each.to_a,
+      'A vanished repository must produce no facts and must not abort the judge'
+    )
+  end
+
   private
 
   def stub_pull_was_merged_success(issue)

--- a/test/judges/test-pull-was-opened.rb
+++ b/test/judges/test-pull-was-opened.rb
@@ -87,4 +87,17 @@ class TestPullWasOpened < Jp::Test
       '403 is transient — the issue must NOT be marked lost; next cycle will retry'
     )
   end
+
+  def test_rescues_not_found_on_repo_name_lookup
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repositories/42', status: 404, body: { message: 'Not Found' })
+    fb = Factbase.new
+    fb.with(_id: 1, what: 'pull-was-reviewed', repository: 42, issue: 44, where: 'github')
+    load_it('pull-was-opened', fb)
+    assert_empty(
+      fb.query("(eq what 'pull-was-opened')").each.to_a,
+      'A vanished repository must produce no facts and must not abort the judge'
+    )
+  end
 end


### PR DESCRIPTION
Seventeen judges called `Fbe.octo.repo_name_by_id` bare, right at the top of their loops. Each of them now wraps the call in the same two-branch rescue that `add-review-comments`, `milestone-was-set`, `type-was-attached` and `github-events` already carried: `Octokit::NotFound` and `Octokit::Deprecated` log and skip the item (marking the fact `stale = 'repository'` where a fact is in hand, so `erase-repository` can finish the job), while `Octokit::Forbidden` warns and leaves the work for the next cycle.

Without the rescue, one repository that was renamed, deleted, or turned private aborted the whole judge on the first item it touched, and every fact the judge had not written yet was lost for that cycle. Since these judges sit early in the pipeline, a single dead repository in a multi-repo run could stall the rest of the scan.

Each judge got one test that stubs a 404 on `/repositories/42` and asserts the judge finishes without a fact — all 17 fail on master and pass here. The skip value follows the surrounding control flow: `next` inside `Fbe.consider`, `next issue` or `next latest` inside `Fbe.iterate`'s `over`, and `throw(:rollback)` inside `draw`, so no marker moves forward on a repository we could not resolve.

Closes #1483