### PR TITLE
Write the stale flags of eliminate-ghosts in one transaction

### DIFF
--- a/judges/eliminate-ghosts/eliminate-ghosts.rb
+++ b/judges/eliminate-ghosts/eliminate-ghosts.rb
@@ -46,16 +46,17 @@ Fbe.fb.query('(and (absent stale) (eq where "github") (exists who))').each do |f
   end
 end
 
-bad.each do |u|
-  Fbe.fb.query("(and (not (eq stale 'who')) (eq where 'github') (eq who #{u}))").each do |f|
-    f.stale = 'who'
+Fbe.fb.txn do |fbt|
+  bad.each do |u|
+    fbt.query("(and (not (eq stale 'who')) (eq where 'github') (eq who #{u}))").each do |f|
+      f.stale = 'who'
+    end
   end
-end
-
-Fbe.fb.query('(and (eq where "github") (exists who) (unique who) (eq stale "who"))').each do |f|
-  next if good.include?(f.who)
-  Fbe.fb.query("(and (eq who #{f.who}) (not (eq stale 'who')) (eq where 'github'))").each do |ff|
-    ff.stale = 'who'
+  fbt.query('(and (eq where "github") (exists who) (unique who) (eq stale "who"))').each do |f|
+    next if good.include?(f.who)
+    fbt.query("(and (eq who #{f.who}) (not (eq stale 'who')) (eq where 'github'))").each do |ff|
+      ff.stale = 'who'
+    end
   end
 end
 

--- a/test/judges/test-eliminate-ghosts.rb
+++ b/test/judges/test-eliminate-ghosts.rb
@@ -138,6 +138,21 @@ class TestEliminateGhosts < Jp::Test
     )
   end
 
+  def test_writes_the_stale_flags_in_one_transaction
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/user/999', body: {}, status: 404)
+    fb = Factbase.new
+    fb.with(_id: 1, where: 'github', who: 999, what: 'something-a')
+      .with(_id: 2, where: 'github', who: 999, what: 'something-b')
+    loog = Loog::Buffer.new
+    load_it('eliminate-ghosts', fb, loog:)
+    assert_includes(
+      loog.to_s, 'Txn #',
+      'The stale flags of a ghost cannot be written one by one, outside a transaction'
+    )
+  end
+
   def test_keeps_user_active_on_forbidden_lookup
     WebMock.disable_net_connect!
     rate_limit_up


### PR DESCRIPTION
The two staling loops in `eliminate-ghosts.rb` wrote fact by fact, outside any transaction, so anything that ended the run between them left a ghost half retired. Nothing on the next run noticed: the first loop just picks up wherever it stopped, while consumers reading `(absent stale)` see a user that is partly retired and partly not. Both loops run inside one `Fbe.fb.txn` now, the way `who-is-alive` has since #1720.

I should be straight about the test: it asserts that the factbase logs a `Txn #` line, which shows the writes went through a transaction but does not prove atomicity under a mid-loop failure. Injecting such a failure needs a fake factbase, and #1720 was closed without one, so I matched that.

This branch was rebased onto master after #1930 landed, so the `forbidden` set half of the original diff is gone — master already has it, with the same design and an equivalent test. 357 tests green, rubocop clean.

Closes #1912