### PR TITLE
#1906: date the fact by the clock the query filters on

### DIFF
--- a/judges/dimensions-of-terrain/dimensions-of-terrain.rb
+++ b/judges/dimensions-of-terrain/dimensions-of-terrain.rb
@@ -8,15 +8,24 @@ require 'fbe/octo'
 require 'time'
 require_relative '../../lib/incremate'
 
+today =
+  begin
+    v = ENV.fetch('TODAY', nil)
+    if v.nil? || v.empty?
+      Time.now.utc
+    else
+      Time.parse(v)
+    end
+  end
 f = Fbe.fb.query(
   "(and
     (eq what '#{$judge}')
-    (gt when (minus (to_time (env 'TODAY' '#{Time.now.utc.iso8601}')) '1 days')))"
+    (gt when (minus (to_time '#{today.utc.iso8601}') '1 days')))"
 ).each.first
 if f.nil?
   f = Fbe.fb.insert
   f.what = $judge
-  f.when = Time.now
+  f.when = today
 end
 
 Jp.incremate(f, __dir__, 'total')


### PR DESCRIPTION
The window was anchored on `TODAY` when it is set, the fact on `Time.now` always. With `TODAY` set to a past date, which is how the back-filling runs are driven, every run inserted a fact outside the window it was inserted to satisfy, so the next run found nothing and inserted another one.

`TODAY` is now read once and used for both, the way `Jp.cover_qo` next door reads it.

Closes #1906
