### PR TITLE
#1948: bury the issue before the early return

### DIFF
--- a/lib/issue_was_lost.rb
+++ b/lib/issue_was_lost.rb
@@ -17,6 +17,7 @@ def Jp.issue_was_lost(where, repository, issue)
       (absent stale)
       (absent tombstone))"
     ).each { |f| f.stale = 'issue' }
+  Fbe::Tombstone.new.bury!(where, repository, issue)
   return if stale.positive?
   f =
     Fbe.if_absent do |n|
@@ -31,6 +32,5 @@ def Jp.issue_was_lost(where, repository, issue)
   end
   f.stale = 'issue'
   f.when = Time.now
-  Fbe::Tombstone.new.bury!(where, repository, issue)
   $loog.info("The issue #{issue} was marked as lost, #{stale} facts marked as stale")
 end

--- a/test/judges/test-issue-was-assigned.rb
+++ b/test/judges/test-issue-was-assigned.rb
@@ -50,9 +50,10 @@ class TestIssueWasAssigned < Jp::Test
     fb.with(_id: 1, what: 'issue-was-opened', repository: 42, issue: 44, where: 'github')
       .with(_id: 2, what: 'issue-was-opened', repository: 42, issue: 45, where: 'github')
     load_it('issue-was-assigned', fb)
-    assert_equal(2, fb.all.size)
+    assert_equal(3, fb.all.size)
     assert_equal(2, fb.picks(what: 'issue-was-opened').size)
     assert_equal(0, fb.picks(what: 'issue-was-assigned').size)
+    assert_equal(1, fb.picks(what: 'tombstone').size)
   end
 
   def test_with_duplicate_assigned_event

--- a/test/lib/test_issue_was_lost.rb
+++ b/test/lib/test_issue_was_lost.rb
@@ -48,6 +48,23 @@ class TestIssueWasLost < Minitest::Test
     end
   end
 
+  def test_buries_issue_that_had_a_prior_fact
+    fb = Factbase.new
+    f = fb.insert
+    f.where = 'github'
+    f.repository = 42
+    f.issue = 7
+    f.what = 'pull-was-opened'
+    Fbe.stub(:fb, fb) do
+      $loog = Loog::NULL
+      Jp.issue_was_lost('github', 42, 7)
+      assert(
+        Fbe::Tombstone.new(fb: fb).has?('github', 42, 7),
+        'an issue whose prior fact was marked stale must be buried too'
+      )
+    end
+  end
+
   def test_buries_issue_in_the_tombstone
     fb = Factbase.new
     Fbe.stub(:fb, fb) do


### PR DESCRIPTION
The burial sat after `return if stale.positive?`, and every caller hands over
the coordinates of a fact that the query above matches, so `stale` was at
least one and the tombstone never saw the issue. A pull deleted on GitHub was
marked stale and then fetched again by every judge guarded by
`(absent tombstone)`.

The burial happens before that return now. The new test starts from a
factbase that already holds a fact for the issue, which is the path the old
tests never covered; it fails on master as it is.

Closes #1948
