### PR TITLE
#1899: take the metrics in a fixed order, not at random

### DIFF
--- a/lib/incremate.rb
+++ b/lib/incremate.rb
@@ -17,7 +17,7 @@ def Jp.incremate(
   epoch: $epoch || Time.now, kickoff: $kickoff || Time.now
 )
   evaluated = 0
-  Dir[File.join(dir, "#{prefix}_*.rb")].sort.each do |rb|
+  Dir[File.join(dir, "#{prefix}_*.rb")].each do |rb|
     n = File.basename(rb).gsub(/\.rb$/, '')
     if fact[n]
       $loog.debug("#{n} is here: #{fact[n].first}")

--- a/lib/incremate.rb
+++ b/lib/incremate.rb
@@ -17,7 +17,7 @@ def Jp.incremate(
   epoch: $epoch || Time.now, kickoff: $kickoff || Time.now
 )
   evaluated = 0
-  Dir[File.join(dir, "#{prefix}_*.rb")].shuffle.each do |rb|
+  Dir[File.join(dir, "#{prefix}_*.rb")].sort.each do |rb|
     n = File.basename(rb).gsub(/\.rb$/, '')
     if fact[n]
       $loog.debug("#{n} is here: #{fact[n].first}")


### PR DESCRIPTION
The files were shuffled and the loop stopped when the budget ran out, so each run evaluated a random subset and the next run shuffled again from scratch. A metric skipped once had the same chance of being skipped again, and with `qos_max_per_fact` the budget is deliberately smaller than the number of metrics, so the wait for one of them had no bound.

A fixed order gives it one. A metric already in the fact is skipped, so every run starts where the last one was cut off and the missing ones are collected within a known number of runs.

Closes #1899
