### PR TITLE
#1695: declare least-privilege permissions in every workflow

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -11,6 +11,8 @@ name: actionlint
     branches:
       - master
   workflow_call:
+permissions:
+  contents: read
 jobs:
   actionlint:
     timeout-minutes: 15

--- a/.github/workflows/bashate.yml
+++ b/.github/workflows/bashate.yml
@@ -10,6 +10,8 @@ name: bashate
   pull_request:
     branches:
       - master
+permissions:
+  contents: read
 jobs:
   bashate:
     timeout-minutes: 15

--- a/.github/workflows/checkmake.yml
+++ b/.github/workflows/checkmake.yml
@@ -9,6 +9,8 @@ name: checkmake
   pull_request:
     branches:
       - master
+permissions:
+  contents: read
 jobs:
   checkmake:
     timeout-minutes: 15

--- a/.github/workflows/copyrights.yml
+++ b/.github/workflows/copyrights.yml
@@ -11,6 +11,8 @@ name: copyrights
     branches:
       - master
   workflow_call:
+permissions:
+  contents: read
 jobs:
   copyrights:
     timeout-minutes: 15

--- a/.github/workflows/hadolint.yml
+++ b/.github/workflows/hadolint.yml
@@ -10,6 +10,8 @@ name: hadolint
   pull_request:
     branches:
       - master
+permissions:
+  contents: read
 jobs:
   hadolint:
     timeout-minutes: 15

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -10,6 +10,8 @@ name: make
   pull_request:
     branches:
       - master
+permissions:
+  contents: read
 jobs:
   make:
     timeout-minutes: 15

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -6,6 +6,8 @@ name: markdown-lint
 'on':
   push:
   workflow_call:
+permissions:
+  contents: read
 jobs:
   markdown-lint:
     timeout-minutes: 15

--- a/.github/workflows/pdd.yml
+++ b/.github/workflows/pdd.yml
@@ -11,6 +11,8 @@ name: pdd
     branches:
       - master
   workflow_call:
+permissions:
+  contents: read
 jobs:
   pdd:
     timeout-minutes: 15

--- a/.github/workflows/rake.yml
+++ b/.github/workflows/rake.yml
@@ -10,6 +10,8 @@ name: rake
   pull_request:
     branches:
       - master
+permissions:
+  contents: read
 jobs:
   rake:
     timeout-minutes: 15

--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -11,6 +11,8 @@ name: reuse
     branches:
       - master
   workflow_call:
+permissions:
+  contents: read
 jobs:
   reuse:
     timeout-minutes: 15

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -10,6 +10,8 @@ name: shellcheck
   pull_request:
     branches:
       - master
+permissions:
+  contents: read
 jobs:
   shellcheck:
     timeout-minutes: 15

--- a/.github/workflows/titles.yml
+++ b/.github/workflows/titles.yml
@@ -6,6 +6,8 @@ name: titles
 'on':
   issues:
     types: [opened]
+permissions:
+  issues: write
 jobs:
   titles:
     timeout-minutes: 15

--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -11,6 +11,8 @@ name: typos
     branches:
       - master
   workflow_call:
+permissions:
+  contents: read
 jobs:
   typos:
     timeout-minutes: 15

--- a/.github/workflows/up.yml
+++ b/.github/workflows/up.yml
@@ -9,6 +9,9 @@ name: up
       - master
     tags:
       - '*'
+permissions:
+  contents: write
+  pull-requests: write
 jobs:
   up:
     timeout-minutes: 15

--- a/.github/workflows/xcop.yml
+++ b/.github/workflows/xcop.yml
@@ -11,6 +11,8 @@ name: xcop
     branches:
       - master
   workflow_call:
+permissions:
+  contents: read
 jobs:
   xcop:
     timeout-minutes: 15

--- a/.github/workflows/yamllint.yml
+++ b/.github/workflows/yamllint.yml
@@ -11,6 +11,8 @@ name: yamllint
     branches:
       - master
   workflow_call:
+permissions:
+  contents: read
 jobs:
   yamllint:
     timeout-minutes: 15


### PR DESCRIPTION
Only `zerocracy.yml` declared a top-level `permissions:` block, so the other sixteen workflows ran with whatever the repository default happens to be.

Each of them now says what it needs and nothing more. Fourteen only read the checkout, so they get `contents: read`. `up.yml` opens a pull request, so it gets `contents: write` and `pull-requests: write`. `titles.yml` edits issue titles, so it gets `issues: write`.

This is the workflow half of the change that was in #1761, rebased on current master and split per issue as the review asked.

Closes #1695
