### PR TITLE
Don't invent zero comment counts on forbidden or transient errors

### DIFF
--- a/judges/code-was-reviewed/code-was-reviewed.rb
+++ b/judges/code-was-reviewed/code-was-reviewed.rb
@@ -116,7 +116,7 @@ Fbe.consider(
             "[#{$judge}] Access forbidden to issue comments for #{repo}##{f.issue} " \
             "(transient, will retry next cycle): #{e.class}: #{e.message}"
           )
-          0
+          next
         rescue Octokit::TooManyRequests, Octokit::Unauthorized, Octokit::ServerError,
           Net::OpenTimeout, Net::ReadTimeout, SocketError,
           Errno::ECONNRESET, Errno::ETIMEDOUT => e
@@ -124,7 +124,7 @@ Fbe.consider(
             "[#{$judge}] Transient error fetching issue comments for #{repo}##{f.issue} " \
             "(will retry next cycle): #{e.class}: #{e.message}"
           )
-          0
+          next
         end
       n.comments = count
       n.review_comments =
@@ -138,7 +138,7 @@ Fbe.consider(
             "[#{$judge}] Access forbidden to review comments for #{repo}##{f.issue} " \
             "(transient, will retry next cycle): #{e.class}: #{e.message}"
           )
-          0
+          next
         rescue Octokit::TooManyRequests, Octokit::Unauthorized, Octokit::ServerError,
           Net::OpenTimeout, Net::ReadTimeout, SocketError,
           Errno::ECONNRESET, Errno::ETIMEDOUT => e
@@ -146,7 +146,7 @@ Fbe.consider(
             "[#{$judge}] Transient error fetching review comments for #{repo}##{f.issue} " \
             "(will retry next cycle): #{e.class}: #{e.message}"
           )
-          0
+          next
         end
       n.seconds = Integer(review[:submitted_at] - pr[:created_at])
       n.details =

--- a/test/judges/test-code-was-reviewed.rb
+++ b/test/judges/test-code-was-reviewed.rb
@@ -290,9 +290,9 @@ class TestCodeWasReviewed < Jp::Test
     fb.with(_id: 1, what: 'pull-was-closed', repository: 42, issue: 44, where: 'github')
     load_it('code-was-reviewed', fb)
     n = fb.query('(eq what "code-was-reviewed")').each.first
-    refute(n.nil?, 'a code-was-reviewed fact must still exist for the reviewer')
-    refute(
-      n.all_properties.include?('comments'),
+    refute_nil(n, 'a code-was-reviewed fact must still exist for the reviewer')
+    refute_includes(
+      n.all_properties, 'comments',
       'a forbidden issue-comments fetch cannot invent a zero comment count'
     )
   end
@@ -324,9 +324,9 @@ class TestCodeWasReviewed < Jp::Test
     fb.with(_id: 1, what: 'pull-was-closed', repository: 42, issue: 44, where: 'github')
     load_it('code-was-reviewed', fb)
     n = fb.query('(eq what "code-was-reviewed")').each.first
-    refute(n.nil?, 'a code-was-reviewed fact must still exist for the reviewer')
-    refute(
-      n.all_properties.include?('review_comments'),
+    refute_nil(n, 'a code-was-reviewed fact must still exist for the reviewer')
+    refute_includes(
+      n.all_properties, 'review_comments',
       'a forbidden review-comments fetch cannot invent a zero comment count'
     )
   end

--- a/test/judges/test-code-was-reviewed.rb
+++ b/test/judges/test-code-was-reviewed.rb
@@ -264,6 +264,73 @@ class TestCodeWasReviewed < Jp::Test
     )
   end
 
+  def test_leaves_comments_unset_when_issue_comments_forbidden
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repositories/42', body: { id: 42, full_name: 'foo/foo' })
+    stub_github(
+      'https://api.github.com/repos/foo/foo/pulls/44',
+      body: {
+        id: 50, number: 44, user: { id: 421, login: 'user' },
+        created_at: Time.parse('2025-09-01 15:35:30 UTC'), additions: 12, deletions: 5
+      }
+    )
+    stub_github(
+      'https://api.github.com/repos/foo/foo/pulls/44/reviews?per_page=100',
+      body: [
+        { id: 49_111, user: { id: 422, login: 'user2' }, submitted_at: Time.parse('2025-09-02 10:39:20 UTC') }
+      ]
+    )
+    stub_github(
+      'https://api.github.com/repos/foo/foo/issues/44/comments?per_page=100',
+      status: 403,
+      body: { message: 'Resource not accessible by integration' }
+    )
+    fb = Factbase.new
+    fb.with(_id: 1, what: 'pull-was-closed', repository: 42, issue: 44, where: 'github')
+    load_it('code-was-reviewed', fb)
+    n = fb.query('(eq what "code-was-reviewed")').each.first
+    refute(n.nil?, 'a code-was-reviewed fact must still exist for the reviewer')
+    refute(
+      n.all_properties.include?('comments'),
+      'a forbidden issue-comments fetch cannot invent a zero comment count'
+    )
+  end
+
+  def test_leaves_review_comments_unset_when_review_comments_forbidden
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repositories/42', body: { id: 42, full_name: 'foo/foo' })
+    stub_github(
+      'https://api.github.com/repos/foo/foo/pulls/44',
+      body: {
+        id: 50, number: 44, user: { id: 421, login: 'user' },
+        created_at: Time.parse('2025-09-01 15:35:30 UTC'), additions: 12, deletions: 5
+      }
+    )
+    stub_github(
+      'https://api.github.com/repos/foo/foo/pulls/44/reviews?per_page=100',
+      body: [
+        { id: 49_111, user: { id: 422, login: 'user2' }, submitted_at: Time.parse('2025-09-02 10:39:20 UTC') }
+      ]
+    )
+    stub_github('https://api.github.com/repos/foo/foo/issues/44/comments?per_page=100', body: [])
+    stub_github(
+      'https://api.github.com/repos/foo/foo/pulls/44/reviews/49111/comments?per_page=100',
+      status: 403,
+      body: { message: 'Resource not accessible by integration' }
+    )
+    fb = Factbase.new
+    fb.with(_id: 1, what: 'pull-was-closed', repository: 42, issue: 44, where: 'github')
+    load_it('code-was-reviewed', fb)
+    n = fb.query('(eq what "code-was-reviewed")').each.first
+    refute(n.nil?, 'a code-was-reviewed fact must still exist for the reviewer')
+    refute(
+      n.all_properties.include?('review_comments'),
+      'a forbidden review-comments fetch cannot invent a zero comment count'
+    )
+  end
+
   def test_dont_crash_when_pull_has_no_hoc
     WebMock.disable_net_connect!
     rate_limit_up


### PR DESCRIPTION
The two comment counters in \`code-was-reviewed.rb\` turned every rescued error into a stored zero: \`Fbe.octo.issue_comments\` and \`Fbe.octo.pull_request_review_comments\` both fell back to \`0\` on \`Forbidden\` and on transient errors (rate limits, timeouts, server errors), and that zero was then written onto the fact as if it were the real count.

Since nothing marked the fact as incomplete afterwards, one throttled or briefly forbidden run was enough to record a review as having zero comments for good, and that number feeds the reward math downstream.

This changes those two rescue arms to \`next\` out of the transaction instead, the same way the outer chains already do for repo/PR/review lookups, so a forbidden or transient failure leaves the field unset rather than writing a fabricated zero. A permanent \`NotFound\`/\`Deprecated\` on the comments endpoint is left as the one case where zero is honest, and keeps its \`0\`.

Added two tests covering forbidden responses on the issue-comments and review-comments endpoints, asserting the fields are left unset.

Closes #1942