### PR TITLE
disable auto pagination in Jp.qosearch

### DIFF
--- a/lib/qos_search.rb
+++ b/lib/qos_search.rb
@@ -67,7 +67,7 @@ def Jp.qosearch(query, method: :search_issues, **)
   @scount[jg] += 1
   raise(RuntimeError, "Unsafe search method: #{method}") unless
     %i[search_issues search_code search_commits].include?(method)
-  Fbe.octo.__send__(method, query, **)
+  Fbe.octo.with_disable_auto_paginate { |octo| octo.__send__(method, query, **) }
 rescue Octokit::TooManyRequests => e
   @offquota[jg] = true
   @offquotatime[jg] = Time.now

--- a/test/judges/test-quality-of-service.rb
+++ b/test/judges/test-quality-of-service.rb
@@ -2556,6 +2556,7 @@ class TestQualityOfService < Jp::Test
     octo.define_singleton_method(:pull_request_reviews) { |*| [] }
     octo.define_singleton_method(:pull_request_review_comments) { |*| [] }
     octo.define_singleton_method(:off_quota?) { false }
+    octo.define_singleton_method(:with_disable_auto_paginate) { |&block| block.call(octo) }
     rl = Object.new
     rl.define_singleton_method(:remaining) { 30 }
     octo.define_singleton_method(:rate_limit) { rl }

--- a/test/lib/test_qos_search.rb
+++ b/test/lib/test_qos_search.rb
@@ -37,6 +37,36 @@ class TestQosSearch < Jp::Test
     assert_equal(1, found[:items].first[:number])
   end
 
+  def test_does_not_follow_pagination_links
+    rate_limit_up
+    stub_github(
+      'https://api.github.com/search/issues?per_page=100&q=repo:foo/foo%20type:issue',
+      body: { total_count: 2, items: [{ number: 1 }] },
+      headers: {
+        'Content-Type' => 'application/json',
+        'X-RateLimit-Remaining' => '999',
+        'Link' => '<https://api.github.com/search/issues?page=2&per_page=100&q=repo:foo/foo%20type:issue>; rel="next"'
+      }
+    )
+    Jp.qosearch('repo:foo/foo type:issue')
+    assert_not_requested(:get, %r{https://api\.github\.com/search/issues\?page=2})
+  end
+
+  def test_does_not_follow_pagination_links_for_code_search
+    rate_limit_up
+    stub_github(
+      'https://api.github.com/search/code?per_page=100&q=repo:foo/foo%20test',
+      body: { total_count: 2, items: [{ name: 'a.rb' }] },
+      headers: {
+        'Content-Type' => 'application/json',
+        'X-RateLimit-Remaining' => '999',
+        'Link' => '<https://api.github.com/search/code?page=2&per_page=100&q=repo:foo/foo%20test>; rel="next"'
+      }
+    )
+    Jp.qosearch('repo:foo/foo test', method: :search_code)
+    assert_not_requested(:get, %r{https://api\.github\.com/search/code\?page=2})
+  end
+
   def test_skips_search_when_core_quota_low
     stub_request(:get, 'https://api.github.com/rate_limit').to_return(
       body: { rate: { remaining: 49, limit: 1000 } }.to_json,


### PR DESCRIPTION
Fbe.octo runs with auto_paginate = true, so a single Jp.qosearch call can walk through several pages of the GitHub Search API before returning, while the budget tracked by qos_search.rb only charges one unit per call. Each page is its own request against the search endpoint's allowance, so the state machine's per-minute budget can be overrun well beyond what it thinks it's spending.

This wraps the underlying search call in Fbe.octo.with_disable_auto_paginate, so one Jp.qosearch call now issues exactly one HTTP request, matching the one unit it charges against the budget.

Closes #1983