### PR TITLE
Bind values in the duplicate-event query

### DIFF
--- a/judges/github-events/github-events.rb
+++ b/judges/github-events/github-events.rb
@@ -14,6 +14,7 @@ require 'tago'
 require_relative '../../lib/fill_fact'
 require_relative '../../lib/pull_request'
 require_relative '../../lib/supervision'
+require_relative '../../lib/twice'
 
 Fbe.iterate do
   as 'events_were_scanned'
@@ -402,22 +403,6 @@ Fbe.iterate do
     end
     skip(json)
   end
-
-  def self.twice?(fb, fact, what, fields)
-    pairs = fields.map { [_1, fact[_1]&.first] }
-    pairs.reject! { _1.last.nil? }
-    eqs =
-      pairs.map do |prop, value|
-        val =
-          case value
-          when String then "'#{value}'"
-          when Time then value.utc.iso8601
-          else value
-          end
-        "(eq #{prop} #{val})"
-      end
-    fb.query("(and (eq what '#{what}') #{eqs.join(' ')})").each.to_a.size > 1
-  end
   over do |repository, latest|
     begin
       rname = Fbe.octo.repo_name_by_id(repository)
@@ -488,7 +473,7 @@ Fbe.iterate do
               next
             end
             fill(f, json)
-            uniques.each { |w, ff| throw :rollback if twice?(fbt, f, w, ff) }
+            uniques.each { |w, ff| throw :rollback if Jp.twice?(fbt, f, w, ff) }
             if f['issue']
               throw :rollback unless Fbe.fb.query(
                 "(and

--- a/lib/twice.rb
+++ b/lib/twice.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+# SPDX-License-Identifier: MIT
+
+require_relative 'jp'
+
+def Jp.twice?(fb, fact, what, fields)
+  pairs = fields.to_h { [_1, fact[_1]&.first] }
+  pairs.compact!
+  fb.query(
+    "(and (eq what $what) #{pairs.keys.map { "(eq #{_1} $#{_1})" }.join(' ')})"
+  ).each(fb, pairs.merge('what' => what)).to_a.size > 1
+end

--- a/test/lib/test_twice.rb
+++ b/test/lib/test_twice.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+# SPDX-License-Identifier: MIT
+
+require 'factbase'
+require_relative '../../lib/twice'
+require_relative '../test__helper'
+
+class TestTwice < Minitest::Test
+  def test_finds_the_second_copy_of_the_same_event
+    fb = Factbase.new
+    2.times { insert(fb, 'bug') }
+    assert(
+      Jp.twice?(fb, fb.query('(exists label)').each.to_a.first, 'label-was-attached', %w[where repository issue label]),
+      'the second copy of the same event cannot stay unnoticed'
+    )
+  end
+
+  def test_lets_a_unique_event_through
+    fb = Factbase.new
+    insert(fb, 'bug')
+    refute(
+      Jp.twice?(fb, fb.query('(exists label)').each.to_a.first, 'label-was-attached', %w[where repository issue label]),
+      'a unique event cannot be taken for a duplicate'
+    )
+  end
+
+  def test_finds_the_second_copy_when_the_label_has_an_apostrophe
+    fb = Factbase.new
+    2.times { insert(fb, "won't fix") }
+    assert(
+      Jp.twice?(fb, fb.query('(exists label)').each.to_a.first, 'label-was-attached', %w[where repository issue label]),
+      'an apostrophe in a label cannot hide a duplicate'
+    )
+  end
+
+  def test_finds_the_second_copy_when_the_label_ends_with_a_backslash
+    fb = Factbase.new
+    2.times { insert(fb, 'fix\\') }
+    assert(
+      Jp.twice?(fb, fb.query('(exists label)').each.to_a.first, 'label-was-attached', %w[where repository issue label]),
+      'a backslash in a label cannot hide a duplicate'
+    )
+  end
+
+  def test_reads_a_label_that_looks_like_a_query_as_plain_text
+    fb = Factbase.new
+    2.times { insert(fb, "x') (eq issue 999) (eq label 'y") }
+    assert(
+      Jp.twice?(fb, fb.query('(exists label)').each.to_a.first, 'label-was-attached', %w[where repository issue label]),
+      'a label that looks like a query cannot be read as one'
+    )
+  end
+
+  def test_ignores_the_events_of_another_repository
+    fb = Factbase.new
+    insert(fb, 'bug')
+    insert(fb, 'bug', repository: 55)
+    refute(
+      Jp.twice?(
+        fb, fb.query('(eq repository 42)').each.to_a.first, 'label-was-attached', %w[where repository issue label]
+      ),
+      'events of another repository cannot count as duplicates'
+    )
+  end
+
+  private
+
+  def insert(fb, label, repository: 42)
+    f = fb.insert
+    f.what = 'label-was-attached'
+    f.where = 'github'
+    f.repository = repository
+    f.issue = 7
+    f.label = label
+    f
+  end
+end


### PR DESCRIPTION
The `twice?` duplicate check used to paste field values straight into the S-expression. It now lives in `lib/twice.rb` as `Jp.twice?` and passes them as Factbase `$`-parameters — `fb.query("(and (eq what $what) (eq label $label) ...)").each(fb, params)` — the same binding `Fbe.iterate` already uses for `$before` and `$repository`.

Three of the six tests in `test/lib/test_twice.rb` fail on master. A label with an apostrophe (`won't fix`) and one ending in a backslash both blow up with `Factbase::Syntax::Broken: String not closed`, and a label shaped like `x') (eq issue 999) (eq label 'y` quietly rewrites the predicate so the duplicate is never spotted. Binding beats escaping here: factbase's tokenizer decides a quote is escaped by looking at the previous character, so a value ending in a backslash cannot be expressed in the query at all, no matter how carefully you escape it.

I moved the function to `lib/` because that is the only way to test it — the judge itself never sets `label` or `type` on a fact, so `where`, always the literal `github`, is the only string that reaches the builder today. The bug is latent, not live.

Follow-ups for you: PR #1751 escapes the quote only and ships no tests, so it can be closed. And `lib/cover_qo.rb`, `lib/issue_was_lost.rb`, `revive-user`, `who-has-name` and `who-is-alive` still build queries the old way — those are #1662 and #1668, and the same binding trick fixes them.

Closes #1663