### PR TITLE
fix(#1982): stop re-fetching each repo to check archived flag

### DIFF
--- a/judges/dimensions-of-terrain/total_repositories.rb
+++ b/judges/dimensions-of-terrain/total_repositories.rb
@@ -3,22 +3,11 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
 # SPDX-License-Identifier: MIT
 
-require 'fbe/octo'
 require 'fbe/unmask_repos'
 require_relative '../../lib/patches/unmask_repos'
 
 def total_repositories(_fact)
   total = 0
-  Fbe.unmask_repos do |repo|
-    total += 1 unless Fbe.octo.repository(repo)[:archived]
-  rescue Octokit::NotFound, Octokit::Deprecated => e
-    $loog.info("Repository #{repo} not found: #{e.message}")
-    next
-  rescue Octokit::Forbidden => e
-    $loog.warn(
-      "[#{$judge}] Repository #{repo} forbidden (transient, will retry next cycle): #{e.class}: #{e.message}"
-    )
-    next
-  end
+  Fbe.unmask_repos { total += 1 }
   { total_repositories: total }
 end

--- a/test/judges/test-dimensions-of-terrain.rb
+++ b/test/judges/test-dimensions-of-terrain.rb
@@ -139,6 +139,26 @@ class TestDimensionsOfTerrain < Jp::Test
     end
   end
 
+  def test_total_repositories_does_not_refetch_repos_unmask_repos_already_checked
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repos/foo/foo', body: { full_name: 'foo/foo', archived: false })
+    stub_github('https://api.github.com/repos/foo/bar', body: { full_name: 'foo/bar', archived: false })
+    stub_github('https://api.github.com/repos/foo/qwe', body: { full_name: 'foo/qwe', archived: true })
+    $fb = Factbase.new
+    $global = {}
+    $local = {}
+    Jp.qoreset
+    $judge = 'dimensions-of-terrain'
+    $options = Judges::Options.new({ 'repositories' => 'foo/foo,foo/bar,foo/qwe' })
+    $loog = Loog::NULL
+    $epoch = Time.now
+    $kickoff = Time.now
+    load(File.join(__dir__, '../../judges/dimensions-of-terrain/total_repositories.rb'))
+    total_repositories($fb.insert)
+    assert_requested(:get, 'https://api.github.com/repos/foo/foo', times: 1)
+  end
+
   def test_total_releases_skips_non_array_response
     WebMock.disable_net_connect!
     rate_limit_up


### PR DESCRIPTION
Fbe.unmask_repos already drops archived repositories before yielding them (lib/patches/unmask_repos.rb), so the Fbe.octo.repository(repo)[:archived] check in total_repositories.rb always read false. It cost one extra GitHub API call per repository per cycle, on a branch that could never be taken, in a judge that already runs out of quota often enough for #1206.

The fix reduces the body to a single increment per yielded repo, since the archived filter now lives entirely in unmask_repos. Added a test that fails against the old code (each repo fetched twice) and passes against the fix (fetched once).

Closes #1982.