### PR TITLE
#1905: read the total the search already reports

### DIFF
--- a/judges/quality-of-service/some_backlog_size.rb
+++ b/judges/quality-of-service/some_backlog_size.rb
@@ -13,16 +13,12 @@ def some_backlog_size(fact)
   Fbe.unmask_repos do |repo|
     (fact.since.utc.to_date..fact.when.utc.to_date).last(7).each do |date|
       return {} if Fbe.octo.off_quota?(resource: :search)
-      count = 0
       found = Jp.qosearch(
         "repo:#{repo} type:issue created:*..#{date.iso8601[0..9]} (closed:>=#{date.iso8601[0..9]} OR state:open)",
         advanced_search: true
       )
       return {} if found.nil?
-      found[:items].each do |item|
-        count += 1 if item[:closed_at].nil? || item[:closed_at].utc.to_date >= date
-      end
-      issues << count
+      issues << found[:total_count]
     end
   end
   { some_backlog_size: issues }


### PR DESCRIPTION
The `(closed:>=date OR state:open)` in the query and the `closed_at.nil? || closed_at >= date` in the block were the same condition, so the block accepted every item the query returned and the count was `found[:items].size`.

That cost two things: every page had to be fetched, though the total was already in the first response, and the search API stops handing out results after a thousand, so a larger backlog was reported as a thousand with nothing saying it was cut.

`some_merged_pulls` next door reads `total_count`. This one now does too.

Closes #1905
