### PR TITLE
fix(#1981): remove dead outer rescue blocks in dimensions-of-terrain metrics

### DIFF
--- a/judges/dimensions-of-terrain/total_active_contributors.rb
+++ b/judges/dimensions-of-terrain/total_active_contributors.rb
@@ -32,15 +32,6 @@ def total_active_contributors(fact)
       author = commit.dig(:author, :id)
       seen << author unless author.nil?
     end
-  rescue Octokit::NotFound, Octokit::Deprecated => e
-    $loog.info("Search commits not found for #{repo}: #{e.message}")
-    next
-  rescue Octokit::Forbidden => e
-    $loog.warn(
-      "[#{$judge}] Access forbidden to search commits in #{repo} " \
-      "(transient, will retry next cycle): #{e.class}: #{e.message}"
-    )
-    next
   end
   { total_active_contributors: seen.count }
 end

--- a/judges/dimensions-of-terrain/total_commits.rb
+++ b/judges/dimensions-of-terrain/total_commits.rb
@@ -24,15 +24,6 @@ def total_commits(_fact)
     end
     next if json[:size].nil? || json[:size].zero?
     repos << [*repo.split('/'), json[:default_branch]]
-  rescue Octokit::NotFound, Octokit::Deprecated => e
-    $loog.info("Repository not found for #{repo}: #{e.message}")
-    next
-  rescue Octokit::Forbidden => e
-    $loog.warn(
-      "[#{$judge}] Access forbidden to repository #{repo} " \
-      "(transient, will retry next cycle): #{e.class}: #{e.message}"
-    )
-    next
   end
   {
     total_commits:

--- a/judges/dimensions-of-terrain/total_contributors.rb
+++ b/judges/dimensions-of-terrain/total_contributors.rb
@@ -41,15 +41,6 @@ def total_contributors(_fact)
     list.each do |contributor|
       contributors << contributor[:id]
     end
-  rescue Octokit::NotFound, Octokit::Deprecated => e
-    $loog.info("Repository/contributors info not found for #{repo}: #{e.message}")
-    next
-  rescue Octokit::Forbidden => e
-    $loog.warn(
-      "[#{$judge}] Access forbidden to repository/contributors in #{repo} " \
-      "(transient, will retry next cycle): #{e.class}: #{e.message}"
-    )
-    next
   end
   { total_contributors: contributors.count }
 end

--- a/judges/dimensions-of-terrain/total_releases.rb
+++ b/judges/dimensions-of-terrain/total_releases.rb
@@ -27,15 +27,6 @@ def total_releases(_fact)
     releases.each do |_|
       total += 1
     end
-  rescue Octokit::NotFound, Octokit::Deprecated => e
-    $loog.info("Releases not found for #{repo}: #{e.message}")
-    next
-  rescue Octokit::Forbidden => e
-    $loog.warn(
-      "[#{$judge}] Access forbidden to releases in #{repo} " \
-      "(transient, will retry next cycle): #{e.class}: #{e.message}"
-    )
-    next
   end
   { total_releases: total }
 end


### PR DESCRIPTION
## Summary
- Removes the outer `begin`/`rescue` blocks in `total_active_contributors.rb`, `total_commits.rb`, `total_contributors.rb`, and `total_releases.rb` that duplicated the inner `begin`/`rescue` handling the only API call in each block.
- Nothing after the inner rescue can raise an Octokit error, so the outer handler was unreachable dead code.

Fixes #1981
