### PR TITLE
#1922: ask for uniqueness after the fact is chosen

### DIFF
--- a/judges/eliminate-ghosts/eliminate-ghosts.rb
+++ b/judges/eliminate-ghosts/eliminate-ghosts.rb
@@ -52,7 +52,7 @@ Fbe.fb.txn do |fbt|
       f.stale = 'who'
     end
   end
-  fbt.query('(and (eq where "github") (exists who) (unique who) (eq stale "who"))').each do |f|
+  fbt.query('(and (eq where "github") (exists who) (eq stale "who") (unique who))').each do |f|
     next if good.include?(f.who)
     fbt.query("(and (eq who #{f.who}) (not (eq stale 'who')) (eq where 'github'))").each do |ff|
       ff.stale = 'who'

--- a/judges/eliminate-ghosts/scan-users.yml
+++ b/judges/eliminate-ghosts/scan-users.yml
@@ -39,7 +39,7 @@ input:
     stale: who
 expected:
   - /fb[count(f)=8]
-  - /fb/f[_id=7 and stale='who']
+  - /fb/f[_id=7 and stale/v='who']
   - /fb/f[_id=1 and who=526301 and not(stale)]
   - /fb/f[_id=2 and who and stale]
   - /fb/f[_id=3 and who=404001 and not(stale)]

--- a/judges/eliminate-ghosts/scan-users.yml
+++ b/judges/eliminate-ghosts/scan-users.yml
@@ -27,8 +27,19 @@ input:
     _id: 6
     where: github
     who: 404_002
+  -
+    _id: 7
+    where: github
+    who: 777_777
+    stale: repository
+  -
+    _id: 8
+    where: github
+    who: 777_777
+    stale: who
 expected:
-  - /fb[count(f)=6]
+  - /fb[count(f)=8]
+  - /fb/f[_id=7 and stale='who']
   - /fb/f[_id=1 and who=526301 and not(stale)]
   - /fb/f[_id=2 and who and stale]
   - /fb/f[_id=3 and who=404001 and not(stale)]


### PR DESCRIPTION
`(unique who)` sat before `(eq stale "who")`, and `unique` remembers the value
it saw even when a later operand rejects the fact, so the first stored fact of
a user took that user's slot. When that fact was not the stale one, the query
matched nothing and the loop did no work.

With two facts for one user, the first `stale='repository'` and the second
`stale='who'`:

```
(and (eq where "github") (exists who) (unique who) (eq stale "who"))  -> []
(and (eq where "github") (exists who) (eq stale "who") (unique who))  -> [8]
```

and running the loop body over the same two facts leaves the first one as
`["repository"]` with the old order and `["repository", "who"]` with the new
one.

The pack gained that pair, under a user id the fake never looks up, so only
the propagation loop touches them.

`fix-wrong-closures.rb:21` has the same shape with `(unique issue)`. Left
alone here, one issue per pull request.

Closes #1922
