### PR TITLE
Omit total_builds_ran when a repository cannot be read

### DIFF
--- a/judges/quantity-of-deliverables/total_builds_ran.rb
+++ b/judges/quantity-of-deliverables/total_builds_ran.rb
@@ -7,25 +7,28 @@ require 'fbe/octo'
 require 'fbe/unmask_repos'
 
 def total_builds_ran(fact)
-  {
-    total_builds_ran:
-      Fbe.unmask_repos.sum do |repo|
-        Fbe.octo.with_disable_auto_paginate do |octo|
-          octo.repository_workflow_runs(
-            repo,
-            created: "#{fact.since.utc.iso8601[0..9]}..#{fact.when.utc.iso8601[0..9]}",
-            per_page: 1
-          )[:total_count]
-        end
-      rescue Octokit::NotFound, Octokit::Deprecated => e
-        $loog.info("Workflow runs not found for #{repo}: #{e.message}")
-        0
-      rescue Octokit::Forbidden => e
-        $loog.warn(
-          "[#{$judge}] Access forbidden to workflow runs for #{repo} " \
-          "(transient, will retry next cycle): #{e.class}: #{e.message}"
-        )
-        next 0
+  total = 0
+  Fbe.unmask_repos.each do |repo|
+    total +=
+      Fbe.octo.with_disable_auto_paginate do |octo|
+        octo.repository_workflow_runs(
+          repo,
+          created: "#{fact.since.utc.iso8601[0..9]}..#{fact.when.utc.iso8601[0..9]}",
+          per_page: 1
+        )[:total_count]
       end
-  }
+  rescue Octokit::NotFound, Octokit::Deprecated => e
+    $loog.info(
+      "[#{$judge}] Workflow runs of #{repo} are not readable, " \
+      "no total_builds_ran reported: #{e.class}: #{e.message}"
+    )
+    return {}
+  rescue Octokit::Forbidden => e
+    $loog.warn(
+      "[#{$judge}] Access forbidden to workflow runs of #{repo}, " \
+      "no total_builds_ran reported (will retry next cycle): #{e.class}: #{e.message}"
+    )
+    return {}
+  end
+  { total_builds_ran: total }
 end

--- a/test/judges/test-quantity-of-deliverables.rb
+++ b/test/judges/test-quantity-of-deliverables.rb
@@ -370,7 +370,7 @@ class TestQuantityOfDeliverables < Jp::Test
     end
   end
 
-  def test_total_builds_ran_skips_forbidden
+  def test_dont_report_total_when_forbidden
     WebMock.disable_net_connect!
     rate_limit_up
     stub_github(
@@ -383,10 +383,56 @@ class TestQuantityOfDeliverables < Jp::Test
     $judge = 'quantity-of-deliverables'
     $loog = Loog::NULL
     $global = {}
-    $options = Judges::Options.new({ 'repositories' => 'foo/foo' })
+    $options = Judges::Options.new({ 'repositories' => 'foo/blocked' })
     Fbe.stub(:unmask_repos, ['foo/blocked']) do
       load(File.join(__dir__, '../../judges/quantity-of-deliverables/total_builds_ran.rb'))
-      assert_equal({ total_builds_ran: 0 }, total_builds_ran(fact))
+      assert_empty(total_builds_ran(fact), 'forbidden repository is reported as a total instead of being omitted')
+    end
+  end
+
+  def test_dont_report_total_when_one_repo_forbidden
+    WebMock.disable_net_connect!
+    rate_limit_up
+    seed = Random.new_seed
+    runs = Random.new(seed).rand(1..999)
+    stub_github(
+      'https://api.github.com/repos/foo/good/actions/runs?created=2025-10-01..2025-10-06&per_page=1',
+      body: { total_count: runs, workflow_runs: [] }
+    )
+    stub_github(
+      'https://api.github.com/repos/foo/blocked/actions/runs?created=2025-10-01..2025-10-06&per_page=1',
+      status: 403, body: { message: 'Forbidden' }
+    )
+    fact = Object.new
+    fact.define_singleton_method(:since) { Time.parse('2025-10-01 00:00:00 UTC') }
+    fact.define_singleton_method(:when) { Time.parse('2025-10-06 00:00:00 UTC') }
+    $judge = 'quantity-of-deliverables'
+    $loog = Loog::NULL
+    $global = {}
+    $options = Judges::Options.new({ 'repositories' => 'foo/good,foo/blocked' })
+    Fbe.stub(:unmask_repos, %w[foo/good foo/blocked]) do
+      load(File.join(__dir__, '../../judges/quantity-of-deliverables/total_builds_ran.rb'))
+      assert_empty(total_builds_ran(fact), "partial total is reported while a repository is blocked, seed: #{seed}")
+    end
+  end
+
+  def test_dont_report_total_when_runs_are_absent
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github(
+      'https://api.github.com/repos/foo/gone/actions/runs?created=2025-10-01..2025-10-06&per_page=1',
+      status: 404, body: { message: 'Not Found' }
+    )
+    fact = Object.new
+    fact.define_singleton_method(:since) { Time.parse('2025-10-01 00:00:00 UTC') }
+    fact.define_singleton_method(:when) { Time.parse('2025-10-06 00:00:00 UTC') }
+    $judge = 'quantity-of-deliverables'
+    $loog = Loog::NULL
+    $global = {}
+    $options = Judges::Options.new({ 'repositories' => 'foo/gone' })
+    Fbe.stub(:unmask_repos, ['foo/gone']) do
+      load(File.join(__dir__, '../../judges/quantity-of-deliverables/total_builds_ran.rb'))
+      assert_empty(total_builds_ran(fact), 'unreadable repository is reported as a total instead of being omitted')
     end
   end
 


### PR DESCRIPTION
When `repository_workflow_runs` failed for one repository, that repository quietly contributed zero to the sum, and the sum was stored on the fact as if it were complete. Nothing ever revisits a fact that already carries `total_builds_ran`, so the number for that period stayed short forever. The `Forbidden` arm was the worst of it: it logged that the failure was transient and would be retried next cycle, and then made sure no retry could ever happen.

Now an unreadable repository ends the count instead of shrinking it. Both rescue arms return an empty hash, `incremate` writes nothing, and the property stays absent, so the next cycle picks the judge up again and has a real chance of producing an honest total. The two arms also agree in form now, rather than one saying `0` and the other `next 0` for the same effect.

The old `total_builds_ran_skips_forbidden` test asserted the bug, so it is replaced by three: a forbidden repository on its own, a forbidden repository alongside a readable one that used to yield a plausible partial total, and an unreadable one.

Closes #2026
