### PR TITLE
Look up a forbidden user once per run in eliminate-ghosts

### DIFF
--- a/judges/eliminate-ghosts/eliminate-ghosts.rb
+++ b/judges/eliminate-ghosts/eliminate-ghosts.rb
@@ -12,9 +12,10 @@ require_relative '../../lib/nick_of'
 
 good = Set.new
 bad = Set.new
+forbidden = Set.new
 
 Fbe.fb.query('(and (absent stale) (eq where "github") (exists who))').each do |f|
-  next if good.include?(f.who) || bad.include?(f.who)
+  next if good.include?(f.who) || bad.include?(f.who) || forbidden.include?(f.who)
   next if Fbe.octo.off_quota?
   elapsed($loog, level: Logger::INFO) do
     nick =
@@ -23,6 +24,7 @@ Fbe.fb.query('(and (absent stale) (eq where "github") (exists who))').each do |f
       rescue Fbe::Error => e
         case e.cause
         when Octokit::Forbidden
+          forbidden.add(f.who)
           $loog.warn(
             "[#{$judge}] Access forbidden to user ##{f.who} " \
             "(transient, will retry next cycle): #{e.cause.class}: #{e.cause.message}"

--- a/test/judges/test-eliminate-ghosts.rb
+++ b/test/judges/test-eliminate-ghosts.rb
@@ -139,4 +139,19 @@ class TestEliminateGhosts < Jp::Test
       'fact must not be marked stale on a transient 403; the cycle should retry on the next run'
     )
   end
+
+  def test_looks_up_forbidden_user_once_per_run
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub = stub_github(
+      'https://api.github.com/user/29139614',
+      status: 403,
+      body: { message: 'Resource not accessible by integration' }
+    )
+    fb = Factbase.new
+    fb.with(_id: 1, what: 'issue-was-opened', repository: 42, issue: 44, who: 29_139_614, where: 'github')
+      .with(_id: 2, what: 'issue-was-closed', repository: 42, issue: 44, who: 29_139_614, where: 'github')
+    load_it('eliminate-ghosts', fb)
+    assert_requested(stub, times: 1)
+  end
 end


### PR DESCRIPTION
The scan in eliminate-ghosts.rb skips a fact when its user is already known good or bad, but the Octokit::Forbidden branch never recorded the user anywhere, so every later fact with the same who walked back into Jp.nick_of and asked about a user that had just answered 403.

This adds a third set, forbidden, checked alongside good and bad, and filled in when a lookup comes back 403. The 403 stays non-permanent: forbidden users are still retried on the next cycle, they just aren't asked about more than once within the same run.

Closes #1911