### PR TITLE
fix(#1945): commit f.reviews only after reviews are actually recorded

### DIFF
--- a/judges/code-was-reviewed/code-was-reviewed.rb
+++ b/judges/code-was-reviewed/code-was-reviewed.rb
@@ -88,8 +88,10 @@ Fbe.consider(
       )
       next
     end
-  f.reviews = reviews.count
-  next if pr.dig(:user, :id).nil?
+  if pr.dig(:user, :id).nil?
+    f.reviews = reviews.count
+    next
+  end
   count = nil
   reviews.each do |review|
     next if review.dig(:user, :id).nil?
@@ -163,6 +165,7 @@ Fbe.consider(
       )
     end
   end
+  f.reviews = reviews.count
 end
 
 Fbe.octo.print_trace!

--- a/judges/code-was-reviewed/code-was-reviewed.rb
+++ b/judges/code-was-reviewed/code-was-reviewed.rb
@@ -89,8 +89,10 @@ Fbe.consider(
       next
     end
   f.reviews = reviews.count
+  next if pr.dig(:user, :id).nil?
   count = nil
   reviews.each do |review|
+    next if review.dig(:user, :id).nil?
     next if review.dig(:user, :id) == pr.dig(:user, :id)
     Fbe.fb.txn do |fbt|
       n =

--- a/test/judges/test-code-was-reviewed.rb
+++ b/test/judges/test-code-was-reviewed.rb
@@ -282,24 +282,17 @@ class TestCodeWasReviewed < Jp::Test
         { id: 49_112, user: { id: 422, login: 'user2' }, submitted_at: Time.parse('2025-09-02 10:39:20 UTC') }
       ]
     )
-    stub_github(
-      'https://api.github.com/repos/foo/foo/issues/44/comments?per_page=100', body: []
-    )
-    stub_github(
-      'https://api.github.com/repos/foo/foo/pulls/44/reviews/49112/comments?per_page=100', body: []
-    )
+    stub_github('https://api.github.com/repos/foo/foo/issues/44/comments?per_page=100', body: [])
+    stub_github('https://api.github.com/repos/foo/foo/pulls/44/reviews/49112/comments?per_page=100', body: [])
     stub_github('https://api.github.com/user/421', body: { id: 421, login: 'user1' })
     stub_github('https://api.github.com/user/422', body: { id: 422, login: 'user2' })
     fb = Factbase.new
     fb.with(_id: 1, what: 'pull-was-closed', repository: 42, issue: 44, where: 'github')
     load_it('code-was-reviewed', fb)
-    assert(
-      fb.one?(what: 'code-was-reviewed', repository: 42, issue: 44, who: 422),
-      'a review left by a live account must be credited even when a deleted account reviewed too'
-    )
-    refute(
-      fb.one?(what: 'code-was-reviewed', repository: 42, issue: 44, who: nil),
-      'a review left by a deleted account cannot produce a fact'
+    assert_equal(
+      [422],
+      fb.picks(what: 'code-was-reviewed', repository: 42, issue: 44).map(&:who),
+      'a review left by a deleted account produced a fact or the live reviewer was not credited'
     )
   end
 

--- a/test/judges/test-code-was-reviewed.rb
+++ b/test/judges/test-code-was-reviewed.rb
@@ -296,6 +296,7 @@ class TestCodeWasReviewed < Jp::Test
       'The fact of a vanished repository must be marked stale instead of aborting the judge'
     )
   end
+
   def test_does_not_record_a_review_from_a_deleted_account
     WebMock.disable_net_connect!
     rate_limit_up

--- a/test/judges/test-code-was-reviewed.rb
+++ b/test/judges/test-code-was-reviewed.rb
@@ -264,6 +264,71 @@ class TestCodeWasReviewed < Jp::Test
     )
   end
 
+  def test_skips_a_review_by_a_deleted_account
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repositories/42', body: { id: 42, full_name: 'foo/foo' })
+    stub_github(
+      'https://api.github.com/repos/foo/foo/pulls/44',
+      body: {
+        id: 50, number: 44, user: { id: 421, login: 'user' },
+        created_at: Time.parse('2025-09-01 15:35:30 UTC'), additions: 12, deletions: 5
+      }
+    )
+    stub_github(
+      'https://api.github.com/repos/foo/foo/pulls/44/reviews?per_page=100',
+      body: [
+        { id: 49_111, user: nil, submitted_at: Time.parse('2025-09-02 10:39:20 UTC') },
+        { id: 49_112, user: { id: 422, login: 'user2' }, submitted_at: Time.parse('2025-09-02 10:39:20 UTC') }
+      ]
+    )
+    stub_github(
+      'https://api.github.com/repos/foo/foo/issues/44/comments?per_page=100', body: []
+    )
+    stub_github(
+      'https://api.github.com/repos/foo/foo/pulls/44/reviews/49112/comments?per_page=100', body: []
+    )
+    stub_github('https://api.github.com/user/421', body: { id: 421, login: 'user1' })
+    stub_github('https://api.github.com/user/422', body: { id: 422, login: 'user2' })
+    fb = Factbase.new
+    fb.with(_id: 1, what: 'pull-was-closed', repository: 42, issue: 44, where: 'github')
+    load_it('code-was-reviewed', fb)
+    assert(
+      fb.one?(what: 'code-was-reviewed', repository: 42, issue: 44, who: 422),
+      'a review left by a live account must be credited even when a deleted account reviewed too'
+    )
+    refute(
+      fb.one?(what: 'code-was-reviewed', repository: 42, issue: 44, who: nil),
+      'a review left by a deleted account cannot produce a fact'
+    )
+  end
+
+  def test_skips_reviews_of_a_pull_authored_by_a_deleted_account
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repositories/42', body: { id: 42, full_name: 'foo/foo' })
+    stub_github(
+      'https://api.github.com/repos/foo/foo/pulls/44',
+      body: {
+        id: 50, number: 44, user: nil,
+        created_at: Time.parse('2025-09-01 15:35:30 UTC'), additions: 12, deletions: 5
+      }
+    )
+    stub_github(
+      'https://api.github.com/repos/foo/foo/pulls/44/reviews?per_page=100',
+      body: [
+        { id: 49_111, user: { id: 422, login: 'user2' }, submitted_at: Time.parse('2025-09-02 10:39:20 UTC') }
+      ]
+    )
+    fb = Factbase.new
+    fb.with(_id: 1, what: 'pull-was-closed', repository: 42, issue: 44, where: 'github')
+    load_it('code-was-reviewed', fb)
+    refute(
+      fb.one?(what: 'code-was-reviewed', repository: 42, issue: 44),
+      'a pull authored by a deleted account cannot credit its reviewers'
+    )
+  end
+
   def test_dont_crash_when_pull_has_no_hoc
     WebMock.disable_net_connect!
     rate_limit_up


### PR DESCRIPTION
## Summary
- `f.reviews = reviews.count` was set before the loop that actually records the review facts and outside the `Fbe.fb.txn` transaction that wraps each review's writes.
- If anything in that loop raised (e.g. `Fbe.who` going out to `user_name_by_id` for a deleted account, or a rate limit), the transaction rolled back its own writes, but `f.reviews` had already been committed — permanently marking the pull as "reviewed" with `(absent reviews)` no longer true, so it's never retried.
- `f.reviews` is now only set once the loop over reviews has completed, or immediately when the PR's author is unknown (since no review facts will be recorded in that branch either).

Fixes #1945