### PR TITLE
fix(#1989): unify TODAY reading behind Jp.today

### DIFF
--- a/judges/dimensions-of-terrain/dimensions-of-terrain.rb
+++ b/judges/dimensions-of-terrain/dimensions-of-terrain.rb
@@ -7,16 +7,9 @@ require 'fbe/fb'
 require 'fbe/octo'
 require 'time'
 require_relative '../../lib/incremate'
+require_relative '../../lib/today'
 
-today =
-  begin
-    v = ENV.fetch('TODAY', nil)
-    if v.nil? || v.empty?
-      Time.now.utc
-    else
-      Time.parse(v)
-    end
-  end
+today = Jp.today
 f = Fbe.fb.query(
   "(and
     (eq what '#{$judge}')

--- a/judges/who-has-name/who-has-name.rb
+++ b/judges/who-has-name/who-has-name.rb
@@ -12,6 +12,7 @@ require 'fbe/octo'
 require 'fbe/overwrite'
 require 'octokit'
 require_relative '../../lib/nick_of'
+require_relative '../../lib/today'
 
 alive = []
 
@@ -62,7 +63,7 @@ end
 Fbe.consider(
   "(and
     (eq what 'who-has-name')
-    (lt when (minus (to_time (env 'TODAY' '#{Time.now.utc.iso8601}')) '5 days'))
+    (lt when (minus (to_time '#{Jp.today.utc.iso8601}') '5 days'))
     (absent stale)
     (absent tombstone)
     (absent done)

--- a/judges/who-is-alive/who-is-alive.rb
+++ b/judges/who-is-alive/who-is-alive.rb
@@ -10,13 +10,14 @@ require 'fbe/octo'
 require 'logger'
 require 'octokit'
 require_relative '../../lib/nick_of'
+require_relative '../../lib/today'
 
 seen = []
 
 Fbe.consider(
   "(and
     (eq what 'who-has-name')
-    (lt when (minus (to_time (env 'TODAY' '#{Time.now.utc.iso8601}')) '2 days'))
+    (lt when (minus (to_time '#{Jp.today.utc.iso8601}') '2 days'))
     (absent stale)
     (absent tombstone)
     (absent done)

--- a/lib/cover_qo.rb
+++ b/lib/cover_qo.rb
@@ -6,17 +6,10 @@
 require 'fbe/fb'
 require 'fbe/if_absent'
 require_relative 'jp'
+require_relative 'today'
 
 def Jp.cover_qo(days, judge: $judge, loog: $loog, today: nil)
-  today ||=
-    begin
-      v = ENV.fetch('TODAY', nil)
-      if v.nil? || v.empty?
-        Time.now.utc
-      else
-        Time.parse(v)
-      end
-    end
+  today ||= Jp.today
   slice = days * 24 * 60 * 60
   facts = Fbe.fb.query("(and (eq what '#{judge}') (exists since) (exists when))").each.to_a.sort_by(&:since)
   last = facts.map(&:when).max

--- a/lib/today.rb
+++ b/lib/today.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+# SPDX-License-Identifier: MIT
+
+require 'time'
+require_relative 'jp'
+
+def Jp.today
+  v = ENV.fetch('TODAY', nil)
+  if v.nil? || v.empty?
+    Time.now.utc
+  else
+    Time.parse(v)
+  end
+end

--- a/test/lib/test_today.rb
+++ b/test/lib/test_today.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+# SPDX-License-Identifier: MIT
+
+require 'time'
+require_relative '../../lib/today'
+require_relative '../test__helper'
+
+class TestToday < Minitest::Test
+  def test_returns_now_when_env_var_is_absent
+    ENV.delete('TODAY')
+    now = Time.now
+    Time.stub(:now, now) do
+      assert_equal(Integer(now.utc), Integer(Jp.today))
+    end
+  end
+
+  def test_returns_now_when_env_var_is_empty
+    ENV['TODAY'] = ''
+    now = Time.now
+    Time.stub(:now, now) do
+      assert_equal(Integer(now.utc), Integer(Jp.today))
+    end
+  ensure
+    ENV.delete('TODAY')
+  end
+
+  def test_parses_env_var_when_present
+    ENV['TODAY'] = '2025-03-15T00:00:00Z'
+    assert_equal(Integer(Time.parse('2025-03-15T00:00:00Z')), Integer(Jp.today))
+  ensure
+    ENV.delete('TODAY')
+  end
+end


### PR DESCRIPTION
## Summary

- `dimensions-of-terrain.rb` and `cover_qo.rb` each carried the same nine-line `ENV['TODAY']` parsing block; `who-is-alive.rb` and `who-has-name.rb` instead read `TODAY` through the factbase `(env 'TODAY' ...)` term, which does its own parsing and treats an empty `TODAY` differently.
- Extracted the shared logic into `Jp.today` (`lib/today.rb`) and switched all four call sites to use it, so an empty or absent `TODAY` behaves identically everywhere.

Closes #1989

@yegor256 please take a look.