### PR TITLE
fix(#1985): total_files.rb honors the truncated flag on git tree

### DIFF
--- a/judges/dimensions-of-terrain/total_files.rb
+++ b/judges/dimensions-of-terrain/total_files.rb
@@ -9,6 +9,7 @@ require_relative '../../lib/patches/unmask_repos'
 
 def total_files(_fact)
   files = 0
+  truncated = false
   Fbe.unmask_repos do |repo|
     info =
       begin
@@ -37,7 +38,13 @@ def total_files(_fact)
         )
         next
       end
+    if tree[:truncated]
+      $loog.info("Tree for #{repo}@#{info[:default_branch]} is truncated, skipping total_files")
+      truncated = true
+      break
+    end
     files += (tree[:tree] || []).count { |item| item[:type] == 'blob' }
   end
+  return {} if truncated
   { total_files: files }
 end

--- a/test/judges/test-dimensions-of-terrain.rb
+++ b/test/judges/test-dimensions-of-terrain.rb
@@ -647,6 +647,40 @@ class TestDimensionsOfTerrain < Jp::Test
     end
   end
 
+  def test_total_files_skips_property_when_tree_truncated
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github(
+      'https://api.github.com/repos/foo/big', body: {
+        name: 'big', full_name: 'foo/big', size: 1,
+        stargazers_count: 0, forks: 0, default_branch: 'master', archived: false
+      }
+    )
+    stub_github('https://api.github.com/repos/foo/big/releases?per_page=100', body: [])
+    stub_github(
+      'https://api.github.com/repos/foo/big/git/trees/master?recursive=true',
+      body: {
+        sha: 'a', tree: [
+        { path: 'f.rb', mode: '100644', type: 'blob', sha: 'b', size: 1 }
+      ], truncated: true
+      }
+    )
+    stub_github('https://api.github.com/repos/foo/big/contributors?per_page=100', body: [])
+    stub_github(
+      'https://api.github.com/search/commits?per_page=100&q=repo:foo/big%20author-date:%3E2024-08-30',
+      body: { total_count: 0, incomplete_results: false, items: [] }
+    )
+    fb = Factbase.new
+    Fbe.stub(:github_graph, Fbe::Graph::Fake.new) do
+      Time.stub(:now, Time.parse('2024-09-29 21:00:00 UTC')) do
+        load_it('dimensions-of-terrain', fb, Judges::Options.new({ 'repositories' => 'foo/big' }))
+        f = fb.query("(eq what 'dimensions-of-terrain')").each.first
+        refute_nil(f)
+        assert_nil(f['total_files'])
+      end
+    end
+  end
+
   def test_total_contributors
     WebMock.disable_net_connect!
     stub_request(:get, 'https://api.github.com/rate_limit').to_return(


### PR DESCRIPTION
## Summary
- `total_files.rb` checks `tree[:truncated]` after fetching the recursive git tree; when GitHub clips the response (100,000 entries / 7 MB cap), the judge returns `{}` so `total_files` stays unset instead of recording a capped, incomplete count.
- Added `test_total_files_skips_property_when_tree_truncated` covering the truncated case.

Closes #1985