### PR TITLE
fix(#1937): rescue transient GitHub errors in add-review-comments.rb

### DIFF
--- a/judges/add-review-comments/add-review-comments.rb
+++ b/judges/add-review-comments/add-review-comments.rb
@@ -26,6 +26,12 @@ Fbe.consider(
       $loog.info("Failed to find repository #{f.repository}: #{e.message}")
       f.stale = 'repository'
       next
+    rescue Octokit::TooManyRequests => e
+      $loog.warn(
+        "[#{$judge}] API rate limit exhausted for repository #{f.repository} " \
+        "(transient, will retry next cycle): #{e.class}: #{e.message}"
+      )
+      next
     rescue Octokit::Forbidden => e
       $loog.warn(
         "[#{$judge}] Access forbidden to repository #{f.repository} " \
@@ -45,6 +51,12 @@ Fbe.consider(
     rescue Octokit::NotFound, Octokit::Deprecated => e
       $loog.info("Failed to find issue ##{f.issue} in #{repo}: #{e.message}")
       Jp.issue_was_lost(f.where, f.repository, f.issue)
+      next
+    rescue Octokit::TooManyRequests => e
+      $loog.warn(
+        "[#{$judge}] API rate limit exhausted for issue ##{f.issue} in #{repo} " \
+        "(transient, will retry next cycle): #{e.class}: #{e.message}"
+      )
       next
     rescue Octokit::Forbidden => e
       $loog.warn(

--- a/judges/add-review-comments/add-review-comments.rb
+++ b/judges/add-review-comments/add-review-comments.rb
@@ -44,6 +44,14 @@ Fbe.consider(
         "(will retry next cycle): #{e.class}: #{e.message}"
       )
       next
+    rescue Octokit::Unauthorized, Octokit::ServerError,
+      Net::OpenTimeout, Net::ReadTimeout, SocketError,
+      Errno::ECONNRESET, Errno::ETIMEDOUT => e
+      $loog.warn(
+        "[#{$judge}] Transient error fetching repository #{f.repository} " \
+        "(will retry next cycle): #{e.class}: #{e.message}"
+      )
+      next
     end
   json =
     begin
@@ -67,6 +75,14 @@ Fbe.consider(
     rescue Octokit::AbuseDetected => e
       $loog.warn(
         "[#{$judge}] Issue access abuse detected for #{repo}##{f.issue} " \
+        "(will retry next cycle): #{e.class}: #{e.message}"
+      )
+      next
+    rescue Octokit::Unauthorized, Octokit::ServerError,
+      Net::OpenTimeout, Net::ReadTimeout, SocketError,
+      Errno::ECONNRESET, Errno::ETIMEDOUT => e
+      $loog.warn(
+        "[#{$judge}] Transient error fetching issue ##{f.issue} in #{repo} " \
         "(will retry next cycle): #{e.class}: #{e.message}"
       )
       next

--- a/test/judges/test-add-review-comments.rb
+++ b/test/judges/test-add-review-comments.rb
@@ -171,6 +171,50 @@ class TestAddReviewComments < Jp::Test
     assert_nil(f['stale'], 'rate limit is transient — fact must NOT be marked stale; pull lookup will retry')
   end
 
+  def test_rescues_server_error_on_repo_lookup
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github(
+      'https://api.github.com/repositories/42',
+      status: 500,
+      body: { message: 'Internal Server Error' }
+    )
+    fb = Factbase.new
+    fact = fb.insert
+    fact.what = 'pull-was-reviewed'
+    fact.issue = 44
+    fact.repository = 42
+    fact.where = 'github'
+    load_it('add-review-comments', fb)
+    f = fb.query('(eq issue 44)').each.first
+    refute_nil(f)
+    assert_nil(
+      f['stale'],
+      '500 is transient — seed fact must NOT be marked stale=repository; next cycle will retry the repo lookup'
+    )
+  end
+
+  def test_rescues_server_error_on_pull_request_lookup
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repositories/42', body: { id: 42, full_name: 'foo/foo' })
+    stub_github(
+      'https://api.github.com/repos/foo/foo/pulls/44',
+      status: 500,
+      body: { message: 'Internal Server Error' }
+    )
+    fb = Factbase.new
+    fact = fb.insert
+    fact.what = 'pull-was-reviewed'
+    fact.issue = 44
+    fact.repository = 42
+    fact.where = 'github'
+    load_it('add-review-comments', fb)
+    f = fb.query('(eq issue 44)').each.first
+    refute_nil(f)
+    assert_nil(f['stale'], '500 is transient — fact must NOT be marked stale; pull lookup will retry next cycle')
+  end
+
   def stub(repo, *pulls)
     pulls.each do |pl|
       stub_github(

--- a/test/judges/test-add-review-comments.rb
+++ b/test/judges/test-add-review-comments.rb
@@ -127,6 +127,50 @@ class TestAddReviewComments < Jp::Test
     assert_nil(f['stale'], '403 is transient — fact must NOT be marked stale; pull lookup will retry next cycle')
   end
 
+  def test_rescues_too_many_requests_on_repo_lookup
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github(
+      'https://api.github.com/repositories/42',
+      status: 403,
+      body: { message: 'API rate limit exceeded for installation ID 1' }
+    )
+    fb = Factbase.new
+    fact = fb.insert
+    fact.what = 'pull-was-reviewed'
+    fact.issue = 44
+    fact.repository = 42
+    fact.where = 'github'
+    load_it('add-review-comments', fb)
+    f = fb.query('(eq issue 44)').each.first
+    refute_nil(f)
+    assert_nil(
+      f['stale'],
+      'rate limit is transient — seed fact must NOT be marked stale=repository; next cycle will retry the repo lookup'
+    )
+  end
+
+  def test_rescues_too_many_requests_on_pull_request_lookup
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repositories/42', body: { id: 42, full_name: 'foo/foo' })
+    stub_github(
+      'https://api.github.com/repos/foo/foo/pulls/44',
+      status: 403,
+      body: { message: 'API rate limit exceeded for installation ID 1' }
+    )
+    fb = Factbase.new
+    fact = fb.insert
+    fact.what = 'pull-was-reviewed'
+    fact.issue = 44
+    fact.repository = 42
+    fact.where = 'github'
+    load_it('add-review-comments', fb)
+    f = fb.query('(eq issue 44)').each.first
+    refute_nil(f)
+    assert_nil(f['stale'], 'rate limit is transient — fact must NOT be marked stale; pull lookup will retry')
+  end
+
   def stub(repo, *pulls)
     pulls.each do |pl|
       stub_github(


### PR DESCRIPTION
The two GitHub calls in add-review-comments.rb, repo_name_by_id and pull_request, only rescued Octokit::NotFound, Octokit::Deprecated, Octokit::TooManyRequests, Octokit::Forbidden, and Octokit::AbuseDetected. A 401, a 5xx, or a dropped socket would escape both begin blocks, and since Fbe::Conclude#roll only rescues Fbe::OffQuota, the exception would kill the whole cycle instead of just the fact that triggered it.

This adds a rescue for Octokit::Unauthorized, Octokit::ServerError, Net::OpenTimeout, Net::ReadTimeout, SocketError, Errno::ECONNRESET, and Errno::ETIMEDOUT to both blocks, logging a warning and moving on to the next fact. It's the same clause already used in code-was-reviewed.rb, so a transient GitHub error now costs one fact instead of the whole batch.

Added two tests, one per lookup, that stub a 500 response and check the seed fact is left alone rather than marked stale.

Fixes #1937