### PR TITLE
Skip total_commits instead of writing a zero when the count fails

### DIFF
--- a/judges/dimensions-of-terrain/total_commits.rb
+++ b/judges/dimensions-of-terrain/total_commits.rb
@@ -6,6 +6,7 @@
 require 'fbe/github_graph'
 require 'fbe/octo'
 require 'fbe/unmask_repos'
+require 'net/http'
 require_relative '../../lib/patches/unmask_repos'
 
 def total_commits(_fact)
@@ -26,16 +27,16 @@ def total_commits(_fact)
     next if json[:default_branch].nil?
     repos << [*repo.split('/'), json[:default_branch]]
   end
-  {
-    total_commits:
-    begin
-      repos.empty? ? 0 : Fbe.github_graph.total_commits(repos:).sum { _1['total_commits'] }
-    rescue GraphQL::Client::Error, Fbe::Error => e
-      $loog.info("Can't count total commits: #{e.message}")
-      0
-    rescue Net::OpenTimeout, Net::ReadTimeout, SocketError, Errno::ECONNRESET, Errno::ETIMEDOUT => e
-      $loog.warn("[#{$judge}] Network error counting commits: #{e.message}")
-      0
-    end
-  }
+  begin
+    { total_commits: repos.empty? ? 0 : Fbe.github_graph.total_commits(repos:).sum { _1['total_commits'] } }
+  rescue GraphQL::Client::Error, Fbe::Error => e
+    $loog.info("Can't count commits in #{repos.count} repositories, skipping total_commits: #{e.message}")
+    {}
+  rescue Net::OpenTimeout, Net::ReadTimeout, SocketError, Errno::ECONNRESET, Errno::ETIMEDOUT => e
+    $loog.warn(
+      "[#{$judge}] Network error counting commits in #{repos.count} repositories " \
+      "(transient, will retry next cycle), skipping total_commits: #{e.message}"
+    )
+    {}
+  end
 end

--- a/test/judges/test-dimensions-of-terrain.rb
+++ b/test/judges/test-dimensions-of-terrain.rb
@@ -541,7 +541,7 @@ class TestDimensionsOfTerrain < Jp::Test
     end
   end
 
-  def test_total_commits_rescues_fbe_error_from_graph
+  def test_total_commits_skips_property_on_fbe_error
     WebMock.disable_net_connect!
     rate_limit_up
     stub_github(
@@ -562,7 +562,65 @@ class TestDimensionsOfTerrain < Jp::Test
     end.new
     Fbe.stub(:github_graph, graph) do
       load(File.join(__dir__, '../../judges/dimensions-of-terrain/total_commits.rb'))
-      assert_equal({ total_commits: 0 }, total_commits(nil))
+      assert_equal({}, total_commits(nil))
+    end
+  end
+
+  def test_total_commits_skips_property_on_network_error
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github(
+      'https://api.github.com/repos/foo/unreachable', body: {
+        name: 'unreachable', full_name: 'foo/unreachable', size: 42,
+        stargazers_count: 0, forks: 0, default_branch: 'main', archived: false
+      }
+    )
+    $judge = 'dimensions-of-terrain'
+    $global = {}
+    $local = {}
+    $loog = Loog::NULL
+    $options = Judges::Options.new({ 'repositories' => 'foo/unreachable' })
+    graph = Class.new(Fbe::Graph::Fake) do
+      define_method(:total_commits) do |*_args, **_kwargs|
+        raise(Net::ReadTimeout, 'api.github.com kept silent for 60 seconds')
+      end
+    end.new
+    Fbe.stub(:github_graph, graph) do
+      load(File.join(__dir__, '../../judges/dimensions-of-terrain/total_commits.rb'))
+      assert_equal({}, total_commits(nil))
+    end
+  end
+
+  def test_dont_write_total_commits_when_graph_breaks
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github(
+      'https://api.github.com/repos/foo/broken', body: {
+        name: 'broken', full_name: 'foo/broken', size: 3,
+        stargazers_count: 0, forks: 0, default_branch: 'master', archived: false
+      }
+    )
+    stub_github('https://api.github.com/repos/foo/broken/releases?per_page=100', body: [])
+    stub_github(
+      'https://api.github.com/repos/foo/broken/git/trees/master?recursive=true',
+      body: { sha: 'a', tree: [], truncated: false }
+    )
+    stub_github('https://api.github.com/repos/foo/broken/contributors?per_page=100', body: [])
+    stub_github(
+      'https://api.github.com/search/commits?per_page=100&q=repo:foo/broken%20author-date:%3E2024-08-30',
+      body: { total_count: 0, incomplete_results: false, items: [] }
+    )
+    graph = Class.new(Fbe::Graph::Fake) do
+      define_method(:total_commits) do |*_args, **_kwargs|
+        raise(Fbe::Error, "Repository 'foo/broken' or branch 'master' not found")
+      end
+    end.new
+    fb = Factbase.new
+    Fbe.stub(:github_graph, graph) do
+      Time.stub(:now, Time.parse('2024-09-29 21:00:00 UTC')) do
+        load_it('dimensions-of-terrain', fb, Judges::Options.new({ 'repositories' => 'foo/broken' }))
+        assert_nil(fb.query("(eq what 'dimensions-of-terrain')").each.first['total_commits'])
+      end
     end
   end
 


### PR DESCRIPTION
A failed GraphQL call or a network timeout while counting commits used to be recorded as a real count of zero. Since `total_commits` is a cumulative total that only ever grows, one timeout dragged the vitals chart down to zero and the next cycle threw it back up again. The number lost the distinction between "we looked and there are no commits" and "we could not look", and only the log line kept it.

The judge now returns an empty hash from both rescue branches, so `incremate` writes no property at all and the value from the previous cycle stands until a count succeeds. This is the same shape `total_files` already uses when it gives up on a truncated tree. A genuine zero still reaches the fact when there are no repositories to measure. The two log messages now carry the repository count, and `net/http` is required explicitly, since the network rescue is what the new behaviour rests on.

Three tests cover it: the two rescue branches in isolation, and one that runs the whole judge and asserts the fact carries no `total_commits` after the graph fails.

The same shape lives in `code-was-reviewed.rb`, reported separately as #1942, and is left alone here.

Closes #2025
