### PR TITLE
Move two judge tests onto the fake GitHub server

### DIFF
--- a/test/fake_github.rb
+++ b/test/fake_github.rb
@@ -9,13 +9,13 @@ require 'socket'
 require_relative '../lib/jp'
 
 # rubocop:disable Elegant/NoComments
-# @todo #1923:60min Move the rest of the tests onto this server.
-#  Thirty three files under `test/` still build their GitHub with
-#  `stub_request` and `stub_github`, over a thousand stubs in all, the
-#  heaviest being `test/judges/test-quality-of-service.rb` with two
-#  hundred and fifty three. Each of them should declare its routes through
-#  `Jp::FakeGithub` instead, one file at a time, so that a reviewer can
-#  follow every step. When the last one is moved, `stub_github` and
+# @todo #1960:60min Move the rest of the tests onto this server.
+#  Thirty one files under `test/` still build their GitHub with
+#  `stub_request` and `stub_github`, one thousand one hundred and ninety one
+#  stubs in all, the heaviest being `test/judges/test-quality-of-service.rb`
+#  with two hundred and fifty three. Each of them should declare its routes
+#  through `Jp::FakeGithub` instead, one file at a time, so that a reviewer
+#  can follow every step. When the last one is moved, `stub_github` and
 #  `rate_limit_up` go from `test/test__helper.rb`, the `webmock` gem goes
 #  from the `Gemfile`, and `require 'webmock/minitest'` goes with it.
 # rubocop:enable Elegant/NoComments

--- a/test/judges/test-fix-missing-comments.rb
+++ b/test/judges/test-fix-missing-comments.rb
@@ -4,40 +4,41 @@
 # SPDX-License-Identifier: MIT
 
 require 'factbase'
+require_relative '../fake_github'
 require_relative '../test__helper'
 
 class TestFixMissingComments < Jp::Test
   using SmartFactbase
 
   def test_rescues_forbidden_on_pull_lookup
-    WebMock.disable_net_connect!
-    rate_limit_up
-    stub_github('https://api.github.com/repos/foo/foo', body: { id: 42, full_name: 'foo/foo' })
-    stub_github('https://api.github.com/repositories/42', body: { id: 42, full_name: 'foo/foo' })
-    stub_github(
-      'https://api.github.com/repos/foo/foo/pulls/44',
-      status: 403,
-      body: { message: 'Resource not accessible by integration' }
-    )
     fb = Factbase.new
     fb.with(_id: 1, what: 'pull-was-merged', repository: 42, issue: 44, where: 'github')
-    load_it('fix-missing-comments', fb)
-    f = fb.query('(eq issue 44)').each.first
-    refute_nil(f)
-    assert_nil(f['stale'], '403 must retry without marking stale')
-    assert_nil(f['comments'], '403 must leave comments absent until retry')
+    Jp::FakeGithub.new(
+      'GET /rate_limit' => { resources: { search: { remaining: 30, limit: 30 } }, rate: { remaining: 1000 } },
+      'GET /repos/foo/foo' => { id: 42, full_name: 'foo/foo' },
+      'GET /repositories/42' => { id: 42, full_name: 'foo/foo' },
+      'GET /repos/foo/foo/pulls/44' => [403, { message: 'Resource not accessible by integration' }]
+    ).run do
+      load_it('fix-missing-comments', fb)
+    end
+    assert_equal(
+      %w[_id issue repository what where], fb.pick(issue: 44).all_properties.sort,
+      'the fact changed after 403, while the pull request was never read and the next cycle must retry'
+    )
   end
 
   def test_rescues_not_found_on_repo_name_lookup
-    WebMock.disable_net_connect!
-    rate_limit_up
-    stub_github('https://api.github.com/repositories/42', status: 404, body: { message: 'Not Found' })
     fb = Factbase.new
     fb.with(_id: 1, what: 'pull-was-merged', repository: 42, issue: 44, where: 'github')
-    load_it('fix-missing-comments', fb)
+    Jp::FakeGithub.new(
+      'GET /rate_limit' => { resources: { search: { remaining: 30, limit: 30 } }, rate: { remaining: 1000 } },
+      'GET /repositories/42' => [404, { message: 'Not Found' }]
+    ).run do
+      load_it('fix-missing-comments', fb)
+    end
     assert(
       fb.one?(what: 'pull-was-merged', repository: 42, stale: 'repository'),
-      'The fact of a vanished repository must be marked stale instead of aborting the judge'
+      'the fact of a vanished repository is not stale, while the judge must mark it instead of aborting'
     )
   end
 end

--- a/test/judges/test-issue-was-opened.rb
+++ b/test/judges/test-issue-was-opened.rb
@@ -4,39 +4,41 @@
 # SPDX-License-Identifier: MIT
 
 require 'factbase'
+require_relative '../fake_github'
 require_relative '../test__helper'
 
 class TestIssueWasOpened < Jp::Test
   using SmartFactbase
 
   def test_rescues_forbidden_on_issue_lookup
-    WebMock.disable_net_connect!
-    rate_limit_up
-    stub_github('https://api.github.com/repos/foo/foo', body: { id: 42, full_name: 'foo/foo' })
-    stub_github('https://api.github.com/repositories/42', body: { id: 42, full_name: 'foo/foo' })
-    stub_github(
-      'https://api.github.com/repos/foo/foo/issues/44',
-      status: 403,
-      body: { message: 'Resource not accessible by integration' }
-    )
     fb = Factbase.new
     fb.with(_id: 1, what: 'issue-was-closed', repository: 42, issue: 44, where: 'github')
-    load_it('issue-was-opened', fb)
-    f = fb.query('(eq issue 44)').each.first
-    refute_nil(f)
-    assert_nil(f['stale'], '403 is transient — fact must NOT be marked stale; next cycle will retry the lookup')
+    Jp::FakeGithub.new(
+      'GET /rate_limit' => { resources: { search: { remaining: 30, limit: 30 } }, rate: { remaining: 1000 } },
+      'GET /repos/foo/foo' => { id: 42, full_name: 'foo/foo' },
+      'GET /repositories/42' => { id: 42, full_name: 'foo/foo' },
+      'GET /repos/foo/foo/issues/44' => [403, { message: 'Resource not accessible by integration' }]
+    ).run do
+      load_it('issue-was-opened', fb)
+    end
+    assert_nil(
+      fb.pick(issue: 44)['stale'],
+      'the fact is stale after a transient 403, while the next cycle must retry the lookup'
+    )
   end
 
   def test_rescues_not_found_on_repo_name_lookup
-    WebMock.disable_net_connect!
-    rate_limit_up
-    stub_github('https://api.github.com/repositories/42', status: 404, body: { message: 'Not Found' })
     fb = Factbase.new
     fb.with(_id: 1, what: 'issue-was-closed', repository: 42, issue: 44, where: 'github')
-    load_it('issue-was-opened', fb)
-    assert_empty(
-      fb.query("(eq what 'issue-was-opened')").each.to_a,
-      'A vanished repository must produce no facts and must not abort the judge'
+    Jp::FakeGithub.new(
+      'GET /rate_limit' => { resources: { search: { remaining: 30, limit: 30 } }, rate: { remaining: 1000 } },
+      'GET /repositories/42' => [404, { message: 'Not Found' }]
+    ).run do
+      load_it('issue-was-opened', fb)
+    end
+    assert(
+      fb.none?(what: 'issue-was-opened'),
+      'a vanished repository produced facts, while the judge must make none and not abort'
     )
   end
 end


### PR DESCRIPTION
Two more judge tests now declare their GitHub routes through `Jp::FakeGithub` instead of building them with `stub_request` and `stub_github`: `test-issue-was-opened.rb` and `test-fix-missing-comments.rb`. Each of them talks to a real socket on an ephemeral port, so the test says which endpoints exist rather than which HTTP calls are permitted, and a broken route makes the test fail instead of silently falling through to WebMock.

While moving them, the assertions collapsed to one per test, as the rules ask. The forbidden-pull case now compares the whole property list of the fact after a 403, which covers both the absent `stale` and the absent `comments` in a single claim.

The puzzle stays, with its numbers refreshed: thirty one files and one thousand one hundred and ninety one stubs are still on WebMock, the heaviest being `test-quality-of-service.rb`. The migration keeps going one file at a time until `stub_github`, `rate_limit_up` and the `webmock` gem can go.

Closes #1960
