### PR TITLE
Accept milestone options positionally in the fake Octokit

### DIFF
--- a/lib/patches/fake_octokit.rb
+++ b/lib/patches/fake_octokit.rb
@@ -6,7 +6,7 @@
 require 'fbe/octo'
 
 class Fbe::FakeOctokit
-  def list_milestones(_repo, **)
+  def list_milestones(_repo, _options = {})
     []
   end
 end

--- a/test/judges/test-milestone-was-set.rb
+++ b/test/judges/test-milestone-was-set.rb
@@ -206,4 +206,14 @@ class TestMilestoneWasSet < Jp::Test
       'A milestone missing from the factbase cannot stay missing when its neighbours are known'
     )
   end
+
+  def test_scans_a_repository_in_testing_mode
+    fb = Factbase.new
+    fb.with(_id: 1, what: 'issue-was-opened', repository: 42, issue: 44, where: 'github')
+    load_it('milestone-was-set', fb, Judges::Options.new({ 'repositories' => 'foo/foo', 'testing' => true }))
+    assert_empty(
+      fb.query("(eq what 'milestone-was-set')").each.to_a,
+      'The judge cannot break when the GitHub client is faked'
+    )
+  end
 end

--- a/test/lib/test_fake_octokit.rb
+++ b/test/lib/test_fake_octokit.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+# SPDX-License-Identifier: MIT
+
+require 'fbe/octo'
+require 'loog'
+require_relative '../../lib/patches/fake_octokit'
+require_relative '../test__helper'
+
+class TestFakeOctokit < Jp::Test
+  def test_lists_milestones_of_a_repository
+    $global = {}
+    $options = Judges::Options.new({ 'testing' => true })
+    $loog = Loog::NULL
+    assert_empty(
+      Fbe.octo.list_milestones('foo/foo', state: 'all'),
+      'The milestones stub cannot refuse the options that judges send with it'
+    )
+  end
+end


### PR DESCRIPTION
The `list_milestones` stub in `lib/patches/fake_octokit.rb` was written as `def list_milestones(_repo, **)`. It now takes `(_repo, _options = {})`, which is how the fakes shipped by `fbe` already declare theirs.

The keywords never reach the stub. `Fbe.octo` wraps the fake in `decoor`, whose `method_missing(*args)` forwards with `@origin.__send__(*args)` and is not marked `ruby2_keywords`, so `state: 'all'` from `judges/milestone-was-set` collapses into a positional Hash and the stub gets two positional arguments: `ArgumentError: wrong number of arguments (given 2, expected 1)`. I reproduced that before touching anything. Fixing `decoor` instead would break `fbe`'s own fakes, since those take the collapsed hash positionally on purpose, so the stub is the right side to change.

The cost was worse than a stubbed call failing: in testing mode — which is what `test-action.sh` and any local run go through — `milestone-was-set` could not complete at all, and under `--fail-fast` every judge scheduled after it was skipped. The existing tests missed it because they stub the HTTP layer with WebMock against a real Octokit client and never load this file, so I added two tests that were red before the change: `test/lib/test_fake_octokit.rb` calls the stub through `Fbe.octo`, and `test-milestone-was-set.rb` now runs the judge once in testing mode. Full suite green at 354 tests, rubocop clean.

Closes #1907