### PR TITLE
Move revive-user and fix-missing-hoc tests onto the fake GitHub server

### DIFF
--- a/test/fake_github.rb
+++ b/test/fake_github.rb
@@ -9,9 +9,9 @@ require 'socket'
 require_relative '../lib/jp'
 
 # rubocop:disable Elegant/NoComments
-# @todo #1960:60min Move the rest of the tests onto this server.
-#  Thirty one files under `test/` still build their GitHub with
-#  `stub_request` and `stub_github`, one thousand one hundred and ninety one
+# @todo #1996:60min Move the rest of the tests onto this server.
+#  Twenty nine files under `test/` still build their GitHub with
+#  `stub_request` and `stub_github`, one thousand one hundred and ninety six
 #  stubs in all, the heaviest being `test/judges/test-quality-of-service.rb`
 #  with two hundred and fifty three. Each of them should declare its routes
 #  through `Jp::FakeGithub` instead, one file at a time, so that a reviewer

--- a/test/judges/test-fix-missing-hoc.rb
+++ b/test/judges/test-fix-missing-hoc.rb
@@ -4,57 +4,57 @@
 # SPDX-License-Identifier: MIT
 
 require 'factbase'
+require_relative '../fake_github'
 require_relative '../test__helper'
 
 class TestFixMissingHoc < Jp::Test
   using SmartFactbase
 
   def test_rescues_forbidden_on_pull_request_lookup
-    WebMock.disable_net_connect!
-    rate_limit_up
-    stub_github('https://api.github.com/repos/foo/foo', body: { id: 42, full_name: 'foo/foo' })
-    stub_github('https://api.github.com/repositories/42', body: { id: 42, full_name: 'foo/foo' })
-    stub_github(
-      'https://api.github.com/repos/foo/foo/pulls/44',
-      status: 403,
-      body: { message: 'Resource not accessible by integration' }
-    )
     fb = Factbase.new
     fb.with(_id: 1, what: 'pull-was-merged', repository: 42, issue: 44, where: 'github')
-    load_it('fix-missing-hoc', fb)
-    f = fb.query('(eq issue 44)').each.first
-    refute_nil(f)
-    assert_nil(f['hoc'], '403 is transient — fact must NOT receive hoc; next cycle will retry')
-    assert_nil(f['stale'], '403 is transient — fact must NOT be marked stale')
+    Jp::FakeGithub.new(
+      'GET /rate_limit' => { resources: { search: { remaining: 30, limit: 30 } }, rate: { remaining: 1000 } },
+      'GET /repos/foo/foo' => { id: 42, full_name: 'foo/foo' },
+      'GET /repositories/42' => { id: 42, full_name: 'foo/foo' },
+      'GET /repos/foo/foo/pulls/44' => [403, { message: 'Resource not accessible by integration' }]
+    ).run do
+      load_it('fix-missing-hoc', fb)
+    end
+    assert_equal(
+      %w[_id issue repository what where], fb.pick(issue: 44).all_properties.sort,
+      'the fact changed after a 403, while the pull request was never read and the next cycle must retry'
+    )
   end
 
   def test_rescues_not_found_on_repo_name_lookup
-    WebMock.disable_net_connect!
-    rate_limit_up
-    stub_github('https://api.github.com/repositories/42', status: 404, body: { message: 'Not Found' })
     fb = Factbase.new
     fb.with(_id: 1, what: 'pull-was-merged', repository: 42, issue: 44, where: 'github')
-    load_it('fix-missing-hoc', fb)
+    Jp::FakeGithub.new(
+      'GET /rate_limit' => { resources: { search: { remaining: 30, limit: 30 } }, rate: { remaining: 1000 } },
+      'GET /repositories/42' => [404, { message: 'Not Found' }]
+    ).run do
+      load_it('fix-missing-hoc', fb)
+    end
     assert(
       fb.one?(what: 'pull-was-merged', repository: 42, stale: 'repository'),
-      'The fact of a vanished repository must be marked stale instead of aborting the judge'
+      'the fact of a vanished repository is not stale, while the judge must mark it instead of aborting'
     )
   end
 
   def test_dont_crash_when_pull_has_no_hoc
-    WebMock.disable_net_connect!
-    rate_limit_up
-    stub_github('https://api.github.com/repositories/42', body: { id: 42, full_name: 'foo/foo' })
-    stub_github(
-      'https://api.github.com/repos/foo/foo/pulls/44',
-      body: { id: 50, number: 44, state: 'closed', changed_files: 1 }
-    )
     fb = Factbase.new
     fb.with(_id: 1, what: 'pull-was-merged', repository: 42, issue: 44, where: 'github')
-    load_it('fix-missing-hoc', fb)
+    Jp::FakeGithub.new(
+      'GET /rate_limit' => { resources: { search: { remaining: 30, limit: 30 } }, rate: { remaining: 1000 } },
+      'GET /repositories/42' => { id: 42, full_name: 'foo/foo' },
+      'GET /repos/foo/foo/pulls/44' => { id: 50, number: 44, state: 'closed', changed_files: 1 }
+    ).run do
+      load_it('fix-missing-hoc', fb)
+    end
     assert_equal(
       0, fb.pick(issue: 44).hoc,
-      'A pull request that reports no additions and no deletions cannot abort the judge'
+      'a pull request reporting no additions and no deletions aborted the judge'
     )
   end
 end

--- a/test/judges/test-revive-user.rb
+++ b/test/judges/test-revive-user.rb
@@ -4,25 +4,24 @@
 # SPDX-License-Identifier: MIT
 
 require 'factbase'
-require 'octokit'
+require_relative '../fake_github'
 require_relative '../test__helper'
 
 class TestReviveUser < Jp::Test
   using SmartFactbase
 
   def test_stale_user_stays_stale_on_forbidden
-    WebMock.disable_net_connect!
-    rate_limit_up
-    stub_github(
-      'https://api.github.com/user/29139614',
-      status: 403,
-      body: { message: 'Resource not accessible by integration' }
-    )
     fb = Factbase.new
     fb.with(_id: 1, what: 'pull-was-merged', repository: 42, issue: 44, who: 29_139_614, where: 'github', stale: 'who')
-    load_it('revive-user', fb)
-    fact = fb.query('(eq who 29139614)').each.first
-    refute_nil(fact)
-    assert_equal('who', fact.stale, 'fact should still be stale after 403 — we cannot confirm the user is alive')
+    Jp::FakeGithub.new(
+      'GET /rate_limit' => { resources: { search: { remaining: 30, limit: 30 } }, rate: { remaining: 1000 } },
+      'GET /user/29139614' => [403, { message: 'Resource not accessible by integration' }]
+    ).run do
+      load_it('revive-user', fb)
+    end
+    assert_equal(
+      'who', fb.pick(who: 29_139_614).stale,
+      'the fact lost its staleness after a 403, while the user was never confirmed alive'
+    )
   end
 end


### PR DESCRIPTION
Two more judge tests now declare their GitHub routes through `Jp::FakeGithub` instead of building them with `stub_request` and `stub_github`: `test-revive-user.rb` and `test-fix-missing-hoc.rb`. The routes read as a plain map of `GET /path` to a body or to a status and a body, so what the judge is allowed to see is visible in one place, and the tests no longer depend on WebMock's global state.

While rewriting them I collapsed each test down to a single assertion at the end, restated the failure messages as negative claims about the error, and dropped the unused `require 'octokit'` from `test-revive-user.rb`.

The puzzle in `test/fake_github.rb` is renumbered and its counts are corrected. Twenty nine files are still on the old stubs, one thousand one hundred and ninety six call sites in all. The previous figure of one thousand one hundred and ninety one was an undercount; the tree held one thousand two hundred and three before this change.

Closes #1996
