### PR TITLE
#1903: rebuild the image when anything it copies in changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ verify:
 	e2=$$(cat target/entry.exit)
 	test "$${e2}" = "0"
 
-target/docker-image.txt: Makefile Dockerfile entry.sh Gemfile Gemfile.lock $(wildcard lib/*.rb) $(wildcard judges/*/*.rb)
+target/docker-image.txt: Makefile Dockerfile entry.sh Gemfile Gemfile.lock $(shell find lib judges -type f)
 	mkdir -p "$$(dirname $@)"
 	docker build -t judges-action "$$(pwd)"
 	docker build -t judges-action -q "$$(pwd)" > "$@"


### PR DESCRIPTION
`lib/*.rb` does not match a subdirectory, so `lib/patches/unmask_repos.rb` and `lib/patches/fake_octokit.rb` were left out, and `judges/*/*.yml`, the test packs `make test` runs, were not listed at all. Editing either and running `make test` tested the image built before the edit.

`find lib judges -type f` covers what the `Dockerfile` copies in with `COPY lib` and `COPY judges`.

Closes #1903
