### PR TITLE
Assert total_stars is nil when quota is consumed

### DIFF
--- a/test/judges/test-dimensions-of-terrain.rb
+++ b/test/judges/test-dimensions-of-terrain.rb
@@ -1006,6 +1006,7 @@ class TestDimensionsOfTerrain < Jp::Test
       assert_nil(f['total_issues'])
       assert_nil(f['total_pulls'])
       assert_nil(f['total_forks'])
+      assert_nil(f['total_stars'])
     end
   end
 end


### PR DESCRIPTION
test_not_fill_props_if_quota_consumed checks that no metric is written when a run starts off quota, and it names nine properties. total_stars is missing — it's the twin of total_forks, both written by the same total_stars.rb:30. A regression that wrote a stray total_stars while off quota would go unnoticed.

Adds assert_nil(f['total_stars']) next to the total_forks assertion.

Closes #1993