### PR TITLE
Move fix-missing-branch test onto the fake GitHub server

### DIFF
--- a/test/fake_github.rb
+++ b/test/fake_github.rb
@@ -9,9 +9,9 @@ require 'socket'
 require_relative '../lib/jp'
 
 # rubocop:disable Elegant/NoComments
-# @todo #1996:60min Move the rest of the tests onto this server.
-#  Twenty nine files under `test/` still build their GitHub with
-#  `stub_request` and `stub_github`, one thousand one hundred and ninety six
+# @todo #2020:60min Move the rest of the tests onto this server.
+#  Twenty eight files under `test/` still build their GitHub with
+#  `stub_request` and `stub_github`, one thousand one hundred and eighty nine
 #  stubs in all, the heaviest being `test/judges/test-quality-of-service.rb`
 #  with two hundred and fifty three. Each of them should declare its routes
 #  through `Jp::FakeGithub` instead, one file at a time, so that a reviewer

--- a/test/judges/test-fix-missing-branch.rb
+++ b/test/judges/test-fix-missing-branch.rb
@@ -4,62 +4,60 @@
 # SPDX-License-Identifier: MIT
 
 require 'factbase'
+require_relative '../fake_github'
 require_relative '../test__helper'
 
 class TestFixMissingBranch < Jp::Test
   using SmartFactbase
 
   def test_finds_branch_via_pull_request
-    WebMock.disable_net_connect!
-    rate_limit_up
-    stub_github('https://api.github.com/repos/foo/foo', body: { id: 42, full_name: 'foo/foo' })
-    stub_github('https://api.github.com/repositories/42', body: { id: 42, full_name: 'foo/foo' })
-    stub_github(
-      'https://api.github.com/repos/foo/foo/pulls/44',
-      body: {
-        number: 44,
-        state: 'open',
-        head: { ref: 'feature-branch', sha: 'abc123' }
-      }
-    )
     fb = Factbase.new
     fb.with(_id: 1, what: 'pull-was-opened', repository: 42, issue: 44, where: 'github')
-    load_it('fix-missing-branch', fb)
-    f = fb.query('(eq issue 44)').each.first
-    refute_nil(f)
-    assert_equal('feature-branch', f['branch'].first, 'branch must be extracted from pull_request.head.ref')
-    assert_nil(f['stale'], 'fact must NOT be marked stale when branch is found')
+    Jp::FakeGithub.new(
+      'GET /rate_limit' => { resources: { search: { remaining: 30, limit: 30 } }, rate: { remaining: 1000 } },
+      'GET /repos/foo/foo' => { id: 42, full_name: 'foo/foo' },
+      'GET /repositories/42' => { id: 42, full_name: 'foo/foo' },
+      'GET /repos/foo/foo/pulls/44' => {
+        number: 44, state: 'open', head: { ref: 'feature-branch', sha: 'abc123' }
+      }
+    ).run do
+      load_it('fix-missing-branch', fb)
+    end
+    assert_equal(
+      'feature-branch', fb.pick(issue: 44).branch,
+      'the branch is not the head ref of the pull request, while the judge must copy it from there'
+    )
   end
 
   def test_rescues_forbidden_on_pull_request_lookup
-    WebMock.disable_net_connect!
-    rate_limit_up
-    stub_github('https://api.github.com/repos/foo/foo', body: { id: 42, full_name: 'foo/foo' })
-    stub_github('https://api.github.com/repositories/42', body: { id: 42, full_name: 'foo/foo' })
-    stub_github(
-      'https://api.github.com/repos/foo/foo/pulls/44',
-      status: 403,
-      body: { message: 'Resource not accessible by integration' }
-    )
     fb = Factbase.new
     fb.with(_id: 1, what: 'pull-was-opened', repository: 42, issue: 44, where: 'github')
-    load_it('fix-missing-branch', fb)
-    f = fb.query('(eq issue 44)').each.first
-    refute_nil(f)
-    msg = '403 is transient — fact must NOT be marked stale; next cycle will retry the pull_request lookup'
-    assert_nil(f['stale'], msg)
+    Jp::FakeGithub.new(
+      'GET /rate_limit' => { resources: { search: { remaining: 30, limit: 30 } }, rate: { remaining: 1000 } },
+      'GET /repos/foo/foo' => { id: 42, full_name: 'foo/foo' },
+      'GET /repositories/42' => { id: 42, full_name: 'foo/foo' },
+      'GET /repos/foo/foo/pulls/44' => [403, { message: 'Resource not accessible by integration' }]
+    ).run do
+      load_it('fix-missing-branch', fb)
+    end
+    assert_nil(
+      fb.pick(issue: 44)['stale'],
+      'the fact is stale after a transient 403, while the next cycle must retry the pull request lookup'
+    )
   end
 
   def test_rescues_not_found_on_repo_name_lookup
-    WebMock.disable_net_connect!
-    rate_limit_up
-    stub_github('https://api.github.com/repositories/42', status: 404, body: { message: 'Not Found' })
     fb = Factbase.new
     fb.with(_id: 1, what: 'pull-was-opened', repository: 42, issue: 44, where: 'github')
-    load_it('fix-missing-branch', fb)
+    Jp::FakeGithub.new(
+      'GET /rate_limit' => { resources: { search: { remaining: 30, limit: 30 } }, rate: { remaining: 1000 } },
+      'GET /repositories/42' => [404, { message: 'Not Found' }]
+    ).run do
+      load_it('fix-missing-branch', fb)
+    end
     assert(
       fb.one?(what: 'pull-was-opened', repository: 42, stale: 'repository'),
-      'The fact of a vanished repository must be marked stale instead of aborting the judge'
+      'the fact of a vanished repository is not stale, while the judge must mark it instead of aborting'
     )
   end
 end


### PR DESCRIPTION
The `fix-missing-branch` test built its GitHub out of `stub_request` and `stub_github`, seven stubs across three tests. It now declares its routes through `Jp::FakeGithub`, the same way `fix-missing-comments` and `issue-was-opened` already do, so the judge talks to a real socket instead of a mock.

Each test also lost its extra assertions and keeps the single one its name promises, with the failure message stated as a negative claim.

The puzzle in `test/fake_github.rb` moves on to the twenty eight files that are still on WebMock.

Closes #2020
