### PR TITLE
Measure release intervals inside each repository

### DIFF
--- a/judges/quality-of-service/some_release_interval.rb
+++ b/judges/quality-of-service/some_release_interval.rb
@@ -7,7 +7,7 @@ require 'fbe/octo'
 require 'fbe/unmask_repos'
 
 def some_release_interval(fact)
-  dates = []
+  intervals = []
   Fbe.unmask_repos do |repo|
     releases =
       begin
@@ -22,15 +22,17 @@ def some_release_interval(fact)
         )
         next
       end
+    dates = []
     releases.each do |json|
       next if json[:published_at].nil?
       next if json[:published_at] > fact.when
       break if json[:published_at] < fact.since
       dates << json[:published_at]
     end
+    dates.sort!
+    intervals.concat(dates.each_cons(2).map { |pair| pair.last - pair.first })
   end
-  dates.sort!
   {
-    some_release_interval: (1..(dates.size - 1)).map { |i| dates[i] - dates[i - 1] }
+    some_release_interval: intervals
   }
 end

--- a/test/judges/test-some-release-interval.rb
+++ b/test/judges/test-some-release-interval.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+# SPDX-License-Identifier: MIT
+
+require 'factbase'
+require 'judges/options'
+require 'loog'
+require_relative '../fake_github'
+require_relative '../test__helper'
+
+require_relative '../../judges/quality-of-service/some_release_interval'
+
+class TestSomeReleaseInterval < Jp::Test
+  def test_measures_gaps_between_releases_of_one_repository
+    seed = Random.new_seed
+    random = Random.new(seed)
+    gap = random.rand(600..86_400)
+    shift = random.rand(1...gap)
+    base = Time.parse('2024-08-10 00:00:00 UTC')
+    foo = [{ id: 2, published_at: (base + gap).utc.iso8601 }, { id: 1, published_at: base.utc.iso8601 }]
+    bar = [
+      { id: 4, published_at: (base + shift + gap).utc.iso8601 },
+      { id: 3, published_at: (base + shift).utc.iso8601 }
+    ]
+    fact = Factbase.new.insert
+    fact.since = Time.parse('2024-08-01 00:00:00 UTC')
+    fact.when = Time.parse('2024-09-01 00:00:00 UTC')
+    $global = {}
+    $loog = Loog::NULL
+    $options = Judges::Options.new({ 'repositories' => 'foo/foo,foo/bar' })
+    intervals =
+      Jp::FakeGithub.new(
+        'GET /rate_limit' => { resources: { search: { remaining: 30, limit: 30 } }, rate: { remaining: 1000 } },
+        'GET /repos/foo/foo' => { id: 42, full_name: 'foo/foo' },
+        'GET /repos/foo/bar' => { id: 43, full_name: 'foo/bar' },
+        'GET /repos/foo/foo/releases?per_page=100' => [200, foo],
+        'GET /repos/foo/bar/releases?per_page=100' => [200, bar]
+      ).run { some_release_interval(fact)[:some_release_interval] }
+    assert_equal(
+      [gap, gap], intervals,
+      "the intervals #{intervals.inspect} are gaps between releases of different repositories, seed #{seed}"
+    )
+  end
+
+  def test_skips_repository_with_a_single_release
+    seed = Random.new_seed
+    random = Random.new(seed)
+    gap = random.rand(600..86_400)
+    base = Time.parse('2024-08-10 00:00:00 UTC')
+    foo = [{ id: 2, published_at: (base + gap).utc.iso8601 }, { id: 1, published_at: base.utc.iso8601 }]
+    bar = [{ id: 3, published_at: (base + random.rand(1...gap)).utc.iso8601 }]
+    fact = Factbase.new.insert
+    fact.since = Time.parse('2024-08-01 00:00:00 UTC')
+    fact.when = Time.parse('2024-09-01 00:00:00 UTC')
+    $global = {}
+    $loog = Loog::NULL
+    $options = Judges::Options.new({ 'repositories' => 'foo/foo,foo/bar' })
+    intervals =
+      Jp::FakeGithub.new(
+        'GET /rate_limit' => { resources: { search: { remaining: 30, limit: 30 } }, rate: { remaining: 1000 } },
+        'GET /repos/foo/foo' => { id: 42, full_name: 'foo/foo' },
+        'GET /repos/foo/bar' => { id: 43, full_name: 'foo/bar' },
+        'GET /repos/foo/foo/releases?per_page=100' => [200, foo],
+        'GET /repos/foo/bar/releases?per_page=100' => [200, bar]
+      ).run { some_release_interval(fact)[:some_release_interval] }
+    assert_equal(
+      [gap], intervals,
+      "the lonely release of foo/bar became an interval #{intervals.inspect}, seed #{seed}"
+    )
+  end
+end


### PR DESCRIPTION
`some_release_interval` gathered the publication dates of every release from
every repository into one list, sorted it and took the differences between
neighbours. After the sort the neighbours are usually releases of two different
repositories, so most of the reported values were gaps that no repository ever
waited. With a team of N repositories, N-1 of them crossed a repository
boundary.

The dates are now collected and sorted inside the loop over the repositories,
and the gaps of each repository are concatenated into the result. Every value
the judge reports is the time between two consecutive releases of one
repository, and a repository with a single release contributes nothing.

The new test file drives the metric through `Jp::FakeGithub` with two
repositories whose releases interleave, so the old flat list would answer with
three intervals where the correct answer is two.

Closes #2022

https://claude.ai/code/session_0121E69G1wsCiL4MD3Q3o6r3
