### PR TITLE
Skip workflow runs whose usage cannot be read

### DIFF
--- a/judges/quality-of-service/some_build_success_rate.rb
+++ b/judges/quality-of-service/some_build_success_rate.rb
@@ -30,19 +30,21 @@ def some_build_success_rate(fact)
       end
     wfs = workflows.select { |json| json[:status] == 'completed' && !json[:conclusion].nil? }.first(60)
     runs =
-      wfs.map do |json|
+      wfs.filter_map do |json|
         secs =
           begin
-            (Fbe.octo.workflow_run_usage(repo, json[:id])[:run_duration_ms] || 0) / 1000
+            ms = Fbe.octo.workflow_run_usage(repo, json[:id])[:run_duration_ms]
+            next if ms.nil?
+            ms / 1000
           rescue Octokit::NotFound, Octokit::Deprecated => e
             $loog.info("Workflow run usage not found for #{repo}##{json[:id]}: #{e.message}")
-            0
+            next
           rescue Octokit::Forbidden => e
             $loog.warn(
               "[#{$judge}] Access forbidden to workflow run usage for #{repo}##{json[:id]} " \
               "(transient, will retry next cycle): #{e.class}: #{e.message}"
             )
-            0
+            next
           end
         { json: json, secs: secs, completed: json[:run_started_at] + secs }
       end

--- a/test/judges/test-quality-of-service.rb
+++ b/test/judges/test-quality-of-service.rb
@@ -564,7 +564,7 @@ class TestQualityOfService < Jp::Test
     Fbe.stub(:octo, octo) do
       Fbe.stub(:unmask_repos, ->(&block) { block.call('foo/foo') }) do
         metrics = some_build_success_rate(fact)
-        assert_equal([0, 900], metrics[:some_build_duration])
+        assert_equal([900], metrics[:some_build_duration], 'run with missing usage is not left out of durations')
       end
     end
   end
@@ -595,7 +595,88 @@ class TestQualityOfService < Jp::Test
     Fbe.stub(:octo, octo) do
       Fbe.stub(:unmask_repos, ->(&block) { block.call('foo/foo') }) do
         metrics = some_build_success_rate(fact)
-        assert_equal([0, 600], metrics[:some_build_duration])
+        assert_equal([600], metrics[:some_build_duration], 'run with forbidden usage is not left out of durations')
+      end
+    end
+  end
+
+  def test_dont_count_run_with_unreadable_usage_as_success
+    $loog = Loog::NULL
+    load(File.join(__dir__, '../../judges/quality-of-service/some_build_success_rate.rb'))
+    seed = Random.new_seed
+    secs = Random.new(seed).rand(1..3_600)
+    started = Time.parse('2024-08-07T10:00:00Z')
+    octo = Object.new
+    octo.define_singleton_method(:repository_workflow_runs) do |*|
+      {
+        workflow_runs: [
+          { id: 1, status: 'completed', conclusion: 'success', workflow_id: 101, run_started_at: started },
+          { id: 2, status: 'completed', conclusion: 'success', workflow_id: 101, run_started_at: started + 3_600 }
+        ]
+      }
+    end
+    octo.define_singleton_method(:workflow_run_usage) do |_, id|
+      raise(Octokit::NotFound) if id == 1
+      { run_duration_ms: secs * 1_000 }
+    end
+    fact = Struct.new(:since, :when).new(Time.parse('2024-08-02T21:00:00Z'), Time.parse('2024-08-09T21:00:00Z'))
+    Fbe.stub(:octo, octo) do
+      Fbe.stub(:unmask_repos, ->(&block) { block.call('foo/foo') }) do
+        metrics = some_build_success_rate(fact)
+        assert_equal([1], metrics[:some_build_success_rate], "success rate counts unreadable run, seed: #{seed}")
+      end
+    end
+  end
+
+  def test_dont_pair_failure_with_unreadable_usage
+    $loog = Loog::NULL
+    load(File.join(__dir__, '../../judges/quality-of-service/some_build_success_rate.rb'))
+    started = Time.parse('2024-08-07T10:00:00Z')
+    octo = Object.new
+    octo.define_singleton_method(:repository_workflow_runs) do |*|
+      {
+        workflow_runs: [
+          { id: 1, status: 'completed', conclusion: 'failure', workflow_id: 101, run_started_at: started },
+          { id: 2, status: 'completed', conclusion: 'success', workflow_id: 101, run_started_at: started + 3_600 }
+        ]
+      }
+    end
+    octo.define_singleton_method(:workflow_run_usage) do |_, id|
+      raise(Octokit::Forbidden) if id == 1
+      { run_duration_ms: 600_000 }
+    end
+    fact = Struct.new(:since, :when).new(Time.parse('2024-08-02T21:00:00Z'), Time.parse('2024-08-09T21:00:00Z'))
+    Fbe.stub(:octo, octo) do
+      Fbe.stub(:unmask_repos, ->(&block) { block.call('foo/foo') }) do
+        metrics = some_build_success_rate(fact)
+        assert_equal([], metrics[:some_build_mttr], 'repair times pair a failure with unreadable usage')
+      end
+    end
+  end
+
+  def test_skips_run_without_duration
+    $loog = Loog::NULL
+    load(File.join(__dir__, '../../judges/quality-of-service/some_build_success_rate.rb'))
+    seed = Random.new_seed
+    secs = Random.new(seed).rand(1..3_600)
+    started = Time.parse('2024-08-07T10:00:00Z')
+    octo = Object.new
+    octo.define_singleton_method(:repository_workflow_runs) do |*|
+      {
+        workflow_runs: [
+          { id: 1, status: 'completed', conclusion: 'success', workflow_id: 101, run_started_at: started },
+          { id: 2, status: 'completed', conclusion: 'success', workflow_id: 101, run_started_at: started + 3_600 }
+        ]
+      }
+    end
+    octo.define_singleton_method(:workflow_run_usage) do |_, id|
+      id == 1 ? {} : { run_duration_ms: secs * 1_000 }
+    end
+    fact = Struct.new(:since, :when).new(Time.parse('2024-08-02T21:00:00Z'), Time.parse('2024-08-09T21:00:00Z'))
+    Fbe.stub(:octo, octo) do
+      Fbe.stub(:unmask_repos, ->(&block) { block.call('foo/foo') }) do
+        metrics = some_build_success_rate(fact)
+        assert_equal([secs], metrics[:some_build_duration], "durations count a run without usage, seed: #{seed}")
       end
     end
   end


### PR DESCRIPTION
When `workflow_run_usage` came back as a 404, a 403 or a deprecation, the rescue arm returned zero seconds and the run was recorded as if it had really taken no time at all. That zero landed in `some_build_duration`, and because `completed` is `run_started_at + secs` it also collapsed to the start time, which reordered `runs.sort_by!` and fed the wrong timestamp into the failure-to-success pairing behind `some_build_mttr`. The `Forbidden` arm called itself transient while writing a permanent number.

Now such a run is dropped: `map` becomes `filter_map` and every arm that cannot read the usage does `next`. A transient API failure lowers the sample size instead of pulling the average down.

The same fabricated zero came from `run_duration_ms` being nil, so that path is skipped too rather than defaulting to zero. The tests named `test_skips_run_on_not_found_workflow_run_usage` and `test_skips_run_on_forbidden_workflow_run_usage` asserted the old zeros despite their names, so their expectations were corrected, and three more cover the success rate, the repair times and the missing duration.

`code-was-reviewed.rb` has the same shape and is tracked separately in #1942, so it is untouched here.

Closes #2024