### PR TITLE
Let a failing version check pass quietly in entry.sh

### DIFF
--- a/entries/survives-a-broken-version-check-before-push.sh
+++ b/entries/survives-a-broken-version-check-before-push.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+# SPDX-License-Identifier: MIT
+
+set -e -o pipefail
+
+SELF=$1
+
+source "${SELF}/makes/setup-test-env.sh"
+source "${SELF}/makes/test-common.sh"
+setup_test_env "${SELF}" name
+
+bin="$(pwd)/bin"
+mkdir -p "${bin}"
+cat > "${bin}/curl" << 'EOF'
+#!/usr/bin/env bash
+calls="$(dirname "$0")/calls.txt"
+seen=$(cat "${calls}" 2>/dev/null || echo 0)
+echo $((seen + 1)) > "${calls}"
+if [ "${seen}" -eq 0 ]; then
+    echo '{"tag_name":"0.0.0"}'
+    exit 0
+fi
+exit 7
+EOF
+chmod +x "${bin}/curl"
+
+run_entry_script "${SELF}" success \
+  "PATH=${bin}:${PATH}" \
+  "GITHUB_WORKSPACE=$(pwd)" \
+  "INPUT_FACTBASE=${name}.fb" \
+  "INPUT_CYCLES=1" \
+  "INPUT_REPOSITORIES=yegor256/factbase" \
+  "INPUT_VERBOSE=false" \
+  "INPUT_TOKEN=something" \
+  "INPUT_DRY-RUN=true" \
+  "INPUT_GITHUB-TOKEN=THETOKEN"
+
+factbase_exists "${name}"
+log_contains \
+  "skipping 'push'" \
+  "A version check that cannot reach GitHub must not throw away a cycle that is ready to be pushed"

--- a/entries/survives-a-broken-version-check.sh
+++ b/entries/survives-a-broken-version-check.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+# SPDX-License-Identifier: MIT
+
+set -e -o pipefail
+
+SELF=$1
+
+source "${SELF}/makes/setup-test-env.sh"
+source "${SELF}/makes/test-common.sh"
+setup_test_env "${SELF}" name
+
+bin="$(pwd)/bin"
+mkdir -p "${bin}"
+cat > "${bin}/curl" << 'EOF'
+#!/usr/bin/env bash
+exit 7
+EOF
+chmod +x "${bin}/curl"
+
+run_entry_script "${SELF}" success \
+  "PATH=${bin}:${PATH}" \
+  "GITHUB_WORKSPACE=$(pwd)" \
+  "INPUT_FACTBASE=${name}.fb" \
+  "INPUT_CYCLES=1" \
+  "INPUT_REPOSITORIES=yegor256/factbase" \
+  "INPUT_VERBOSE=false" \
+  "INPUT_TOKEN=something" \
+  "INPUT_DRY-RUN=true" \
+  "INPUT_GITHUB-TOKEN=THETOKEN"
+
+factbase_exists "${name}"
+log_contains \
+  "Could not fetch the latest version from GitHub." \
+  "A version check that cannot reach GitHub must not end the run before any judge starts"

--- a/entry.sh
+++ b/entry.sh
@@ -16,8 +16,8 @@ if [ -n "$(printenv "INPUT_GITHUB-TOKEN")" ]; then
     auth_args=(-H "Authorization: Bearer $(printenv "INPUT_GITHUB-TOKEN")")
 fi
 if [ "${SKIP_VERSION_CHECKING}" != 'true' ]; then
-    resp=$(curl --silent "${auth_args[@]}" -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/zerocracy/judges-action/releases/latest)
-    latest=$(echo -n "$resp" | jq -Rrs "try (fromjson | .tag_name) catch empty")
+    resp=$(curl --silent "${auth_args[@]}" -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/zerocracy/judges-action/releases/latest || true)
+    latest=$(echo -n "$resp" | jq -Rrs "try (fromjson | .tag_name // empty) catch empty")
     if [ -z "${latest}" ]; then
         echo "!!! Could not fetch the latest version from GitHub."
         echo "!!! GitHub returned: "
@@ -281,11 +281,12 @@ else
 fi
 
 if [ "${SKIP_VERSION_CHECKING}" != 'true' ]; then
-    action_version=$(curl --retry 5 --retry-delay 5 --retry-max-time 40 --connect-timeout 5 -sL "${auth_args[@]}" https://api.github.com/repos/zerocracy/judges-action/releases/latest | jq -r '.tag_name')
-    if [ "${action_version}" == "${VERSION}" ] || [ "${action_version}" == null ]; then
+    resp=$(curl --retry 5 --retry-delay 5 --retry-max-time 40 --connect-timeout 5 -sL "${auth_args[@]}" https://api.github.com/repos/zerocracy/judges-action/releases/latest || true)
+    latest=$(echo -n "${resp}" | jq -Rrs "try (fromjson | .tag_name // empty) catch empty")
+    if [ -z "${latest}" ] || [ "${latest}" == "${VERSION}" ]; then
         action_version=${VERSION}
     else
-        action_version="${VERSION}!${action_version}"
+        action_version="${VERSION}!${latest}"
     fi
 else
     action_version=${VERSION}


### PR DESCRIPTION
Both version checks in `entry.sh` ran a bare `curl` inside a command substitution under `set -e -o pipefail`, so a network failure, a DNS failure or a timeout ended the script right there. Both now tolerate a failing `curl` and parse the body the same tolerant way.

The first check is the worse of the two: it killed the run before a single judge started, and the `Could not fetch the latest version` branch that was written for exactly this case could never be reached, because it only covers an HTTP error, which `curl --silent` reports with exit code 0. The second one ended the run after every judge had finished and right before `push`, so the whole cycle was thrown away over a string that only decorates `--meta=action_version`. While I was in there I made a release body without `tag_name` read as absent rather than as the literal string `null`, which is what the old `jq -r '.tag_name'` produced.

Two new entry tests, both red before the change. One puts a `curl` on the PATH that always exits 7 and checks the run still gets going; the other answers the first call and fails afterwards, which is what it takes to reach the second check, and confirms the run survives to `push`. I ran `passes-options.sh` and `scans-one-repo.sh` against the patched script too, plus shellcheck, bashate with the flags CI uses, reuse lint and the Ruby suite. The repository's own `test-action.sh` sets `SKIP_VERSION_CHECKING=true`, which is why neither block was covered until now.

Closes #1900
Closes #1901