### PR TITLE
Guard nil additions and deletions when computing HoC

### DIFF
--- a/judges/code-was-reviewed/code-was-reviewed.rb
+++ b/judges/code-was-reviewed/code-was-reviewed.rb
@@ -101,7 +101,7 @@ Fbe.consider(
         end
       next if n.nil?
       n.when = review[:submitted_at]
-      n.hoc = pr[:additions] + pr[:deletions]
+      n.hoc = (pr[:additions] || 0) + (pr[:deletions] || 0)
       n.author = pr.dig(:user, :id)
       count ||=
         begin

--- a/judges/fix-missing-hoc/fix-missing-hoc.rb
+++ b/judges/fix-missing-hoc/fix-missing-hoc.rb
@@ -55,7 +55,7 @@ Fbe.consider(
       )
       next
     end
-  f.hoc = json[:additions] + json[:deletions]
+  f.hoc = (json[:additions] || 0) + (json[:deletions] || 0)
   $loog.info("Hoc found for #{Fbe.issue(f)}: #{f.hoc}")
 end
 

--- a/judges/github-events/github-events.rb
+++ b/judges/github-events/github-events.rb
@@ -303,7 +303,7 @@ Fbe.iterate do
         end
         skip(json) unless json.dig(:payload, :review, :state) == 'approved'
         fact.what = 'pull-was-reviewed'
-        fact.hoc = pull[:additions] + pull[:deletions]
+        fact.hoc = (pull[:additions] || 0) + (pull[:deletions] || 0)
         fact.comments = pull[:comments] + pull[:review_comments]
         fact.review_comments = pull[:review_comments]
         fact.commits = pull[:commits]

--- a/judges/pull-was-merged/pull-was-merged.rb
+++ b/judges/pull-was-merged/pull-was-merged.rb
@@ -145,7 +145,7 @@ Fbe.iterate do
         $loog.warn("Pull already merged in #{repo}##{issue}, skipping duplicate")
         next issue
       end
-      nn.hoc = json[:additions] + json[:deletions]
+      nn.hoc = (json[:additions] || 0) + (json[:deletions] || 0)
       nn.files = json[:changed_files] if json[:changed_files]
       nn.branch = json[:head][:ref]
       Jp.fill_fact_by_hash(nn, Jp.comments_info(json))

--- a/test/judges/test-code-was-reviewed.rb
+++ b/test/judges/test-code-was-reviewed.rb
@@ -224,4 +224,34 @@ class TestCodeWasReviewed < Jp::Test
       'The fact of a vanished repository must be marked stale instead of aborting the judge'
     )
   end
+
+  def test_dont_crash_when_pull_has_no_hoc
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repositories/42', body: { id: 42, full_name: 'foo/foo' })
+    stub_github(
+      'https://api.github.com/repos/foo/foo/pulls/44',
+      body: {
+        id: 50, number: 44, user: { id: 421, login: 'user' },
+        created_at: Time.parse('2025-09-01 15:35:30 UTC')
+      }
+    )
+    stub_github(
+      'https://api.github.com/repos/foo/foo/pulls/44/reviews?per_page=100',
+      body: [
+        { id: 49_111, user: { id: 422, login: 'user2' }, submitted_at: Time.parse('2025-09-02 10:39:20 UTC') }
+      ]
+    )
+    stub_github('https://api.github.com/repos/foo/foo/issues/44/comments?per_page=100', body: [])
+    stub_github('https://api.github.com/repos/foo/foo/pulls/44/reviews/49111/comments?per_page=100', body: [])
+    stub_github('https://api.github.com/user/421', body: { id: 421, login: 'user' })
+    stub_github('https://api.github.com/user/422', body: { id: 422, login: 'user2' })
+    fb = Factbase.new
+    fb.with(_id: 1, what: 'pull-was-closed', repository: 42, issue: 44, where: 'github')
+    load_it('code-was-reviewed', fb)
+    assert_equal(
+      0, fb.pick(what: 'code-was-reviewed', issue: 44).hoc,
+      'A pull request that reports no additions and no deletions cannot abort the judge'
+    )
+  end
 end

--- a/test/judges/test-fix-missing-hoc.rb
+++ b/test/judges/test-fix-missing-hoc.rb
@@ -40,4 +40,21 @@ class TestFixMissingHoc < Jp::Test
       'The fact of a vanished repository must be marked stale instead of aborting the judge'
     )
   end
+
+  def test_dont_crash_when_pull_has_no_hoc
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repositories/42', body: { id: 42, full_name: 'foo/foo' })
+    stub_github(
+      'https://api.github.com/repos/foo/foo/pulls/44',
+      body: { id: 50, number: 44, state: 'closed', changed_files: 1 }
+    )
+    fb = Factbase.new
+    fb.with(_id: 1, what: 'pull-was-merged', repository: 42, issue: 44, where: 'github')
+    load_it('fix-missing-hoc', fb)
+    assert_equal(
+      0, fb.pick(issue: 44).hoc,
+      'A pull request that reports no additions and no deletions cannot abort the judge'
+    )
+  end
 end

--- a/test/judges/test-github-events.rb
+++ b/test/judges/test-github-events.rb
@@ -2862,6 +2862,44 @@ class TestGithubEvents < Jp::Test
     end
   end
 
+  def test_dont_crash_when_reviewed_pull_has_no_hoc
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repos/foo/foo', body: { id: 42, full_name: 'foo/foo' })
+    stub_github('https://api.github.com/repositories/42', body: { id: 42, full_name: 'foo/foo' })
+    stub_github(
+      'https://api.github.com/repositories/42/events?per_page=100',
+      body: [
+        {
+          id: '40623323543',
+          type: 'PullRequestReviewEvent',
+          actor: { id: 42, login: 'torvalds' },
+          repo: { id: 42, name: 'foo/foo' },
+          created_at: '2025-07-31 12:45:09 UTC',
+          payload: {
+            action: 'created',
+            review: { id: 2_210_067_609, user: { id: 42, login: 'torvalds' }, state: 'approved' },
+            pull_request: { id: 1_990_323_142, number: 93 }
+          }
+        }
+      ]
+    )
+    stub_github('https://api.github.com/user/42', body: { id: 42, login: 'torvalds' })
+    stub_github(
+      'https://api.github.com/repos/foo/foo/pulls/93',
+      body: {
+        number: 93, user: { id: 526_200, login: 'test' },
+        comments: 1, review_comments: 2, commits: 2, changed_files: 3
+      }
+    )
+    fb = Factbase.new
+    load_it('github-events', fb)
+    assert_equal(
+      0, fb.query('(eq what "pull-was-reviewed")').each.to_a.first.hoc,
+      'A reviewed pull request that reports no additions and no deletions cannot abort the judge'
+    )
+  end
+
   private
 
   def stub_event(*json)

--- a/test/judges/test-pull-was-merged.rb
+++ b/test/judges/test-pull-was-merged.rb
@@ -450,6 +450,44 @@ class TestPullWasMerged < Jp::Test
     )
   end
 
+  def test_dont_crash_when_pull_has_no_hoc
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repositories/42', body: { id: 42, full_name: 'foo/foo' })
+    stub_github('https://api.github.com/repos/foo/foo', body: { id: 42, name: 'foo', full_name: 'foo/foo' })
+    stub_github(
+      'https://api.github.com/repos/foo/foo/pulls/44',
+      body: {
+        id: 50, number: 44, user: { id: 421, login: 'user' }, state: 'closed',
+        merged_at: Time.parse('2025-09-30 18:00:00 UTC'),
+        closed_at: Time.parse('2025-09-30 18:00:00 UTC'),
+        created_at: Time.parse('2025-09-30 15:35:30 UTC'),
+        changed_files: 1,
+        head: { ref: '40', sha: 'aa123' },
+        base: { repo: { id: 42, full_name: 'foo/foo' } }
+      }
+    )
+    stub_github(
+      'https://api.github.com/repos/foo/foo/issues/44',
+      body: {
+        number: 44, title: 'some title', state: 'closed',
+        closed_at: Time.parse('2025-09-30 18:00:00 UTC'),
+        closed_by: { login: 'user2', id: 422 }
+      }
+    )
+    stub_github('https://api.github.com/repos/foo/foo/pulls/44/reviews?per_page=100', body: [])
+    stub_github('https://api.github.com/repos/foo/foo/pulls/44/comments?per_page=100', body: [])
+    stub_github('https://api.github.com/repos/foo/foo/issues/44/comments?per_page=100', body: [])
+    stub_github('https://api.github.com/repos/foo/foo/commits/aa123/check-runs?per_page=100', body: { check_runs: [] })
+    fb = Factbase.new
+    fb.with(_id: 1, what: 'pull-was-opened', repository: 42, issue: 44, where: 'github')
+    Fbe.stub(:github_graph, Fbe::Graph::Fake.new) { load_it('pull-was-merged', fb) }
+    assert_equal(
+      0, fb.pick(what: 'pull-was-merged', issue: 44).hoc,
+      'A pull request that reports no additions and no deletions cannot abort the judge'
+    )
+  end
+
   private
 
   def stub_pull_was_merged_success(issue)


### PR DESCRIPTION
Four places added `additions` and `deletions` of a pull request straight from the API response — `github-events.rb`, `pull-was-merged.rb`, `fix-missing-hoc.rb` and `code-was-reviewed.rb`. When a pull request reports neither, `nil + nil` raises `NoMethodError` and the judge dies mid-cycle, losing the facts it had not written yet. They now use the same `|| 0` guard that `github-events.rb:238`, `some_pull_hoc_size.rb:31` and `Jp.comments_info` already had, so all six sites read the same way.

I hesitated over this one, because GitHub's docs do not promise those fields can be missing. What convinced me is that this codebase already assumes they can, in three separate places, and one of them guards the very same `pull_request` response shape; a crash is also a much worse outcome than a zero. Each of the four judges got a test that stubs a pull request without the two fields — all four raise `NoMethodError: undefined method '+' for nil` on master and pass here.

One thing I left alone: `fact.comments = pull[:comments] + pull[:review_comments]` sits one line below the fix in `github-events.rb` and has exactly the same shape, while `Jp.comments_info` guards those two fields with `|| 0`. It is outside what the issue reports, so it is yours to call — say the word and I will add it.

Closes #1648