### PR TITLE
Put the SPDX header above the requires in test_incremate

### DIFF
--- a/test/lib/test_incremate.rb
+++ b/test/lib/test_incremate.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-require 'factbase'
 # SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
 # SPDX-License-Identifier: MIT
 
+require 'factbase'
 require 'judges/options'
 require_relative '../../lib/incremate'
 require_relative '../test__helper'


### PR DESCRIPTION
`test/lib/test_incremate.rb` had `require 'factbase'` sitting between the magic comment and the two SPDX lines. The require moves below the header, matching every other Ruby file in the repository.

I checked all fifteen files the issue names — `lib/pull_request.rb`, `github-events.rb`, the `fix-missing-*` judges and the rest — and every one of them already keeps the header at the top, so they were fixed at some point after the issue was filed. A scan of every `.rb` file outside `target/` and `coverage/` turns up this one file and nothing else, which is why the diff is a single line.

No test comes with this, since nothing about the behaviour changes; `reuse lint` and rubocop pass on the file.

Closes #1461