### PR TITLE
fix(#2027): treat an absent field as a non-match in twice

### DIFF
--- a/lib/twice.rb
+++ b/lib/twice.rb
@@ -7,8 +7,7 @@ require_relative 'jp'
 
 def Jp.twice?(fb, fact, what, fields)
   pairs = fields.to_h { [_1, fact[_1]&.first] }
-  pairs.compact!
   fb.query(
-    "(and (eq what $what) #{pairs.keys.map { "(eq #{_1} $#{_1})" }.join(' ')})"
-  ).each(fb, pairs.merge('what' => what)).to_a.size > 1
+    "(and (eq what $what) #{fields.map { pairs[_1].nil? ? "(absent #{_1})" : "(eq #{_1} $#{_1})" }.join(' ')})"
+  ).each(fb, pairs.compact.merge('what' => what)).to_a.size > 1
 end

--- a/test/lib/test_twice.rb
+++ b/test/lib/test_twice.rb
@@ -65,15 +65,61 @@ class TestTwice < Minitest::Test
     )
   end
 
+  def test_lets_an_unlabeled_event_through_when_another_one_has_a_label
+    fb = Factbase.new
+    event(fb, 'label-was-attached', 42)
+    insert(fb, 'bug', repository: 42)
+    refute(
+      Jp.twice?(fb, fb.query('(absent label)').each.to_a.first, 'label-was-attached', %w[where repository issue label]),
+      'an event without a label cannot be a duplicate of one that carries a label'
+    )
+  end
+
+  def test_finds_the_second_copy_when_neither_event_has_a_label
+    fb = Factbase.new
+    2.times { event(fb, 'label-was-attached', 42) }
+    assert(
+      Jp.twice?(fb, fb.query('(absent label)').each.to_a.first, 'label-was-attached', %w[where repository issue label]),
+      'two identical events without a label cannot both stay'
+    )
+  end
+
+  def test_lets_another_label_through_on_the_same_issue
+    fb = Factbase.new
+    insert(fb, 'bug', repository: 42)
+    insert(fb, 'ошибка', repository: 42)
+    refute(
+      Jp.twice?(
+        fb, fb.query("(eq label 'ошибка')").each.to_a.first, 'label-was-attached', %w[where repository issue label]
+      ),
+      'a second label on the same issue cannot count as a duplicate'
+    )
+  end
+
+  def test_lets_an_authorless_event_through_when_another_one_has_an_author
+    fb = Factbase.new
+    event(fb, 'issue-was-opened', 42)
+    event(fb, 'issue-was-opened', 42).who = 333
+    refute(
+      Jp.twice?(fb, fb.query('(absent who)').each.to_a.first, 'issue-was-opened', %w[where repository issue who]),
+      'an event without an author cannot be a duplicate of one that names an author'
+    )
+  end
+
   private
 
   def insert(fb, label, repository: 42)
+    f = event(fb, 'label-was-attached', repository)
+    f.label = label
+    f
+  end
+
+  def event(fb, what, repository)
     f = fb.insert
-    f.what = 'label-was-attached'
+    f.what = what
     f.where = 'github'
     f.repository = repository
     f.issue = 7
-    f.label = label
     f
   end
 end


### PR DESCRIPTION
`Jp.twice?` built its duplicate-detection query from the fields the fact actually carried, dropping the rest. Dropping a field widens the query instead of narrowing it, so a fact missing one of the compared fields matched every other fact that shared the remaining ones, and the answer flipped from "not a duplicate" to "duplicate".

In `github-events` that decides whether a freshly detected event survives. A `label-was-attached` fact without a `label` collapsed the query to "any label was attached to this issue in this repository", so the first label on an issue was kept and every later one was rolled back. The same happened to `type-was-attached` without a `type`, and to the `who` sets when the actor was gone, which is what a deleted account looks like.

Now every compared field contributes a term: an equality when the fact carries a value, and `(absent ...)` when it does not. Removing a field can no longer broaden the match, and two facts count as the same event only when they agree on the present fields and on the missing ones.

The tests cover an unlabeled event standing next to a labeled one, two unlabeled events that really are duplicates, a second distinct label on the same issue, and an authorless `issue-was-opened` alongside one that names an author.

Closes #2027
