### PR TITLE
Stop watching assignments on finished tickets

### DIFF
--- a/judges/issue-was-unassigned/issue-was-unassigned.rb
+++ b/judges/issue-was-unassigned/issue-was-unassigned.rb
@@ -18,6 +18,15 @@ Fbe.consider(
     (absent stale)
     (absent tombstone)
     (absent done)
+    (empty
+      (and
+        (or
+          (eq what 'issue-was-closed')
+          (eq what 'pull-was-merged')
+          (eq what 'pull-was-closed'))
+        (eq issue $issue)
+        (eq repository $repository)
+        (eq where $where)))
     (eq where 'github'))"
 ) do |f|
   Jp.supervision({ 'repository' => f.repository, 'issue' => f.issue }) do

--- a/test/judges/test-issue-was-unassigned.rb
+++ b/test/judges/test-issue-was-unassigned.rb
@@ -9,6 +9,40 @@ require_relative '../test__helper'
 class TestIssueWasUnassigned < Jp::Test
   using SmartFactbase
 
+  def test_stops_watching_a_closed_issue
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repositories/42', body: { id: 42, full_name: 'foo/foo' })
+    stub = stub_github('https://api.github.com/repos/foo/foo/issues/44/events?per_page=100', body: [])
+    fb = Factbase.new
+    fb.with(
+      _id: 1, what: 'issue-was-assigned', repository: 42, issue: 44, where: 'github', who: 421,
+      when: Time.parse('2025-10-01 19:05:00 UTC')
+    ).with(
+      _id: 2, what: 'issue-was-closed', repository: 42, issue: 44, where: 'github',
+      when: Time.parse('2025-10-05 19:05:00 UTC')
+    )
+    load_it('issue-was-unassigned', fb)
+    assert_not_requested(stub, message: 'a closed issue cannot be watched for unassignment any more')
+  end
+
+  def test_stops_watching_a_merged_pull
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repositories/42', body: { id: 42, full_name: 'foo/foo' })
+    stub = stub_github('https://api.github.com/repos/foo/foo/issues/45/events?per_page=100', body: [])
+    fb = Factbase.new
+    fb.with(
+      _id: 1, what: 'issue-was-assigned', repository: 42, issue: 45, where: 'github', who: 421,
+      when: Time.parse('2025-10-01 19:05:00 UTC')
+    ).with(
+      _id: 2, what: 'pull-was-merged', repository: 42, issue: 45, where: 'github',
+      when: Time.parse('2025-10-05 19:05:00 UTC')
+    )
+    load_it('issue-was-unassigned', fb)
+    assert_not_requested(stub, message: 'a merged pull cannot be watched for unassignment any more')
+  end
+
   def test_not_found_issue_events
     WebMock.disable_net_connect!
     rate_limit_up


### PR DESCRIPTION
`issue-was-unassigned` polls `/repos/X/issues/N/events` for every assignment fact that has no `unassigned` yet. Its query now skips a fact whose issue already carries an `issue-was-closed`, `pull-was-merged` or `pull-was-closed` fact, so a finished ticket is no longer watched.

In `objectionary/eo` run 33368486149 this judge spent **811 requests and 3m15s for zero changes** — the second biggest eater of the 40-minute lifetime after `code-was-reviewed`, which #1915 just fixed. The watch set grew that large because baza's `zzz-tombstone-done` only marks a fact `done` 256 days after the terminal event, so assignments on issues closed months ago kept getting polled every cycle. The only consumer of `unassigned` is judges-action's own `issue-was-assigned`, which uses it to notice a new assignee — and on a closed issue a new assignee changes nothing downstream.

Two new tests, both red on master: the events endpoint must not be requested for a closed issue, nor for a merged pull. Full suite green, 352 tests.

No `Closes` keyword — like #1915 this is one contributor to #1855. After these two, the biggest consumer left in that run is `pull-was-merged` (514 requests, 3m53s), and that one actually produces facts, so it is earning its budget. What remains is client config: `objectionary/eo` runs `cycles: 1` on an hourly cron while each run takes 42 minutes.