### PR TITLE
#1897: keep job ids and run ids in caches of their own

### DIFF
--- a/lib/pull_request.rb
+++ b/lib/pull_request.rb
@@ -139,11 +139,12 @@ def Jp.fetch_workflows(pr, repo: nil)
     )
     return { succeeded_builds: 0, failed_builds: 0 }
   end
-  wcache = {}
+  jobs = {}
+  runs = {}
   (entries[:check_runs] || []).each do |run|
     next unless run.dig(:app, :slug) == 'github-actions'
     rid =
-      wcache[run[:id]] ||=
+      jobs[run[:id]] ||=
         begin
           Fbe.octo.workflow_run_job(repo, run[:id])[:run_id]
         rescue Octokit::NotFound, Octokit::Deprecated => e
@@ -158,7 +159,7 @@ def Jp.fetch_workflows(pr, repo: nil)
         end
     next unless rid
     workflow =
-      wcache[rid] ||=
+      runs[rid] ||=
         begin
           Fbe.octo.workflow_run(repo, rid)
         rescue Octokit::NotFound, Octokit::Deprecated => e


### PR DESCRIPTION
One hash held two kinds of key: a check run id pointing at an Integer, and a workflow run id pointing at a hash. The two come from different sequences at GitHub, so one number can be both, and then the wrong value comes back: `workflow_run` gets asked for a hash, or `workflow[:event]` is called on an Integer and the judge crashes for the whole repository.

Two hashes now, one per kind.

Closes #1897
