### PR TITLE
Count reviews after the self-review filter in code-was-reviewed

### DIFF
--- a/judges/code-was-reviewed/code-was-reviewed.rb
+++ b/judges/code-was-reviewed/code-was-reviewed.rb
@@ -88,7 +88,7 @@ Fbe.consider(
       )
       next
     end
-  f.reviews = reviews.count
+  f.reviews = reviews.count { |review| review.dig(:user, :id) != pr.dig(:user, :id) }
   count = nil
   reviews.each do |review|
     next if review.dig(:user, :id) == pr.dig(:user, :id)

--- a/test/judges/test-code-was-reviewed.rb
+++ b/test/judges/test-code-was-reviewed.rb
@@ -99,6 +99,37 @@ class TestCodeWasReviewed < Jp::Test
     assert_requested(stub, times: 1)
   end
 
+  def test_reviews_count_excludes_self_reviews
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repositories/42', body: { id: 42, full_name: 'foo/foo' })
+    stub_github(
+      'https://api.github.com/repos/foo/foo/pulls/70',
+      body: {
+        id: 70, number: 70, user: { id: 421, login: 'user' },
+        created_at: Time.parse('2025-09-01 15:35:30 UTC'), additions: 1, deletions: 1
+      }
+    )
+    stub_github(
+      'https://api.github.com/repos/foo/foo/pulls/70/reviews?per_page=100',
+      body: [
+        { id: 71_001, user: { id: 421, login: 'user' }, submitted_at: Time.parse('2025-09-02 09:00:00 UTC') },
+        { id: 71_002, user: { id: 422, login: 'user2' }, submitted_at: Time.parse('2025-09-02 10:00:00 UTC') }
+      ]
+    )
+    stub_github('https://api.github.com/repos/foo/foo/issues/70/comments?per_page=100', body: [])
+    stub_github('https://api.github.com/repos/foo/foo/pulls/70/reviews/71002/comments?per_page=100', body: [])
+    stub_github('https://api.github.com/user/421', body: { id: 421, login: 'user1' })
+    stub_github('https://api.github.com/user/422', body: { id: 422, login: 'user2' })
+    fb = Factbase.new
+    fb.with(_id: 1, what: 'pull-was-closed', repository: 42, issue: 70, where: 'github')
+    load_it('code-was-reviewed', fb)
+    assert(
+      fb.one?(what: 'pull-was-closed', repository: 42, issue: 70, where: 'github', reviews: 1),
+      'a self-review must not be counted in the reviews property'
+    )
+  end
+
   def test_marks_a_pull_without_reviews_as_checked
     WebMock.disable_net_connect!
     rate_limit_up


### PR DESCRIPTION
'f.reviews' stored the raw length of what GitHub returned before the loop below it dropped every review whose author was the pull's own author. A pull reviewed only by its author was recorded with reviews > 0 and no code-was-reviewed fact at all, so anything reading 'reviews' as an answer to "was this reviewed by somebody else" got the wrong answer.

Counting after the self-review filter makes the property match the facts the judge actually creates, and keeps its role as the idempotence marker intact.

Closes #1950