### PR TITLE
Stop fetching every repository twice

### DIFF
--- a/lib/patches/unmask_repos.rb
+++ b/lib/patches/unmask_repos.rb
@@ -64,10 +64,6 @@ module Fbe
       raise(Fbe::Error, "No repos found matching: #{options.repositories.inspect}") if repos.empty?
       repos.shuffle!
       loog.debug("Scanning #{repos.size} repositories: #{repos.joined}...")
-      repos.each do |repo|
-        octo.repository(repo)
-      rescue Octokit::NotFound, Octokit::Deprecated, Octokit::Forbidden # rubocop:disable Lint/SuppressedException
-      end
       return repos unless block_given?
       repos.each do |repo|
         break if Fbe.over?(global:, options:, loog:, epoch:, kickoff:, quota_aware:, lifetime_aware:, timeout_aware:)

--- a/test/lib/test_unmask_repos.rb
+++ b/test/lib/test_unmask_repos.rb
@@ -22,6 +22,14 @@ class TestUnmaskRepos < Jp::Test
     )
   end
 
+  def test_fetches_every_repository_once
+    rate_limit_up
+    stub = stub_github('https://api.github.com/repos/bar/bar', body: { full_name: 'bar/bar', archived: false })
+    $loog = Loog::NULL
+    Fbe.unmask_repos(options: Judges::Options.new({ 'repositories' => 'bar/bar' }), global: {}, loog: Loog::NULL)
+    assert_requested(stub, times: 1, message: 'a repository cannot be fetched more than once per expansion')
+  end
+
   def test_skips_the_mask_when_organization_listing_is_forbidden
     rate_limit_up
     stub_github('https://api.github.com/orgs/foo/repos?per_page=100&type=all', body: {}, status: 403)


### PR DESCRIPTION
The pre-check loop at the end of `Fbe.unmask_repos` is gone. The archived filter a few lines above it already calls `octo.repository()` on every resolved repository, so the loop asked GitHub a second time for each one, threw the answer away, and swallowed `Forbidden` on the way past. For an org-wide mask like `zerocracy/*` that doubled the repository lookups before a judge touched any real work.

The loop came in with PR #1544 as a "pre-yield repo check" and never used its result, so there is nothing to preserve — deleting it removes both halves of the complaint at once: the extra calls and the silent rescue.

The new test in `test/lib/test_unmask_repos.rb` pins it down: on master it fails with `expected to execute 1 time but it executed 2 times`. Full suite is green, 348 tests. Note #1730 and #1733 were already closed as duplicates of this one, so they need nothing further.

Closes #1666