### PR TITLE
#1898: read the rate limit once per search

### DIFF
--- a/lib/qos_search.rb
+++ b/lib/qos_search.rb
@@ -27,7 +27,6 @@ def Jp.qosearch(query, method: :search_issues, **)
     @offquota[jg] = false
     @offquotatime[jg] = nil
   end
-  return if Fbe.octo.off_quota?
   now = Time.now
   if @swstart[jg].nil? || (now - @swstart[jg]) >= Jp::SEARCH_WINDOW_SECONDS
     @swstart[jg] = now

--- a/lib/qos_search.rb
+++ b/lib/qos_search.rb
@@ -44,6 +44,9 @@ def Jp.qosearch(query, method: :search_issues, **)
   rescue NoMethodError => e
     raise unless e.name == :get
     left = octo.rate_limit.remaining
+  rescue Fbe::OffQuota => e
+    $loog.info("[#{jg}] Not searching, the quota is spent: #{e.message}")
+    return
   end
   if json
     json = JSON.parse(json, symbolize_names: true) if json.is_a?(String)


### PR DESCRIPTION
`Fbe.octo.off_quota?` is not a cached read, it calls `rate_limit!`, which is a live `GET /rate_limit`. The next lines fetch `/rate_limit` again and read `resources.search.remaining` out of it, which is the number this method actually needs, so the check above it doubled the cost of every search.

Dropping it alone was not enough: `Fbe.octo` intercepts every call with the same check, so the `get` below then raised `Fbe::OffQuota` where the guard used to return quietly. Rescuing it keeps that behaviour with one request instead of two.

Closes #1898
