### PR TITLE
Require lib/patches/unmask_repos in total_issues.rb

### DIFF
--- a/judges/dimensions-of-terrain/total_issues.rb
+++ b/judges/dimensions-of-terrain/total_issues.rb
@@ -5,6 +5,7 @@
 
 require 'fbe/github_graph'
 require 'fbe/unmask_repos'
+require_relative '../../lib/patches/unmask_repos'
 
 def total_issues(_fact)
   issues = 0


### PR DESCRIPTION
Seven of the eight metric files in judges/dimensions-of-terrain require_relative the local unmask_repos patch on line 8, but total_issues.rb only requires fbe/unmask_repos and stops, relying on some other file in the directory having loaded the patch first.

That works by luck of ordering: lib/incremate.rb globs the files in sorted order, so total_active_contributors.rb loads first and installs the patch. But the loader skips any file whose property is already on the fact, and the require sits after that skip. On a fact where every metric except total_issues was already collected, total_issues.rb is the only file loaded, and Fbe.unmask_repos falls back to the plain gem version, which has no rescue around octo.organization_repositories and aborts the judge on a Forbidden while expanding a wildcard mask.

This adds the same require_relative line the other seven files carry, removing the ordering dependency.

Closes #1987