### PR TITLE
Move fix-missing-who tests onto the fake GitHub server

### DIFF
--- a/test/fake_github.rb
+++ b/test/fake_github.rb
@@ -9,9 +9,9 @@ require 'socket'
 require_relative '../lib/jp'
 
 # rubocop:disable Elegant/NoComments
-# @todo #2020:60min Move the rest of the tests onto this server.
-#  Twenty eight files under `test/` still build their GitHub with
-#  `stub_request` and `stub_github`, one thousand one hundred and eighty nine
+# @todo #2028:60min Move the rest of the tests onto this server.
+#  Twenty seven files under `test/` still build their GitHub with
+#  `stub_request` and `stub_github`, one thousand one hundred and seventy nine
 #  stubs in all, the heaviest being `test/judges/test-quality-of-service.rb`
 #  with two hundred and fifty three. Each of them should declare its routes
 #  through `Jp::FakeGithub` instead, one file at a time, so that a reviewer

--- a/test/judges/test-fix-missing-who.rb
+++ b/test/judges/test-fix-missing-who.rb
@@ -4,76 +4,75 @@
 # SPDX-License-Identifier: MIT
 
 require 'factbase'
+require_relative '../fake_github'
 require_relative '../test__helper'
 
 class TestFixMissingWho < Jp::Test
   using SmartFactbase
 
   def test_rescues_forbidden_on_issue_lookup
-    WebMock.disable_net_connect!
-    rate_limit_up
-    stub_github('https://api.github.com/repos/foo/foo', body: { id: 42, full_name: 'foo/foo' })
-    stub_github('https://api.github.com/repositories/42', body: { id: 42, full_name: 'foo/foo' })
-    stub_github(
-      'https://api.github.com/repos/foo/foo/issues/44',
-      status: 403,
-      body: { message: 'Resource not accessible by integration' }
-    )
     fb = Factbase.new
     fb.with(_id: 1, what: 'pull-was-opened', repository: 42, issue: 44, where: 'github')
-    load_it('fix-missing-who', fb)
-    f = fb.query('(eq issue 44)').each.first
-    refute_nil(f)
-    assert_nil(f['stale'], '403 is transient — fact must NOT be marked stale; next cycle will retry the issue lookup')
-    assert_nil(f['who'], 'who must remain absent so the next cycle re-runs the lookup')
+    Jp::FakeGithub.new(
+      'GET /rate_limit' => { resources: { search: { remaining: 30, limit: 30 } }, rate: { remaining: 1000 } },
+      'GET /repos/foo/foo' => { id: 42, full_name: 'foo/foo' },
+      'GET /repositories/42' => { id: 42, full_name: 'foo/foo' },
+      'GET /repos/foo/foo/issues/44' => [403, { message: 'Resource not accessible by integration' }]
+    ).run do
+      load_it('fix-missing-who', fb)
+    end
+    assert_nil(
+      fb.pick(issue: 44)['stale'],
+      'the fact is stale after a transient 403, while the next cycle must retry the issue lookup'
+    )
   end
 
   def test_rescues_deprecated_on_issue_lookup
-    WebMock.disable_net_connect!
-    rate_limit_up
-    stub_github('https://api.github.com/repos/foo/foo', body: { id: 42, full_name: 'foo/foo' })
-    stub_github('https://api.github.com/repositories/42', body: { id: 42, full_name: 'foo/foo' })
-    stub_github(
-      'https://api.github.com/repos/foo/foo/issues/55',
-      status: 410,
-      body: { message: 'Issues are disabled for this repo' }
-    )
     fb = Factbase.new
     fb.with(_id: 1, what: 'issue-was-opened', repository: 42, issue: 55, where: 'github')
-    load_it('fix-missing-who', fb)
-    f = fb.query('(eq issue 55)').each.first
-    refute_nil(f)
-    assert_equal('issue', f['stale'].first, '410 is permanent — fact must be marked stale via Jp.issue_was_lost')
+    Jp::FakeGithub.new(
+      'GET /rate_limit' => { resources: { search: { remaining: 30, limit: 30 } }, rate: { remaining: 1000 } },
+      'GET /repos/foo/foo' => { id: 42, full_name: 'foo/foo' },
+      'GET /repositories/42' => { id: 42, full_name: 'foo/foo' },
+      'GET /repos/foo/foo/issues/55' => [410, { message: 'Issues are disabled for this repo' }]
+    ).run do
+      load_it('fix-missing-who', fb)
+    end
+    assert_equal(
+      'issue', fb.pick(issue: 55)['stale'].first,
+      'the issue is not stale after a permanent 410, while the judge must give up on it'
+    )
   end
 
   def test_reads_merged_by_from_pull_endpoint
-    WebMock.disable_net_connect!
-    rate_limit_up
-    stub_github('https://api.github.com/repos/foo/foo', body: { id: 42, full_name: 'foo/foo' })
-    stub_github('https://api.github.com/repositories/42', body: { id: 42, full_name: 'foo/foo' })
-    stub_github(
-      'https://api.github.com/repos/foo/foo/pulls/66',
-      body: { number: 66, merged_by: { id: 7, login: 'merger' } }
-    )
     fb = Factbase.new
     fb.with(_id: 1, what: 'pull-was-merged', repository: 42, issue: 66, where: 'github')
-    load_it('fix-missing-who', fb)
-    f = fb.query('(eq issue 66)').each.first
-    refute_nil(f)
-    assert_equal(7, f['who'].first, 'merged_by.id from pulls endpoint must be assigned to who')
-    assert_nil(f['stale'], 'fact must not be marked stale when merged_by is present on the pull payload')
+    Jp::FakeGithub.new(
+      'GET /rate_limit' => { resources: { search: { remaining: 30, limit: 30 } }, rate: { remaining: 1000 } },
+      'GET /repos/foo/foo' => { id: 42, full_name: 'foo/foo' },
+      'GET /repositories/42' => { id: 42, full_name: 'foo/foo' },
+      'GET /repos/foo/foo/pulls/66' => { number: 66, merged_by: { id: 7, login: 'merger' } }
+    ).run do
+      load_it('fix-missing-who', fb)
+    end
+    assert_equal(
+      7, fb.pick(issue: 66).who,
+      'the author is not the merged_by user of the pull request, while the judge must copy it from there'
+    )
   end
 
   def test_rescues_not_found_on_repo_name_lookup
-    WebMock.disable_net_connect!
-    rate_limit_up
-    stub_github('https://api.github.com/repositories/42', status: 404, body: { message: 'Not Found' })
     fb = Factbase.new
     fb.with(_id: 1, what: 'pull-was-opened', repository: 42, issue: 44, where: 'github')
-    load_it('fix-missing-who', fb)
+    Jp::FakeGithub.new(
+      'GET /rate_limit' => { resources: { search: { remaining: 30, limit: 30 } }, rate: { remaining: 1000 } },
+      'GET /repositories/42' => [404, { message: 'Not Found' }]
+    ).run do
+      load_it('fix-missing-who', fb)
+    end
     assert(
       fb.one?(what: 'pull-was-opened', repository: 42, stale: 'repository'),
-      'The fact of a vanished repository must be marked stale instead of aborting the judge'
+      'the fact of a vanished repository is not stale, while the judge must mark it instead of aborting'
     )
   end
 end


### PR DESCRIPTION
The four tests of `fix-missing-who` no longer build their GitHub out of
`stub_request` and `stub_github`. Each one now declares the routes it needs on
`Jp::FakeGithub` and runs the judge inside the server, the same way
`fix-missing-branch` was moved earlier.

Along the way the assertions got tightened: one assertion per test, and the
403 case now checks that the fact stays unstale rather than that `who` stays
absent. The old check passed even when the route was never reached, because a
missing route answers 404 and leaves `who` absent too.

The puzzle in `test/fake_github.rb` is renumbered and its counts follow: twenty
seven files are left on the old stubs.

Closes #2028
