### PR TITLE
Treat Octokit::Unauthorized as a config error, not transient

### DIFF
--- a/judges/code-was-reviewed/code-was-reviewed.rb
+++ b/judges/code-was-reviewed/code-was-reviewed.rb
@@ -57,7 +57,10 @@ Fbe.consider(
         "(transient, will retry next cycle): #{e.class}: #{e.message}"
       )
       next
-    rescue Octokit::TooManyRequests, Octokit::Unauthorized, Octokit::ServerError,
+    rescue Octokit::Unauthorized => e
+      $loog.error("[#{$judge}] Not authorized to fetch pull ##{f.issue} in #{repo}: #{e.class}: #{e.message}")
+      next
+    rescue Octokit::TooManyRequests, Octokit::ServerError,
       Net::OpenTimeout, Net::ReadTimeout, SocketError,
       Errno::ECONNRESET, Errno::ETIMEDOUT => e
       $loog.warn(
@@ -79,7 +82,12 @@ Fbe.consider(
         "(transient, will retry next cycle): #{e.class}: #{e.message}"
       )
       next
-    rescue Octokit::TooManyRequests, Octokit::Unauthorized, Octokit::ServerError,
+    rescue Octokit::Unauthorized => e
+      $loog.error(
+        "[#{$judge}] Not authorized to fetch reviews for pull ##{f.issue} in #{repo}: #{e.class}: #{e.message}"
+      )
+      next
+    rescue Octokit::TooManyRequests, Octokit::ServerError,
       Net::OpenTimeout, Net::ReadTimeout, SocketError,
       Errno::ECONNRESET, Errno::ETIMEDOUT => e
       $loog.warn(
@@ -117,7 +125,12 @@ Fbe.consider(
             "(transient, will retry next cycle): #{e.class}: #{e.message}"
           )
           0
-        rescue Octokit::TooManyRequests, Octokit::Unauthorized, Octokit::ServerError,
+        rescue Octokit::Unauthorized => e
+          $loog.error(
+            "[#{$judge}] Not authorized to fetch issue comments for #{repo}##{f.issue}: #{e.class}: #{e.message}"
+          )
+          0
+        rescue Octokit::TooManyRequests, Octokit::ServerError,
           Net::OpenTimeout, Net::ReadTimeout, SocketError,
           Errno::ECONNRESET, Errno::ETIMEDOUT => e
           $loog.warn(
@@ -139,7 +152,12 @@ Fbe.consider(
             "(transient, will retry next cycle): #{e.class}: #{e.message}"
           )
           0
-        rescue Octokit::TooManyRequests, Octokit::Unauthorized, Octokit::ServerError,
+        rescue Octokit::Unauthorized => e
+          $loog.error(
+            "[#{$judge}] Not authorized to fetch review comments for #{repo}##{f.issue}: #{e.class}: #{e.message}"
+          )
+          0
+        rescue Octokit::TooManyRequests, Octokit::ServerError,
           Net::OpenTimeout, Net::ReadTimeout, SocketError,
           Errno::ECONNRESET, Errno::ETIMEDOUT => e
           $loog.warn(

--- a/judges/pull-was-merged/pull-was-merged.rb
+++ b/judges/pull-was-merged/pull-was-merged.rb
@@ -76,7 +76,10 @@ Fbe.iterate do
           "(transient, will retry next cycle): #{e.class}: #{e.message}"
         )
         next issue
-      rescue Octokit::TooManyRequests, Octokit::Unauthorized, Octokit::ServerError,
+      rescue Octokit::Unauthorized => e
+        $loog.error("[#{$judge}] Not authorized to fetch pull ##{issue} in #{repo}: #{e.class}: #{e.message}")
+        next issue
+      rescue Octokit::TooManyRequests, Octokit::ServerError,
         Net::OpenTimeout, Net::ReadTimeout, SocketError,
         Errno::ECONNRESET, Errno::ETIMEDOUT => e
         $loog.warn(
@@ -102,7 +105,10 @@ Fbe.iterate do
           "(transient, will retry next cycle): #{e.class}: #{e.message}"
         )
         next issue
-      rescue Octokit::TooManyRequests, Octokit::Unauthorized, Octokit::ServerError,
+      rescue Octokit::Unauthorized => e
+        $loog.error("[#{$judge}] Not authorized to fetch issue ##{issue} in #{repo}: #{e.class}: #{e.message}")
+        next issue
+      rescue Octokit::TooManyRequests, Octokit::ServerError,
         Net::OpenTimeout, Net::ReadTimeout, SocketError,
         Errno::ECONNRESET, Errno::ETIMEDOUT => e
         $loog.warn(
@@ -124,7 +130,12 @@ Fbe.iterate do
           "(transient, will retry next cycle): #{e.class}: #{e.message}"
         )
         next issue
-      rescue Octokit::TooManyRequests, Octokit::Unauthorized, Octokit::ServerError,
+      rescue Octokit::Unauthorized => e
+        $loog.error(
+          "[#{$judge}] Not authorized to fetch reviews of pull ##{issue} in #{repo}: #{e.class}: #{e.message}"
+        )
+        next issue
+      rescue Octokit::TooManyRequests, Octokit::ServerError,
         Net::OpenTimeout, Net::ReadTimeout, SocketError,
         Errno::ECONNRESET, Errno::ETIMEDOUT => e
         $loog.warn(


### PR DESCRIPTION
Octokit::Unauthorized sat in the same rescue arm as TooManyRequests, ServerError and network timeouts in code-was-reviewed.rb and pull-was-merged.rb. Each of those arms logged a warning promising a retry next cycle, but a 401 means the token is missing, expired or revoked — retrying changes nothing, and the log kept hiding a broken credential behind messages meant for slow networks.

This splits Octokit::Unauthorized into its own rescue arm in both files, logged as an error instead of a warning, so a bad token is visible for what it is rather than looking like transient weather.

Closes #1949