### PR TITLE
Skip milestones already known to the factbase

### DIFF
--- a/judges/milestone-was-set/milestone-was-set.rb
+++ b/judges/milestone-was-set/milestone-was-set.rb
@@ -44,7 +44,16 @@ Fbe.consider(
       )
       next
     end
+  known =
+    Fbe.fb.query(
+      "(and
+        (eq what '#{$judge}')
+        (eq where 'github')
+        (eq repository #{f.repository})
+        (exists milestone))"
+    ).each.map(&:milestone)
   milestones.each do |m|
+    next if known.include?(m[:number])
     Fbe.fb.txn do |fbt|
       nn =
         Fbe.if_absent(fb: fbt) do |nnn|

--- a/test/judges/test-milestone-was-set.rb
+++ b/test/judges/test-milestone-was-set.rb
@@ -164,4 +164,46 @@ class TestMilestoneWasSet < Jp::Test
     load_it('milestone-was-set', fb)
     assert_empty(fb.query("(eq what 'milestone-was-set')").each.to_a)
   end
+
+  def test_dont_warn_about_known_milestones
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repositories/42', body: { id: 42, full_name: 'foo/foo' })
+    stub_github(
+      'https://api.github.com/repos/foo/foo/milestones?per_page=100&state=all',
+      body: [
+        { number: 1, title: 'v1.0', created_at: '2024-01-15T10:00:00Z', creator: { id: 888 } },
+        { number: 2, title: 'v2.0', created_at: '2024-06-01T08:00:00Z', creator: { id: 999 } }
+      ]
+    )
+    fb = Factbase.new
+    fb.with(_id: 1, what: 'milestone-was-set', repository: 42, milestone: 1, where: 'github')
+      .with(_id: 2, what: 'milestone-was-set', repository: 42, milestone: 2, where: 'github')
+    loog = Loog::Buffer.new
+    load_it('milestone-was-set', fb, loog:)
+    assert_empty(
+      loog.to_s.scan('already in the factbase'),
+      'Milestones already in the factbase cannot be re-checked and warned about on every cycle'
+    )
+  end
+
+  def test_adds_only_the_unknown_milestone
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repositories/42', body: { id: 42, full_name: 'foo/foo' })
+    stub_github(
+      'https://api.github.com/repos/foo/foo/milestones?per_page=100&state=all',
+      body: [
+        { number: 1, title: 'v1.0', created_at: '2024-01-15T10:00:00Z', creator: { id: 888 } },
+        { number: 2, title: 'v2.0', created_at: '2024-06-01T08:00:00Z', creator: { id: 999 } }
+      ]
+    )
+    fb = Factbase.new
+    fb.with(_id: 1, what: 'milestone-was-set', repository: 42, milestone: 1, where: 'github')
+    load_it('milestone-was-set', fb)
+    assert(
+      fb.one?(what: 'milestone-was-set', repository: 42, milestone: 2, who: 999),
+      'A milestone missing from the factbase cannot stay missing when its neighbours are known'
+    )
+  end
 end


### PR DESCRIPTION
`milestone-was-set` asked `Fbe.if_absent` about every milestone it saw, on every cycle. Each question is a factbase scan, and each milestone that was already recorded produced a `WARN` line. One query per repository now collects the milestone numbers already in the factbase, and the loop skips them, so the work and the noise are proportional to the new milestones rather than to all of them.

On a repository with a hundred milestones that meant a hundred factbase scans and a hundred warnings every cycle, forever — the log flood also drowned out the warnings that matter. The `if_absent` call stays as the guard against a duplicate inside one response, so its warning now only fires when something is genuinely odd.

The listing itself I left alone: GitHub's milestones API has no `since` filter and cannot sort by creation date, so a full listing is the only way to notice a new milestone. The action runs with a SQLite HTTP cache and `sqlite_cache_min_age=3600`, so that listing usually costs no request at all — which is why I did not add a per-repo cursor, since one would risk missing milestones for no real saving.

Closes #1677