### PR TITLE
Rescue Fbe::Error in total_commits and skip repos without a default branch

### DIFF
--- a/judges/dimensions-of-terrain/total_commits.rb
+++ b/judges/dimensions-of-terrain/total_commits.rb
@@ -23,6 +23,7 @@ def total_commits(_fact)
       next
     end
     next if json[:size].nil? || json[:size].zero?
+    next if json[:default_branch].nil?
     repos << [*repo.split('/'), json[:default_branch]]
   rescue Octokit::NotFound, Octokit::Deprecated => e
     $loog.info("Repository not found for #{repo}: #{e.message}")
@@ -38,11 +39,8 @@ def total_commits(_fact)
     total_commits:
     begin
       repos.empty? ? 0 : Fbe.github_graph.total_commits(repos:).sum { _1['total_commits'] }
-    rescue GraphQL::Client::Error, Octokit::NotFound, Octokit::Deprecated => e
+    rescue GraphQL::Client::Error, Fbe::Error => e
       $loog.info("Can't count total commits: #{e.message}")
-      0
-    rescue Octokit::Forbidden => e
-      $loog.warn("[#{$judge}] Can't count total commits (transient, will retry next cycle): #{e.class}: #{e.message}")
       0
     rescue Net::OpenTimeout, Net::ReadTimeout, SocketError, Errno::ECONNRESET, Errno::ETIMEDOUT => e
       $loog.warn("[#{$judge}] Network error counting commits: #{e.message}")

--- a/test/judges/test-dimensions-of-terrain.rb
+++ b/test/judges/test-dimensions-of-terrain.rb
@@ -468,6 +468,61 @@ class TestDimensionsOfTerrain < Jp::Test
     end
   end
 
+  def test_total_commits_skips_repo_with_missing_default_branch
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github(
+      'https://api.github.com/repos/foo/nobranch', body: {
+        name: 'nobranch', full_name: 'foo/nobranch', size: 1,
+        stargazers_count: 0, forks: 0, default_branch: nil, archived: false
+      }
+    )
+    stub_github('https://api.github.com/repos/foo/nobranch/releases?per_page=100', body: [])
+    stub_github(
+      'https://api.github.com/repos/foo/nobranch/git/trees/?recursive=true',
+      status: 404, body: { message: 'Not Found' }
+    )
+    stub_github('https://api.github.com/repos/foo/nobranch/contributors?per_page=100', body: [])
+    stub_github(
+      'https://api.github.com/search/commits?per_page=100&q=repo:foo/nobranch%20author-date:%3E2024-08-30',
+      body: { total_count: 0, incomplete_results: false, items: [] }
+    )
+    fb = Factbase.new
+    Fbe.stub(:github_graph, Fbe::Graph::Fake.new) do
+      Time.stub(:now, Time.parse('2024-09-29 21:00:00 UTC')) do
+        load_it('dimensions-of-terrain', fb, Judges::Options.new({ 'repositories' => 'foo/nobranch' }))
+        f = fb.query("(eq what 'dimensions-of-terrain')").each.first
+        refute_nil(f)
+        assert_equal(0, f.total_commits)
+      end
+    end
+  end
+
+  def test_total_commits_rescues_fbe_error_from_graph
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github(
+      'https://api.github.com/repos/foo/bad', body: {
+        name: 'bad', full_name: 'foo/bad', size: 1,
+        stargazers_count: 0, forks: 0, default_branch: 'master', archived: false
+      }
+    )
+    $judge = 'dimensions-of-terrain'
+    $global = {}
+    $local = {}
+    $loog = Loog::NULL
+    $options = Judges::Options.new({ 'repositories' => 'foo/bad' })
+    graph = Class.new(Fbe::Graph::Fake) do
+      define_method(:total_commits) do |*_args, **_kwargs|
+        raise(Fbe::Error, "Repository 'foo/bad' or branch 'master' not found")
+      end
+    end.new
+    Fbe.stub(:github_graph, graph) do
+      load(File.join(__dir__, '../../judges/dimensions-of-terrain/total_commits.rb'))
+      assert_equal({ total_commits: 0 }, total_commits(nil))
+    end
+  end
+
   def test_total_files
     WebMock.disable_net_connect!
     stub_request(:get, 'https://api.github.com/rate_limit').to_return(


### PR DESCRIPTION
The GraphQL batch call in \`total_commits.rb\` raises \`Fbe::Error\` when a repository or branch can't be found, but that exception wasn't in the rescue list. The three Octokit arms sitting there (\`NotFound\`, \`Deprecated\`, \`Forbidden\`) were dead code, since \`Fbe::Graph#query\` never raises Octokit errors — so a single renamed default branch anywhere in the batch killed the judge for that cycle instead of being logged and skipped.

This replaces those unreachable arms with \`Fbe::Error\` and adds a guard that skips a repository up front when its \`default_branch\` comes back nil, so a repo in that state never enters the batch in the first place.

Closes #1979