### PR TITLE
Stop retiring the facts of a live user in eliminate-ghosts

### DIFF
--- a/judges/eliminate-ghosts/eliminate-ghosts.rb
+++ b/judges/eliminate-ghosts/eliminate-ghosts.rb
@@ -45,12 +45,13 @@ Fbe.fb.query('(and (absent stale) (eq where "github") (exists who))').each do |f
 end
 
 bad.each do |u|
-  Fbe.fb.query("(and (absent stale) (eq where 'github') (eq who #{u}))").each do |f|
+  Fbe.fb.query("(and (not (eq stale 'who')) (eq where 'github') (eq who #{u}))").each do |f|
     f.stale = 'who'
   end
 end
 
 Fbe.fb.query('(and (eq where "github") (exists who) (unique who) (eq stale "who"))').each do |f|
+  next if good.include?(f.who)
   Fbe.fb.query("(and (eq who #{f.who}) (not (eq stale 'who')) (eq where 'github'))").each do |ff|
     ff.stale = 'who'
   end

--- a/test/judges/test-eliminate-ghosts.rb
+++ b/test/judges/test-eliminate-ghosts.rb
@@ -109,7 +109,7 @@ class TestEliminateGhosts < Jp::Test
     assert(fb.has?(where: 'github', who: 333))
   end
 
-  def test_marks_sibling_facts_stale_for_good_user
+  def test_keeps_sibling_facts_of_a_live_user
     WebMock.disable_net_connect!
     rate_limit_up
     stub_github('https://api.github.com/user/777', body: { login: 'user777', id: 777, type: 'User' })
@@ -118,7 +118,24 @@ class TestEliminateGhosts < Jp::Test
       .with(_id: 2, where: 'github', who: 777, what: 'something-b')
       .with(_id: 3, where: 'github', who: 777, what: 'something-c')
     load_it('eliminate-ghosts', fb)
-    assert_equal(3, fb.picks(where: 'github', who: 777, stale: 'who').count)
+    assert_equal(
+      1, fb.picks(where: 'github', who: 777, stale: 'who').count,
+      'A user answering GitHub in this very run cannot have the rest of its facts retired'
+    )
+  end
+
+  def test_marks_a_fact_that_is_stale_for_another_reason
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/user/888', body: {}, status: 404)
+    fb = Factbase.new
+    fb.with(_id: 1, where: 'github', who: 888, what: 'something-a', stale: 'repository')
+      .with(_id: 2, where: 'github', who: 888, what: 'something-b')
+    load_it('eliminate-ghosts', fb)
+    assert_equal(
+      1, fb.query("(and (eq who 888) (eq stale 'repository') (eq stale 'who'))").each.to_a.size,
+      'A fact stale for another reason cannot stay invisible to revive-user when its user is gone'
+    )
   end
 
   def test_keeps_user_active_on_forbidden_lookup

--- a/test/judges/test-quality-of-service.rb
+++ b/test/judges/test-quality-of-service.rb
@@ -477,6 +477,7 @@ class TestQualityOfService < Jp::Test
   end
 
   def test_skips_unfinished_workflow_runs
+    $loog = Loog::NULL
     load(File.join(__dir__, '../../judges/quality-of-service/some_build_success_rate.rb'))
     timed = []
     octo = Object.new
@@ -510,6 +511,7 @@ class TestQualityOfService < Jp::Test
   end
 
   def test_skips_repo_on_not_found_workflow_runs
+    $loog = Loog::NULL
     load(File.join(__dir__, '../../judges/quality-of-service/some_build_success_rate.rb'))
     octo = Object.new
     octo.define_singleton_method(:repository_workflow_runs) { |*| raise(Octokit::NotFound) }
@@ -523,6 +525,7 @@ class TestQualityOfService < Jp::Test
   end
 
   def test_skips_repo_on_forbidden_workflow_runs
+    $loog = Loog::NULL
     load(File.join(__dir__, '../../judges/quality-of-service/some_build_success_rate.rb'))
     octo = Object.new
     octo.define_singleton_method(:repository_workflow_runs) { |*| raise(Octokit::Forbidden) }
@@ -2531,6 +2534,7 @@ class TestQualityOfService < Jp::Test
   end
 
   def test_some_pull_hoc_size_handles_nil_additions_or_deletions
+    $loog = Loog::NULL
     load(File.join(__dir__, '../../judges/quality-of-service/some_pull_hoc_size.rb'))
     Jp.qoreset
     octo = Object.new


### PR DESCRIPTION
The propagation loop spread `stale='who'` across a user's facts without asking whether the scan right above it had just resolved that user to a live nick. `revive-user` then cleared the flags on the next cycle and this judge set them again, so the factbase kept churning and the user never settled. The loop now skips a user that is in the `good` set. The test that demanded the old outcome asserts the opposite, and it was the only thing holding the flip-flop in place.

The two staling loops also disagreed about facts that were already stale for another reason: the first selected on `(absent stale)`, the second on `(not (eq stale 'who'))`. So a ghost's fact carrying `stale='repository'` was skipped by one loop and appended to by the other, which left it invisible to `revive-user`, whose query looks for `(eq stale 'who')`. Both loops use the same predicate now. `Fbe.delete_one` in `revive-user` removes just the `'who'` value, so a fact holding `['repository', 'who']` is handled properly.

While testing this I hit a third thing, which I have not touched here: in the propagation loop's query, `(unique who)` sits before `(eq stale "who")`, and factbase evaluates the terms of an `and` in order, so the first fact of a user consumes the uniqueness slot even when it is then rejected. The loop therefore does nothing at all unless the user's first stored fact happens to be the stale one — `(and ... (unique who) (eq stale "who"))` returns 0 facts where `(and ... (eq stale "who") (unique who))` returns 1. Reordering would switch that whole loop back on and stale a lot more facts, which is your call rather than mine, so I filed it as #1922.

Closes #1909
Closes #1910