### PR TITLE
fix(#1912): wrap eliminate-ghosts stale marking in a transaction

### DIFF
--- a/judges/eliminate-ghosts/eliminate-ghosts.rb
+++ b/judges/eliminate-ghosts/eliminate-ghosts.rb
@@ -5,6 +5,7 @@
 
 require 'elapsed'
 require 'fbe/consider'
+require 'fbe/fb'
 require 'fbe/octo'
 require 'logger'
 require 'octokit'
@@ -44,15 +45,19 @@ Fbe.fb.query('(and (absent stale) (eq where "github") (exists who))').each do |f
   end
 end
 
-bad.each do |u|
-  Fbe.fb.query("(and (absent stale) (eq where 'github') (eq who #{u}))").each do |f|
-    f.stale = 'who'
+Fbe.fb.txn do |fbt|
+  bad.each do |u|
+    fbt.query("(and (absent stale) (eq where 'github') (eq who #{u}))").each do |f|
+      f.stale = 'who'
+    end
   end
 end
 
-Fbe.fb.query('(and (eq where "github") (exists who) (unique who) (eq stale "who"))').each do |f|
-  Fbe.fb.query("(and (eq who #{f.who}) (not (eq stale 'who')) (eq where 'github'))").each do |ff|
-    ff.stale = 'who'
+Fbe.fb.txn do |fbt|
+  fbt.query('(and (eq where "github") (exists who) (unique who) (eq stale "who"))').each do |f|
+    fbt.query("(and (eq who #{f.who}) (not (eq stale 'who')) (eq where 'github'))").each do |ff|
+      ff.stale = 'who'
+    end
   end
 end
 


### PR DESCRIPTION
Closes #1912

The two staling loops in `eliminate-ghosts.rb` wrote the `stale = 'who'` fact one fact at a time, outside any transaction. Anything that ended the run partway through (a killed process, an unhandled error) could leave some of a ghost's facts flagged stale and the rest not, and nothing on a later run noticed the split state.

This wraps both loops in `Fbe.fb.txn`, the same way `who-is-alive` was fixed for the identical problem in #1720 (PR #1778). Each pass — marking the confirmed-bad users, then propagating `stale` to their sibling facts — now commits or rolls back as a unit.

No new test is included, matching the precedent PR #1778 for that identical fix: the failure mode is process interruption mid-loop, which isn't reachable through a code-level exception in this test harness.