### PR TITLE
Move who-is-alive and nick_of tests onto the fake GitHub server

### DIFF
--- a/test/fake_github.rb
+++ b/test/fake_github.rb
@@ -9,15 +9,15 @@ require 'socket'
 require_relative '../lib/jp'
 
 # rubocop:disable Elegant/NoComments
-# @todo #760:60min Move the rest of the tests onto this server.
-#  Thirty four files under `test/` still build their GitHub with
-#  `stub_request` and `stub_github`, about a hundred and ten stubs in all,
-#  the heaviest being `test/judges/test-github-events.rb` with forty one.
-#  Each of them should declare its routes through `Jp::FakeGithub` instead,
-#  one file at a time, so that a reviewer can follow every step. When the
-#  last one is moved, `stub_github` and `rate_limit_up` go from
-#  `test/test__helper.rb`, the `webmock` gem goes from the `Gemfile`, and
-#  `require 'webmock/minitest'` goes with it.
+# @todo #1923:60min Move the rest of the tests onto this server.
+#  Thirty three files under `test/` still build their GitHub with
+#  `stub_request` and `stub_github`, over a thousand stubs in all, the
+#  heaviest being `test/judges/test-quality-of-service.rb` with two
+#  hundred and fifty three. Each of them should declare its routes through
+#  `Jp::FakeGithub` instead, one file at a time, so that a reviewer can
+#  follow every step. When the last one is moved, `stub_github` and
+#  `rate_limit_up` go from `test/test__helper.rb`, the `webmock` gem goes
+#  from the `Gemfile`, and `require 'webmock/minitest'` goes with it.
 # rubocop:enable Elegant/NoComments
 class Jp::FakeGithub
   def initialize(routes = {})

--- a/test/judges/test-who-is-alive.rb
+++ b/test/judges/test-who-is-alive.rb
@@ -30,13 +30,6 @@ class TestWhoIsAlive < Jp::Test
   end
 
   def test_add_stale_prop_for_not_found_users
-    WebMock.disable_net_connect!
-    rate_limit_up
-    stub_github(
-      'https://api.github.com/user/10',
-      status: 404,
-      body: { message: 'Not Found', documentation_url: 'https://docs.github.com/rest', status: '404' }
-    )
     fb = Factbase.new
     fb.with(_id: 1, where: 'github', who: 10, name: 'user0')
       .with(_id: 2, where: 'github', who: 11, name: 'user1')
@@ -55,7 +48,12 @@ class TestWhoIsAlive < Jp::Test
         when: Time.parse('2025-06-23 20:00:00 UTC')
       )
     Time.stub(:now, Time.parse('2025-06-25 22:00:00 UTC')) do
-      load_it('who-is-alive', fb)
+      Jp::FakeGithub.new(
+        'GET /rate_limit' => { rate: { remaining: 222 } },
+        'GET /user/10' => [404, { message: 'Not Found' }]
+      ).run do
+        load_it('who-is-alive', fb)
+      end
       assert_equal(6, fb.all.size)
       assert(fb.none?(what: 'who-has-name', where: 'github', who: 10, name: 'user0'))
       assert_equal('who', fb.pick(where: 'github', who: 10, name: 'user0').stale)
@@ -65,10 +63,6 @@ class TestWhoIsAlive < Jp::Test
   end
 
   def test_skip_if_user_is_alive
-    WebMock.disable_net_connect!
-    rate_limit_up
-    stub_github('https://api.github.com/user/10', body: { login: 'user0', id: 10, type: 'User' })
-    stub_github('https://api.github.com/user/11', body: { login: 'user1', id: 11, type: 'User' })
     fb = Factbase.new
     fb.with(_id: 1, where: 'github', who: 10, name: 'user0')
       .with(_id: 2, where: 'github', who: 11, name: 'user1')
@@ -86,25 +80,29 @@ class TestWhoIsAlive < Jp::Test
         when: Time.parse('2025-06-23 20:00:00 UTC')
       )
     Time.stub(:now, Time.parse('2025-06-25 22:00:00 UTC')) do
-      load_it('who-is-alive', fb)
+      Jp::FakeGithub.new(
+        'GET /rate_limit' => { rate: { remaining: 222 } },
+        'GET /user/10' => { login: 'user0', id: 10, type: 'User' },
+        'GET /user/11' => { login: 'user1', id: 11, type: 'User' }
+      ).run do
+        load_it('who-is-alive', fb)
+      end
       assert_equal(6, fb.all.size)
     end
   end
 
   def test_keeps_fact_on_forbidden_user_lookup
-    WebMock.disable_net_connect!
-    rate_limit_up
-    stub_github(
-      'https://api.github.com/user/29139614',
-      status: 403,
-      body: { message: 'Resource not accessible by integration' }
-    )
     fb = Factbase.new
     fb.with(
       _id: 1, what: 'who-has-name', where: 'github', who: 29_139_614,
       name: 'someone', when: Time.now - (3 * 86_400)
     )
-    load_it('who-is-alive', fb)
+    Jp::FakeGithub.new(
+      'GET /rate_limit' => { rate: { remaining: 222 } },
+      'GET /user/29139614' => [403, { message: 'Resource not accessible by integration' }]
+    ).run do
+      load_it('who-is-alive', fb)
+    end
     refute_empty(
       fb.query('(eq what "who-has-name")').each.to_a,
       'who-is-alive must not delete the who-has-name fact on a transient 403; the cycle should retry on the next run'

--- a/test/lib/test_nick_of.rb
+++ b/test/lib/test_nick_of.rb
@@ -4,30 +4,31 @@
 # SPDX-License-Identifier: MIT
 
 require_relative '../../lib/nick_of'
+require_relative '../fake_github'
 require_relative '../test__helper'
 
 class TestNickOf < Jp::Test
   def test_propagates_error_on_forbidden_user_lookup
-    WebMock.disable_net_connect!
-    rate_limit_up
-    stub_github(
-      'https://api.github.com/user/29139614',
-      status: 403,
-      body: { message: 'Resource not accessible by integration' }
-    )
     $options = Judges::Options.new({})
     $global = {}
     $loog = Loog::NULL
-    assert_raises(Fbe::Error) { Jp.nick_of(29_139_614, loog: Loog::NULL) }
+    Jp::FakeGithub.new(
+      'GET /rate_limit' => { rate: { remaining: 222 } },
+      'GET /user/29139614' => [403, { message: 'Resource not accessible by integration' }]
+    ).run do
+      assert_raises(Fbe::Error) { Jp.nick_of(29_139_614, loog: Loog::NULL) }
+    end
   end
 
   def test_propagates_error_on_not_found_user_lookup
-    WebMock.disable_net_connect!
-    rate_limit_up
-    stub_github('https://api.github.com/user/29139614', status: 404, body: { message: 'Not Found' })
     $options = Judges::Options.new({})
     $global = {}
     $loog = Loog::NULL
-    assert_raises(Fbe::Error) { Jp.nick_of(29_139_614, loog: Loog::NULL) }
+    Jp::FakeGithub.new(
+      'GET /rate_limit' => { rate: { remaining: 222 } },
+      'GET /user/29139614' => [404, { message: 'Not Found' }]
+    ).run do
+      assert_raises(Fbe::Error) { Jp.nick_of(29_139_614, loog: Loog::NULL) }
+    end
   end
 end


### PR DESCRIPTION
Two more test files now declare their GitHub routes through `Jp::FakeGithub`
instead of building them out of `stub_request` and `stub_github`. The three
remaining tests in `test/judges/test-who-is-alive.rb` and both tests in
`test/lib/test_nick_of.rb` are moved, which finishes those two files
completely — neither one touches WebMock any more.

The puzzle in `test/fake_github.rb` is rewritten for what is left. Its old
numbers were off: it claimed about a hundred and ten stubs with the heaviest
file at forty one, while `grep` finds over a thousand calls and puts
`test/judges/test-quality-of-service.rb` on top with two hundred and fifty
three. Thirty three files still need moving, so the puzzle stays and carries
the corrected counts.

Nothing in the judges or the library changed, and every assertion is the one
it was before — only the way the HTTP layer is faked is different.

Closes #1923
