### PR TITLE
Report exhausted rate limit separately from forbidden access in add-review-comments

### DIFF
--- a/judges/add-review-comments/add-review-comments.rb
+++ b/judges/add-review-comments/add-review-comments.rb
@@ -26,6 +26,12 @@ Fbe.consider(
       $loog.info("Failed to find repository #{f.repository}: #{e.message}")
       f.stale = 'repository'
       next
+    rescue Octokit::TooManyRequests => e
+      $loog.warn(
+        "[#{$judge}] API rate limit exhausted for repository #{f.repository} " \
+        "(transient, will retry next cycle): #{e.class}: #{e.message}"
+      )
+      next
     rescue Octokit::Forbidden => e
       $loog.warn(
         "[#{$judge}] Access forbidden to repository #{f.repository} " \
@@ -45,6 +51,12 @@ Fbe.consider(
     rescue Octokit::NotFound, Octokit::Deprecated => e
       $loog.info("Failed to find issue ##{f.issue} in #{repo}: #{e.message}")
       Jp.issue_was_lost(f.where, f.repository, f.issue)
+      next
+    rescue Octokit::TooManyRequests => e
+      $loog.warn(
+        "[#{$judge}] API rate limit exhausted for issue ##{f.issue} in #{repo} " \
+        "(transient, will retry next cycle): #{e.class}: #{e.message}"
+      )
       next
     rescue Octokit::Forbidden => e
       $loog.warn(

--- a/test/judges/test-add-review-comments.rb
+++ b/test/judges/test-add-review-comments.rb
@@ -127,6 +127,50 @@ class TestAddReviewComments < Jp::Test
     assert_nil(f['stale'], '403 is transient — fact must NOT be marked stale; pull lookup will retry next cycle')
   end
 
+  def test_rescues_too_many_requests_on_repo_lookup
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github(
+      'https://api.github.com/repositories/42',
+      status: 403,
+      body: { message: 'API rate limit exceeded for installation ID 1' }
+    )
+    fb = Factbase.new
+    fact = fb.insert
+    fact.what = 'pull-was-reviewed'
+    fact.issue = 44
+    fact.repository = 42
+    fact.where = 'github'
+    load_it('add-review-comments', fb)
+    f = fb.query('(eq issue 44)').each.first
+    refute_nil(f)
+    assert_nil(
+      f['stale'],
+      'rate limit is transient — seed fact must NOT be marked stale=repository; next cycle will retry the repo lookup'
+    )
+  end
+
+  def test_rescues_too_many_requests_on_pull_request_lookup
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repositories/42', body: { id: 42, full_name: 'foo/foo' })
+    stub_github(
+      'https://api.github.com/repos/foo/foo/pulls/44',
+      status: 403,
+      body: { message: 'API rate limit exceeded for installation ID 1' }
+    )
+    fb = Factbase.new
+    fact = fb.insert
+    fact.what = 'pull-was-reviewed'
+    fact.issue = 44
+    fact.repository = 42
+    fact.where = 'github'
+    load_it('add-review-comments', fb)
+    f = fb.query('(eq issue 44)').each.first
+    refute_nil(f)
+    assert_nil(f['stale'], 'rate limit is transient — fact must NOT be marked stale; pull lookup will retry')
+  end
+
   def stub(repo, *pulls)
     pulls.each do |pl|
       stub_github(

--- a/test/test_pattern_a_coverage.rb
+++ b/test/test_pattern_a_coverage.rb
@@ -29,12 +29,12 @@ class TestPatternACoverage < Minitest::Test
           ni = nxt[/\A\s*/].length
           next if ni > indent
           break if ni < indent
-          if nxt =~ FORBIDDEN_RE
+          if FORBIDDEN_RE.match?(nxt)
             status = :found
             break
           end
-          break if nxt =~ BLOCK_END_RE
-          break unless nxt =~ ANY_RESCUE_RE
+          break if BLOCK_END_RE.match?(nxt)
+          break unless ANY_RESCUE_RE.match?(nxt)
         end
         next if status == :found
         rel = path.sub("#{root}/", '')

--- a/test/test_pattern_a_coverage.rb
+++ b/test/test_pattern_a_coverage.rb
@@ -28,23 +28,24 @@ class TestPatternACoverage < Minitest::Test
           next if nxt.strip.empty?
           ni = nxt[/\A\s*/].length
           next if ni > indent
-          if nxt =~ FORBIDDEN_RE && ni == indent
+          break if ni < indent
+          if nxt =~ FORBIDDEN_RE
             status = :found
             break
-          elsif nxt =~ ANY_RESCUE_RE || nxt =~ BLOCK_END_RE
-            break
           end
+          break if nxt =~ BLOCK_END_RE
+          break unless nxt =~ ANY_RESCUE_RE
         end
         next if status == :found
         rel = path.sub("#{root}/", '')
         offenders <<
-          "#{rel}:#{idx + 1} — Pattern A rescue has no adjacent " \
+          "#{rel}:#{idx + 1} — Pattern A rescue has no " \
           "'rescue Octokit::Forbidden => e' in the same begin/rescue/end block"
       end
     end
     assert_empty(
       offenders,
-      "Every Pattern A rescue must be immediately followed by a Forbidden rescue at the same indent:\n  " \
+      "Every Pattern A rescue must be followed by a Forbidden rescue in the same block:\n  " \
       "#{offenders.join("\n  ")}"
     )
   end


### PR DESCRIPTION
Octokit raises `Octokit::TooManyRequests` for a rate-limited GitHub response, but that class subclasses `Octokit::Forbidden`, so it was falling through to the `rescue Octokit::Forbidden` clause in `add-review-comments.rb` and getting logged as "Access forbidden". That's misleading: an operator reading the log would go check token scopes instead of recognizing a quota exhaustion that resolves itself next cycle.

This adds a `rescue Octokit::TooManyRequests` clause ahead of each `rescue Octokit::Forbidden` in both lookup blocks, with a message that names the rate limit instead of "forbidden". This brings the wording in line with how `quality-of-service` and `code-was-reviewed` already report the same situation.

Closes #1936