### PR TITLE
fix(#1988): key incremate's completion check on the file's own property, not write order

### DIFF
--- a/lib/incremate.rb
+++ b/lib/incremate.rb
@@ -12,7 +12,7 @@ require 'time'
 require_relative 'jp'
 
 def Jp.incremate(
-  fact, dir, prefix, avoid_duplicate: false, pause: 0,
+  fact, dir, prefix, avoid_duplicate: true, pause: 0,
   max_per_fact: nil,
   epoch: $epoch || Time.now, kickoff: $kickoff || Time.now
 )
@@ -40,8 +40,12 @@ def Jp.incremate(
     elapsed($loog, level: Logger::INFO) do
       h = __send__(n, fact)
       h.each do |k, v|
+        next if k.to_s == n
         next if avoid_duplicate && fact.all_properties.include?(k.to_s)
         Array(v).each { fact.__send__("#{k}=", _1) }
+      end
+      if h.key?(n.to_sym) && !(avoid_duplicate && fact.all_properties.include?(n))
+        Array(h[n.to_sym]).each { fact.__send__("#{n}=", _1) }
       end
       throw(:"Collected #{n}: [#{h.map { |k, v| "#{k}: #{v}" }.join(', ')}]")
     end

--- a/test/lib/test_incremate.rb
+++ b/test/lib/test_incremate.rb
@@ -76,6 +76,36 @@ class TestIncremate < Minitest::Test
     $options = nil
   end
 
+  def test_incremate_recovers_from_partial_write
+    WebMock.disable_net_connect!
+    stub_request(:get, 'https://api.github.com/rate_limit').to_return(
+      body: { rate: { remaining: 1000, limit: 1000 } }.to_json,
+      headers: { 'X-RateLimit-Remaining' => '999' }
+    )
+    $global = {}
+    $local = {}
+    $loog = Loog::VERBOSE
+    $options = Judges::Options.new({ 'lifetime' => 100, 'timeout' => 100 })
+    Dir.mktmpdir do |dir|
+      File.write(File.expand_path('some_first.rb', dir), <<~RUBY)
+        def some_first(_f)
+          { some_first: 1, some_second: 2 }
+        end
+      RUBY
+      time = Time.now - 60
+      fb = Factbase.new
+      f = fb.insert
+      f.some_second = 2
+      Jp.incremate(f, dir, 'some', epoch: time, kickoff: time)
+      assert_equal(1, f.some_first, 'the property named after the file must still be collected')
+      assert_equal([2], f['some_second'], 'the property already written before the interruption must not be duplicated')
+    end
+    $global = nil
+    $local = nil
+    $loog = nil
+    $options = nil
+  end
+
   def test_incremate_pauses_between_evaluations
     WebMock.disable_net_connect!
     stub_request(:get, 'https://api.github.com/rate_limit').to_return(


### PR DESCRIPTION
## Summary

- `lib/incremate.rb` skipped re-evaluating a metric file once `fact[n]` was truthy, where `n` is the file's basename.
- For multi-property files (`total_stars.rb`, `total_issues.rb`, `some_issue_lifetime.rb`, `total_commits_pushed.rb`, `total_issues_created.rb`, `some_merged_pulls.rb`, `some_pull_hoc_size.rb`, `some_build_success_rate.rb`, `some_release_hoc_size.rb`, `some_review_time.rb`) `n` is consistently the *first* key each file writes, so a process killed mid-write (the `judges` gem timeout can raise `Timeout::ExitException` at any point) left the fact permanently marked "done" while its other properties were never collected.
- Fixed by always writing the property named after the file *last*, so `fact[n]` only becomes truthy once every property from that run has actually been written — no new bookkeeping property needed, and no behavior change for single-property files.
- `avoid_duplicate` now defaults to `true` so a retried file (after a resumed partial write) doesn't re-append values that were already written before the interruption.

Closes #1988

@yegor256 please take a look.