### PR TITLE
Skip a repository mask whose listing fails

### DIFF
--- a/lib/patches/unmask_repos.rb
+++ b/lib/patches/unmask_repos.rb
@@ -28,9 +28,18 @@ module Fbe
         org = mask.split('/')[0]
         list =
           begin
-            octo.organization_repositories(org, type: 'all')
-          rescue Octokit::NotFound
-            octo.repositories(org)
+            begin
+              octo.organization_repositories(org, type: 'all')
+            rescue Octokit::NotFound
+              octo.repositories(org)
+            end
+          rescue Octokit::NotFound, Octokit::Deprecated, Octokit::Forbidden, Octokit::Unauthorized,
+            Octokit::ServerError, Net::OpenTimeout, Net::ReadTimeout, SocketError, Errno::ECONNRESET => e
+            loog.warn(
+              "[#{$judge}] Cannot list the repositories of #{org.inspect}, " \
+              "skipping the #{mask.inspect} mask (will retry next cycle): #{e.class}: #{e.message}"
+            )
+            next
           end
         list.each do |r|
           repos << r[:full_name] if re.match?(r[:full_name])

--- a/test/lib/test_unmask_repos.rb
+++ b/test/lib/test_unmask_repos.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+# SPDX-License-Identifier: MIT
+
+require 'judges/options'
+require 'loog'
+require_relative '../../lib/patches/unmask_repos'
+require_relative '../test__helper'
+
+class TestUnmaskRepos < Jp::Test
+  def test_falls_back_to_user_repositories_when_organization_is_absent
+    rate_limit_up
+    stub_github('https://api.github.com/orgs/foo/repos?per_page=100&type=all', body: {}, status: 404)
+    stub_github('https://api.github.com/users/foo/repos?per_page=100', body: [{ full_name: 'foo/first' }])
+    stub_github('https://api.github.com/repos/foo/first', body: { full_name: 'foo/first', archived: false })
+    $loog = Loog::NULL
+    assert_equal(
+      ['foo/first'],
+      Fbe.unmask_repos(options: Judges::Options.new({ 'repositories' => 'foo/*' }), global: {}, loog: Loog::NULL),
+      'repositories of a user cannot be lost when the organization is absent'
+    )
+  end
+
+  def test_skips_the_mask_when_organization_listing_is_forbidden
+    rate_limit_up
+    stub_github('https://api.github.com/orgs/foo/repos?per_page=100&type=all', body: {}, status: 403)
+    stub_github('https://api.github.com/repos/bar/bar', body: { full_name: 'bar/bar', archived: false })
+    $loog = Loog::NULL
+    assert_equal(
+      ['bar/bar'],
+      Fbe.unmask_repos(
+        options: Judges::Options.new({ 'repositories' => 'foo/*,bar/bar' }), global: {}, loog: Loog::NULL
+      ),
+      'a forbidden organization cannot break the expansion of the other masks'
+    )
+  end
+
+  def test_skips_the_mask_when_neither_organization_nor_user_exists
+    rate_limit_up
+    stub_github('https://api.github.com/orgs/foo/repos?per_page=100&type=all', body: {}, status: 404)
+    stub_github('https://api.github.com/users/foo/repos?per_page=100', body: {}, status: 404)
+    stub_github('https://api.github.com/repos/bar/bar', body: { full_name: 'bar/bar', archived: false })
+    $loog = Loog::NULL
+    assert_equal(
+      ['bar/bar'],
+      Fbe.unmask_repos(
+        options: Judges::Options.new({ 'repositories' => 'foo/*,bar/bar' }), global: {}, loog: Loog::NULL
+      ),
+      'a mask pointing at nothing cannot break the expansion of the other masks'
+    )
+  end
+
+  def test_skips_the_mask_when_github_fails_to_list_the_organization
+    rate_limit_up
+    stub_github('https://api.github.com/orgs/foo/repos?per_page=100&type=all', body: {}, status: 500)
+    stub_github('https://api.github.com/repos/bar/bar', body: { full_name: 'bar/bar', archived: false })
+    $loog = Loog::NULL
+    assert_equal(
+      ['bar/bar'],
+      Fbe.unmask_repos(
+        options: Judges::Options.new({ 'repositories' => 'foo/*,bar/bar' }), global: {}, loog: Loog::NULL
+      ),
+      'a server error cannot break the expansion of the other masks'
+    )
+  end
+end


### PR DESCRIPTION
The wildcard branch of `Fbe.unmask_repos` only rescued `Octokit::NotFound` around `octo.organization_repositories`, and the `octo.repositories(org)` fallback sat *inside* that rescue clause, where no rescue can reach it. So a 403 on the org, a 500 from GitHub, a dropped socket, or a second 404 on the user killed the judge before it looked at a single repository. Both calls now sit inside one `begin`, and any of those failures logs a warning and moves on to the next mask. If nothing resolves at all, the existing `No repos found matching` error still fires, so a genuinely broken config is still loud.

Note that `Octokit::TooManyRequests` and `Octokit::AbuseDetected` are subclasses of `Octokit::Forbidden`, so they land in the same rescue — by that point Faraday's retry middleware has already tried four times, and skipping the mask this cycle is better than losing the whole run.

`test/lib/test_unmask_repos.rb` is new: three of its four tests fail on master (403 on the org, 404 on both org and user, 500 on the org), the fourth pins the user-repositories fallback that must keep working.

Two things while I was in here. #1731 (bare `*` mask) is invalid: `Fbe.mask_to_regex` on the line above already raises `Org '*' can't have an asterisk`, so a mask without an org never reaches the `split('/')`. And PR #1755 does not fix this issue — its new rescue still falls through to the same unguarded `octo.repositories(org)` inside a rescue clause, its bare-glob branch is unreachable for the `mask_to_regex` reason above, and it ships no tests.

Closes #1729