### PR TITLE
Check every pull for reviews only once

### DIFF
--- a/judges/code-was-reviewed/code-was-reviewed.rb
+++ b/judges/code-was-reviewed/code-was-reviewed.rb
@@ -17,6 +17,7 @@ Fbe.consider(
       (eq what 'pull-was-closed'))
     (exists repository)
     (exists issue)
+    (absent reviews)
     (absent stale)
     (absent tombstone)
     (absent done)
@@ -87,6 +88,7 @@ Fbe.consider(
       )
       next
     end
+  f.reviews = reviews.count
   count = nil
   reviews.each do |review|
     next if review.dig(:user, :id) == pr.dig(:user, :id)

--- a/test/judges/test-code-was-reviewed.rb
+++ b/test/judges/test-code-was-reviewed.rb
@@ -99,6 +99,45 @@ class TestCodeWasReviewed < Jp::Test
     assert_requested(stub, times: 1)
   end
 
+  def test_marks_a_pull_without_reviews_as_checked
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repositories/42', body: { id: 42, full_name: 'foo/foo' })
+    stub_github(
+      'https://api.github.com/repos/foo/foo/pulls/45',
+      body: {
+        id: 45, number: 45, user: { id: 421, login: 'user' },
+        created_at: Time.parse('2025-09-02 17:05:30 UTC'), additions: 2, deletions: 8
+      }
+    )
+    stub_github('https://api.github.com/repos/foo/foo/pulls/45/reviews?per_page=100', body: [])
+    fb = Factbase.new
+    fb.with(_id: 1, what: 'pull-was-merged', repository: 42, issue: 45, where: 'github')
+    load_it('code-was-reviewed', fb)
+    assert(
+      fb.one?(what: 'pull-was-merged', repository: 42, issue: 45, where: 'github', reviews: 0),
+      'a pull with no reviews cannot stay unmarked'
+    )
+  end
+
+  def test_skips_a_pull_that_was_already_checked
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repositories/42', body: { id: 42, full_name: 'foo/foo' })
+    stub_github(
+      'https://api.github.com/repos/foo/foo/pulls/45',
+      body: {
+        id: 45, number: 45, user: { id: 421, login: 'user' },
+        created_at: Time.parse('2025-09-02 17:05:30 UTC'), additions: 2, deletions: 8
+      }
+    )
+    stub = stub_github('https://api.github.com/repos/foo/foo/pulls/45/reviews?per_page=100', body: [])
+    fb = Factbase.new
+    fb.with(_id: 1, what: 'pull-was-merged', repository: 42, issue: 45, where: 'github', reviews: 0)
+    load_it('code-was-reviewed', fb)
+    assert_not_requested(stub, message: 'a pull that was checked already cannot be fetched again')
+  end
+
   def test_rescues_not_found_on_pull_request_lookup
     WebMock.disable_net_connect!
     rate_limit_up


### PR DESCRIPTION
`code-was-reviewed` now writes `reviews` on the pull fact it examined, and its query carries `(absent reviews)`. So a pull is asked about once. Before this, a pull merged without reviews — or reviewed only by its own author — never got a `code-was-reviewed` fact, stayed in the query result, and was fetched from GitHub again on every single cycle, forever.

I measured it on `objectionary/eo`, the repo whose CI scans `objectionary/*`. In run 33368486149 this one judge worked through a backlog of 1787 old pulls, spent **21m5s and 3189 API requests, and made zero changes**. The run then hit `We ran out of lifetime (36m already), must stop here`, and the ten judges queued behind it — `type-was-attached`, `fix-missing-who`, `dimensions-of-terrain`, `quality-of-service`, `find-all-issues` and the rest — each got a few milliseconds and did nothing at all. That is why a merge takes hours to show up: the budget is spent re-asking about pulls from years ago. Worth noting that baza derives `code-was-reviewed` facts from `pull-was-reviewed` facts with no API calls at all, and `code-review-was-rewarded` only looks at facts inside the `days_to_reward` window, so re-scanning ancient pulls in client CI buys nothing.

Two new tests, both red on master: one checks the marker gets written for a pull with no reviews, the other checks the reviews endpoint is not requested for a pull already checked. Full suite green, 350 tests.

No `Closes` keyword on purpose — this is one contributor to #1855, not all of it. Same unbounded-rescan shape sits in `issue-was-unassigned` (811 requests, 3m15s, zero changes in that same run); say the word and I will do that one next. Separately, `objectionary/eo` runs with `cycles: 1` and `cron: '36 * * * *'` while each run takes 42 minutes, so the real gap between runs over the last week ranged from 2h38m to 12h42m — that part is client config, not code.