### PR TITLE
fix skip-recounting.yml to actually assert recounting is skipped

### DIFF
--- a/judges/dimensions-of-terrain/skip-recounting.yml
+++ b/judges/dimensions-of-terrain/skip-recounting.yml
@@ -11,5 +11,11 @@ input:
     _id: 42
     what: dimensions-of-terrain
     when: 2024-03-03T00:00:00
+    total_commits: 777
+    total_stars: 555
 expected:
   - /fb[count(f)=1]
+  - /fb/f[total_commits=777]
+  - /fb/f[total_stars=555]
+  - /fb/f[not(total_forks)]
+  - /fb/f[total_files]


### PR DESCRIPTION
The skip-recounting.yml fixture seeded a fact with only what/when, so Jp.incremate collected every total metric on the first run and the single expectation (/fb[count(f)=1]) only proved that no duplicate fact got inserted, not that recounting was skipped. The test would pass unchanged even if every metric were recomputed on every run.

Seeded the fact with total_commits and total_stars already set, and now assert those values stay unchanged, that total_forks (the sibling key produced by the same total_stars.rb collector) stays unset since that file never re-runs, and that total_files, which wasn't pre-seeded, still gets collected normally.

Closes #1991