### PR TITLE
Leave the factbase alone in dry mode

### DIFF
--- a/entries/keeps-the-summary-in-dry-mode.sh
+++ b/entries/keeps-the-summary-in-dry-mode.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+# SPDX-License-Identifier: MIT
+
+set -e -o pipefail
+
+SELF=$1
+
+source "${SELF}/makes/setup-test-env.sh"
+source "${SELF}/makes/test-common.sh"
+setup_test_env "${SELF}" name
+
+bundle exec judges eval "${name}.fb" "f = \$fb.insert; f.what = 'judges-summary'; f.cycles = 7"
+before=$(cksum < "${name}.fb")
+
+run_entry_script "${SELF}" success \
+  "GITHUB_WORKSPACE=$(pwd)" \
+  "INPUT_FACTBASE=${name}.fb" \
+  "INPUT_CYCLES=1" \
+  "INPUT_REPOSITORIES=yegor256/factbase" \
+  "INPUT_VERBOSE=false" \
+  "INPUT_TOKEN=something" \
+  "INPUT_DRY-RUN=true" \
+  "INPUT_GITHUB-TOKEN=THETOKEN"
+
+kept=$(bundle exec ruby -e "require 'factbase'; f = Factbase.new; f.import(File.binread(ARGV[0])); puts f.query(\"(and (eq what 'judges-summary') (eq cycles 7))\").each.to_a.size" "${name}.fb")
+test "${kept}" = '1' || die "A dry run must keep the judges-summary facts of the factbase it was given, found ${kept} of them"
+test "$(cksum < "${name}.fb")" = "${before}" || die "A dry run must leave the factbase exactly as it found it"

--- a/entry.sh
+++ b/entry.sh
@@ -138,16 +138,18 @@ else
     echo "Since 'fail-fast' is not set to 'true', we will run all judges even if some of them fail"
 fi
 
-${JUDGES} "${gopts[@]}" eval \
-    "${fb}" \
-    "\$fb.query(\"(eq what 'judges-summary')\").delete!"
-
 if [ "$(printenv "INPUT_DRY-RUN" || echo 'false')" == 'true' ]; then
     ALL_JUDGES=$(mktemp -d)
     trap 'rm -rf "$ALL_JUDGES"' EXIT INT TERM
     options+=("--no-expect-judges")
+    summary=off
+    echo "We are in 'dry' mode; keeping the summary facts of the factbase intact"
 else
     ALL_JUDGES=${SELF}/judges
+    summary=add
+    ${JUDGES} "${gopts[@]}" eval \
+        "${fb}" \
+        "\$fb.query(\"(eq what 'judges-summary')\").delete!"
 fi
 
 github_token_found=false
@@ -256,7 +258,7 @@ echo "The total number of cycles to run is ${cycles}"
 ${JUDGES} "${gopts[@]}" --hello update \
     --no-log \
     --quiet \
-    --summary=add \
+    "--summary=${summary}" \
     --shuffle=aaa \
     --boost=github-events \
     --lifetime "${lifetime}" \


### PR DESCRIPTION
`action.yml` describes `dry-run` as "Skip all judges, make no changes to the factbase", but the `judges eval` that deletes the `judges-summary` facts ran before the branch that knows whether the run is dry. So a dry run emptied the summary of the caller's factbase and `update --summary=add` wrote a fresh one in its place. The deletion now happens only on a real run, and a dry run asks for `--summary=off`, which is what it takes for the file to come out as it went in.

The new entry test seeds a summary fact with `cycles=7`, runs a dry run, and checks both that the fact is still there and that `cksum` of the file has not moved. It was red before the change, finding zero of those facts, and I confirmed by hand that the bytes are now identical before and after.

One thing you may want to decide separately: on a real run that `eval` is already redundant. `judges update` deletes the summary itself when `--summary=add` is given (`log_summary` in `lib/judges/commands/update.rb`), and the `eval` also runs before `pull` replaces the file with the server's copy, so it operates on a factbase that is about to be thrown away. I left it in place rather than remove it, since dropping it is a bigger call than fixing the dry-run promise.

Closes #1902