### PR TITLE
Guard total_contributors against a nil contributor id

### DIFF
--- a/judges/dimensions-of-terrain/total_contributors.rb
+++ b/judges/dimensions-of-terrain/total_contributors.rb
@@ -39,7 +39,8 @@ def total_contributors(_fact)
       end
     next unless list.is_a?(Array)
     list.each do |contributor|
-      contributors << contributor[:id]
+      id = contributor[:id]
+      contributors << id unless id.nil?
     end
   rescue Octokit::NotFound, Octokit::Deprecated => e
     $loog.info("Repository/contributors info not found for #{repo}: #{e.message}")

--- a/test/judges/test-dimensions-of-terrain.rb
+++ b/test/judges/test-dimensions-of-terrain.rb
@@ -726,6 +726,45 @@ class TestDimensionsOfTerrain < Jp::Test
     end
   end
 
+  def test_total_contributors_skips_entries_without_id
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github(
+      'https://api.github.com/repos/foo/foo',
+      body: {
+        name: 'foo', full_name: 'foo/foo', private: false,
+        created_at: Time.parse('2024-07-11 20:35:25 UTC'),
+        updated_at: Time.parse('2024-09-23 07:23:36 UTC'),
+        pushed_at: Time.parse('2024-09-23 20:22:51 UTC'),
+        size: 1, stargazers_count: 1, forks: 1, default_branch: 'master'
+      }
+    )
+    stub_github('https://api.github.com/repos/foo/foo/releases?per_page=100', body: [])
+    stub_github(
+      'https://api.github.com/repos/foo/foo/git/trees/master?recursive=true',
+      body: { sha: 'abc', tree: [], truncated: false }
+    )
+    stub_github(
+      'https://api.github.com/repos/foo/foo/contributors?per_page=100',
+      body: [
+        { login: 'user1', id: 2_476_362, type: 'User', contributions: 120 },
+        { login: 'ghost', type: 'User', contributions: 1 }
+      ]
+    )
+    stub_github(
+      'https://api.github.com/search/commits?per_page=100&q=repo:foo/foo%20author-date:%3E2024-08-30',
+      body: { total_count: 0, incomplete_results: false, items: [] }
+    )
+    fb = Factbase.new
+    Fbe.stub(:github_graph, Fbe::Graph::Fake.new) do
+      Time.stub(:now, Time.parse('2024-09-29 21:00:00 UTC')) do
+        load_it('dimensions-of-terrain', fb)
+        f = fb.query("(eq what 'dimensions-of-terrain')").each.first
+        assert_equal(1, f.total_contributors)
+      end
+    end
+  end
+
   def test_total_active_contributors
     require_relative('../../lib/qos_search')
     Jp.qoreset


### PR DESCRIPTION
total_active_contributors.rb already skips entries where the author has no id, since GitHub's contributors endpoint can return a record without one. total_contributors.rb did not have the same guard, so a missing id landed in the set as nil and inflated the count by one.

This adds the same `unless id.nil?` check to total_contributors.rb, along with a test that stubs a contributors response containing one entry without an id.

Closes #1990