### PR TITLE
Move AbuseDetected and TooManyRequests rescues above Forbidden

### DIFF
--- a/judges/add-review-comments/add-review-comments.rb
+++ b/judges/add-review-comments/add-review-comments.rb
@@ -26,16 +26,16 @@ Fbe.consider(
       $loog.info("Failed to find repository #{f.repository}: #{e.message}")
       f.stale = 'repository'
       next
-    rescue Octokit::Forbidden => e
-      $loog.warn(
-        "[#{$judge}] Access forbidden to repository #{f.repository} " \
-        "(transient, will retry next cycle): #{e.class}: #{e.message}"
-      )
-      next
     rescue Octokit::AbuseDetected => e
       $loog.warn(
         "[#{$judge}] Repository access abuse detected for #{f.repository} " \
         "(will retry next cycle): #{e.class}: #{e.message}"
+      )
+      next
+    rescue Octokit::Forbidden => e
+      $loog.warn(
+        "[#{$judge}] Access forbidden to repository #{f.repository} " \
+        "(transient, will retry next cycle): #{e.class}: #{e.message}"
       )
       next
     end
@@ -46,16 +46,16 @@ Fbe.consider(
       $loog.info("Failed to find issue ##{f.issue} in #{repo}: #{e.message}")
       Jp.issue_was_lost(f.where, f.repository, f.issue)
       next
-    rescue Octokit::Forbidden => e
-      $loog.warn(
-        "[#{$judge}] Access forbidden to issue ##{f.issue} in #{repo} " \
-        "(transient, will retry next cycle): #{e.class}: #{e.message}"
-      )
-      next
     rescue Octokit::AbuseDetected => e
       $loog.warn(
         "[#{$judge}] Issue access abuse detected for #{repo}##{f.issue} " \
         "(will retry next cycle): #{e.class}: #{e.message}"
+      )
+      next
+    rescue Octokit::Forbidden => e
+      $loog.warn(
+        "[#{$judge}] Access forbidden to issue ##{f.issue} in #{repo} " \
+        "(transient, will retry next cycle): #{e.class}: #{e.message}"
       )
       next
     end

--- a/judges/code-was-reviewed/code-was-reviewed.rb
+++ b/judges/code-was-reviewed/code-was-reviewed.rb
@@ -51,18 +51,18 @@ Fbe.consider(
       $loog.info("The pull request ##{f.issue} doesn't exist in #{repo}: #{e.message}")
       Jp.issue_was_lost(f.where, f.repository, f.issue)
       next
-    rescue Octokit::Forbidden => e
-      $loog.warn(
-        "[#{$judge}] Access forbidden to pull ##{f.issue} in #{repo} " \
-        "(transient, will retry next cycle): #{e.class}: #{e.message}"
-      )
-      next
     rescue Octokit::TooManyRequests, Octokit::Unauthorized, Octokit::ServerError,
       Net::OpenTimeout, Net::ReadTimeout, SocketError,
       Errno::ECONNRESET, Errno::ETIMEDOUT => e
       $loog.warn(
         "[#{$judge}] Transient error fetching pull ##{f.issue} in #{repo} " \
         "(will retry next cycle): #{e.class}: #{e.message}"
+      )
+      next
+    rescue Octokit::Forbidden => e
+      $loog.warn(
+        "[#{$judge}] Access forbidden to pull ##{f.issue} in #{repo} " \
+        "(transient, will retry next cycle): #{e.class}: #{e.message}"
       )
       next
     end
@@ -73,18 +73,18 @@ Fbe.consider(
       $loog.info("The pull request ##{f.issue} doesn't exist in #{repo}: #{e.message}")
       Jp.issue_was_lost(f.where, f.repository, f.issue)
       next
-    rescue Octokit::Forbidden => e
-      $loog.warn(
-        "[#{$judge}] Access forbidden to reviews for pull ##{f.issue} in #{repo} " \
-        "(transient, will retry next cycle): #{e.class}: #{e.message}"
-      )
-      next
     rescue Octokit::TooManyRequests, Octokit::Unauthorized, Octokit::ServerError,
       Net::OpenTimeout, Net::ReadTimeout, SocketError,
       Errno::ECONNRESET, Errno::ETIMEDOUT => e
       $loog.warn(
         "[#{$judge}] Transient error fetching reviews for pull ##{f.issue} in #{repo} " \
         "(will retry next cycle): #{e.class}: #{e.message}"
+      )
+      next
+    rescue Octokit::Forbidden => e
+      $loog.warn(
+        "[#{$judge}] Access forbidden to reviews for pull ##{f.issue} in #{repo} " \
+        "(transient, will retry next cycle): #{e.class}: #{e.message}"
       )
       next
     end
@@ -111,18 +111,18 @@ Fbe.consider(
         rescue Octokit::NotFound, Octokit::Deprecated => e
           $loog.info("Issue comments not found for #{repo}##{f.issue}: #{e.message}")
           0
-        rescue Octokit::Forbidden => e
-          $loog.warn(
-            "[#{$judge}] Access forbidden to issue comments for #{repo}##{f.issue} " \
-            "(transient, will retry next cycle): #{e.class}: #{e.message}"
-          )
-          0
         rescue Octokit::TooManyRequests, Octokit::Unauthorized, Octokit::ServerError,
           Net::OpenTimeout, Net::ReadTimeout, SocketError,
           Errno::ECONNRESET, Errno::ETIMEDOUT => e
           $loog.warn(
             "[#{$judge}] Transient error fetching issue comments for #{repo}##{f.issue} " \
             "(will retry next cycle): #{e.class}: #{e.message}"
+          )
+          0
+        rescue Octokit::Forbidden => e
+          $loog.warn(
+            "[#{$judge}] Access forbidden to issue comments for #{repo}##{f.issue} " \
+            "(transient, will retry next cycle): #{e.class}: #{e.message}"
           )
           0
         end
@@ -133,18 +133,18 @@ Fbe.consider(
         rescue Octokit::NotFound, Octokit::Deprecated => e
           $loog.info("Review comments not found for #{repo}##{f.issue}: #{e.message}")
           0
-        rescue Octokit::Forbidden => e
-          $loog.warn(
-            "[#{$judge}] Access forbidden to review comments for #{repo}##{f.issue} " \
-            "(transient, will retry next cycle): #{e.class}: #{e.message}"
-          )
-          0
         rescue Octokit::TooManyRequests, Octokit::Unauthorized, Octokit::ServerError,
           Net::OpenTimeout, Net::ReadTimeout, SocketError,
           Errno::ECONNRESET, Errno::ETIMEDOUT => e
           $loog.warn(
             "[#{$judge}] Transient error fetching review comments for #{repo}##{f.issue} " \
             "(will retry next cycle): #{e.class}: #{e.message}"
+          )
+          0
+        rescue Octokit::Forbidden => e
+          $loog.warn(
+            "[#{$judge}] Access forbidden to review comments for #{repo}##{f.issue} " \
+            "(transient, will retry next cycle): #{e.class}: #{e.message}"
           )
           0
         end

--- a/judges/fix-missing-comments/fix-missing-comments.rb
+++ b/judges/fix-missing-comments/fix-missing-comments.rb
@@ -44,16 +44,16 @@ Fbe.consider(
       $loog.info("#{Fbe.issue(f)} doesn't exist in #{repo}: #{e.message}")
       Jp.issue_was_lost(f.where, f.repository, f.issue)
       next
-    rescue Octokit::Forbidden => e
-      $loog.warn(
-        "[#{$judge}] Access forbidden to #{Fbe.issue(f)} in #{repo} " \
-        "(transient, will retry next cycle): #{e.class}: #{e.message}"
-      )
-      next
     rescue Octokit::TooManyRequests, Octokit::Unauthorized, Octokit::ServerError => e
       $loog.warn(
         "[#{$judge}] Transient error fetching #{Fbe.issue(f)} in #{repo} " \
         "(will retry next cycle): #{e.class}: #{e.message}"
+      )
+      next
+    rescue Octokit::Forbidden => e
+      $loog.warn(
+        "[#{$judge}] Access forbidden to #{Fbe.issue(f)} in #{repo} " \
+        "(transient, will retry next cycle): #{e.class}: #{e.message}"
       )
       next
     end

--- a/test/test_pattern_a_coverage.rb
+++ b/test/test_pattern_a_coverage.rb
@@ -30,7 +30,7 @@ class TestPatternACoverage < Minitest::Test
           if nxt =~ FORBIDDEN_RE && ni == indent
             status = :found
             break
-          elsif nxt =~ BLOCK_END_RE
+          elsif BLOCK_END_RE.match?(nxt)
             break
           end
         end

--- a/test/test_pattern_a_coverage.rb
+++ b/test/test_pattern_a_coverage.rb
@@ -8,8 +8,7 @@ require 'minitest/autorun'
 class TestPatternACoverage < Minitest::Test
   PATTERN_A_RE = /^(\s*)rescue\s+Octokit::NotFound\s*,\s*Octokit::Deprecated\s*=>\s*e/
   FORBIDDEN_RE = /^\s*rescue\s+Octokit::Forbidden\s*=>\s*e/
-  ANY_RESCUE_RE = /^\s*rescue\b/
-  BLOCK_END_RE  = /^\s*end\b/
+  BLOCK_END_RE = /^\s*end\b/
 
   def test_pattern_a_block_has_forbidden_rescue
     root = File.expand_path('..', __dir__)
@@ -31,20 +30,20 @@ class TestPatternACoverage < Minitest::Test
           if nxt =~ FORBIDDEN_RE && ni == indent
             status = :found
             break
-          elsif nxt =~ ANY_RESCUE_RE || nxt =~ BLOCK_END_RE
+          elsif nxt =~ BLOCK_END_RE
             break
           end
         end
         next if status == :found
         rel = path.sub("#{root}/", '')
         offenders <<
-          "#{rel}:#{idx + 1} — Pattern A rescue has no adjacent " \
+          "#{rel}:#{idx + 1} — Pattern A rescue has no " \
           "'rescue Octokit::Forbidden => e' in the same begin/rescue/end block"
       end
     end
     assert_empty(
       offenders,
-      "Every Pattern A rescue must be immediately followed by a Forbidden rescue at the same indent:\n  " \
+      "Every Pattern A rescue must be followed by a Forbidden rescue at the same indent:\n  " \
       "#{offenders.join("\n  ")}"
     )
   end


### PR DESCRIPTION
Octokit::AbuseDetected and Octokit::TooManyRequests are both subclasses of Octokit::Forbidden. Ruby matches rescue clauses top to bottom by ancestry, so wherever a rescue Octokit::Forbidden clause sat before its more specific sibling, the sibling could never run.

This reorders the six affected begin/rescue blocks in judges/add-review-comments/add-review-comments.rb, judges/fix-missing-comments/fix-missing-comments.rb, and judges/code-was-reviewed/code-was-reviewed.rb so the specific subclass is rescued first, restoring the intended distinction between abuse/rate-limit throttling and a plain permissions failure.

Closes #1935