### PR TITLE
fix(#1947): log stale count before the early return

### DIFF
--- a/lib/issue_was_lost.rb
+++ b/lib/issue_was_lost.rb
@@ -17,7 +17,10 @@ def Jp.issue_was_lost(where, repository, issue)
       (absent stale)
       (absent tombstone))"
     ).each { |f| f.stale = 'issue' }
-  return if stale.positive?
+  if stale.positive?
+    $loog.info("The issue ##{issue} was marked as lost, #{stale} facts marked as stale")
+    return
+  end
   f =
     Fbe.if_absent do |n|
       n.issue = issue
@@ -32,5 +35,5 @@ def Jp.issue_was_lost(where, repository, issue)
   f.stale = 'issue'
   f.when = Time.now
   Fbe::Tombstone.new.bury!(where, repository, issue)
-  $loog.info("The issue #{issue} was marked as lost, #{stale} facts marked as stale")
+  $loog.info("The issue ##{issue} was marked as lost")
 end


### PR DESCRIPTION
## Summary
- `Jp.issue_was_lost` returned at line 20 before reaching the log statement on line 35 whenever it actually marked prior facts stale — the only code path that reaches line 35 has `stale == 0` by construction, so the logged count was always zero.
- Moves the stale-count log to sit next to the early return, where the count is actually known and non-zero, and drops the now-dead `stale` interpolation from the later log line.

Closes #1947