### PR TITLE
rescue fbe error instead of dead octokit classes in total_issues judge

### DIFF
--- a/judges/dimensions-of-terrain/total_issues.rb
+++ b/judges/dimensions-of-terrain/total_issues.rb
@@ -13,14 +13,8 @@ def total_issues(_fact)
     json =
       begin
         Fbe.github_graph.total_issues_and_pulls(*repo.split('/'))
-      rescue Octokit::NotFound, Octokit::Deprecated => e
+      rescue Fbe::Error => e
         $loog.info("Can't count issues and pulls in #{repo}: #{e.message}")
-        next
-      rescue Octokit::Forbidden => e
-        $loog.warn(
-          "[#{$judge}] Access forbidden to issues and pulls in #{repo} " \
-          "(transient, will retry next cycle): #{e.class}: #{e.message}"
-        )
         next
       rescue GraphQL::Client::Error,
         Net::OpenTimeout, Net::ReadTimeout, SocketError, Errno::ECONNRESET, Errno::ETIMEDOUT => e

--- a/test/judges/test-dimensions-of-terrain.rb
+++ b/test/judges/test-dimensions-of-terrain.rb
@@ -370,6 +370,29 @@ class TestDimensionsOfTerrain < Jp::Test
     end
   end
 
+  def test_total_issues_skips_repo_on_fbe_error
+    WebMock.disable_net_connect!
+    rate_limit_up
+    %w[bad good].each do |name|
+      stub_github("https://api.github.com/repos/foo/#{name}", body: { full_name: "foo/#{name}", archived: false })
+    end
+    $judge = 'dimensions-of-terrain'
+    $global = {}
+    $local = {}
+    $loog = Loog::NULL
+    $options = Judges::Options.new({ 'repositories' => 'foo/bad,foo/good' })
+    graph = Class.new(Fbe::Graph::Fake) do
+      define_method(:total_issues_and_pulls) do |_owner, name|
+        raise(Fbe::Error, 'GitHub GraphQL query failed') if name == 'bad'
+        { 'issues' => 7, 'pulls' => 5 }
+      end
+    end.new
+    Fbe.stub(:github_graph, graph) do
+      load(File.join(__dir__, '../../judges/dimensions-of-terrain/total_issues.rb'))
+      assert_equal({ total_issues: 7, total_pulls: 5 }, total_issues(nil))
+    end
+  end
+
   def test_total_issues_keeps_local_graph_bug
     WebMock.disable_net_connect!
     rate_limit_up


### PR DESCRIPTION
The GraphQL query in Fbe::Graph#query raises Fbe::Error on any GraphQL failure, going through GraphQL::Client::HTTP rather than Octokit. The rescue clauses in total_issues.rb caught Octokit::NotFound, Octokit::Deprecated and Octokit::Forbidden, none of which that call path can ever raise, so a rate-limited or moved repository aborted the judge on the first repository of the loop.

This swaps those two Octokit rescue arms for a single Fbe::Error arm, logging and skipping the repository the same way the GraphQL::Client::Error and network-timeout arm already does. The GraphQL::Client::Error and network arms are unchanged.

Closes #1980