### PR TITLE
Remove dead stubs from test_skips_a_pull_that_was_already_checked

### DIFF
--- a/test/judges/test-code-was-reviewed.rb
+++ b/test/judges/test-code-was-reviewed.rb
@@ -123,19 +123,21 @@ class TestCodeWasReviewed < Jp::Test
   def test_skips_a_pull_that_was_already_checked
     WebMock.disable_net_connect!
     rate_limit_up
-    stub_github('https://api.github.com/repositories/42', body: { id: 42, full_name: 'foo/foo' })
-    stub_github(
-      'https://api.github.com/repos/foo/foo/pulls/45',
-      body: {
-        id: 45, number: 45, user: { id: 421, login: 'user' },
-        created_at: Time.parse('2025-09-02 17:05:30 UTC'), additions: 2, deletions: 8
-      }
-    )
     stub = stub_github('https://api.github.com/repos/foo/foo/pulls/45/reviews?per_page=100', body: [])
     fb = Factbase.new
     fb.with(_id: 1, what: 'pull-was-merged', repository: 42, issue: 45, where: 'github', reviews: 0)
     load_it('code-was-reviewed', fb)
     assert_not_requested(stub, message: 'a pull that was checked already cannot be fetched again')
+  end
+
+  def test_skips_a_pull_that_is_already_stale
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub = stub_github('https://api.github.com/repos/foo/foo/pulls/45/reviews?per_page=100', body: [])
+    fb = Factbase.new
+    fb.with(_id: 1, what: 'pull-was-merged', repository: 42, issue: 45, where: 'github', stale: 'repository')
+    load_it('code-was-reviewed', fb)
+    assert_not_requested(stub, message: 'a pull already marked stale cannot be fetched again')
   end
 
   def test_rescues_not_found_on_pull_request_lookup


### PR DESCRIPTION
The fact set up in this test carries reviews: 0, and the judge's query requires (absent reviews), so the block that would call repo_name_by_id and pull_request never runs for it. That left the stubs for repositories/42 and pulls/45 as dead fixture — they suggested the test exercised the lookup path when the only assertion is about the reviews endpoint never being hit.

Removed both unused stubs so the test only sets up what it actually exercises. Also added a sibling test, test_skips_a_pull_that_is_already_stale, covering the same skip behavior for a pull already marked stale, since the judge's query guards on absent stale the same way it guards on absent reviews.

Closes #1953

@yegor256 please take a look