### PR TITLE
Read a route array as a status pair only when it starts with an integer

### DIFF
--- a/test/fake_github.rb
+++ b/test/fake_github.rb
@@ -81,7 +81,7 @@ class Jp::FakeGithub
   def reply(route)
     case route
     when Integer then [route, {}]
-    when Array then route
+    when Array then route.first.is_a?(Integer) ? route : [200, route]
     else [200, route]
     end
   end

--- a/test/test_fake_github.rb
+++ b/test/test_fake_github.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+# SPDX-License-Identifier: MIT
+
+require 'octokit'
+require_relative 'fake_github'
+require_relative 'test__helper'
+
+class TestFakeGithub < Jp::Test
+  def test_serves_array_body
+    seed = Random.new_seed
+    number = Random.new(seed).rand(1_000_000)
+    Jp::FakeGithub.new(
+      'GET /repos/foo/foo/releases' => [{ id: number, name: 'Ω первый' }]
+    ).run do
+      assert_equal(
+        number, Octokit::Client.new.releases('foo/foo').first[:id],
+        "the array body did not reach the client as the single release declared, seed #{seed}"
+      )
+    end
+  end
+
+  def test_serves_empty_array_body
+    Jp::FakeGithub.new(
+      'GET /repos/foo/foo/releases' => []
+    ).run do
+      assert_empty(
+        Octokit::Client.new.releases('foo/foo'),
+        'the empty array body did not reach the client as an empty list of releases'
+      )
+    end
+  end
+
+  def test_serves_status_paired_with_array_body
+    seed = Random.new_seed
+    number = Random.new(seed).rand(1_000_000)
+    Jp::FakeGithub.new(
+      'GET /repos/foo/foo/releases' => [200, [{ id: number, name: '' }]]
+    ).run do
+      assert_equal(
+        number, Octokit::Client.new.releases('foo/foo').first[:id],
+        "the status paired with an array body did not reach the client as the release declared, seed #{seed}"
+      )
+    end
+  end
+
+  def test_serves_hash_body
+    seed = Random.new_seed
+    number = Random.new(seed).rand(1_000_000)
+    Jp::FakeGithub.new(
+      'GET /repos/foo/foo' => { id: number, full_name: 'foo/foo' }
+    ).run do
+      assert_equal(
+        number, Octokit::Client.new.repository('foo/foo')[:id],
+        "the hash body did not reach the client as the repository declared, seed #{seed}"
+      )
+    end
+  end
+end

--- a/test/test_fake_github.rb
+++ b/test/test_fake_github.rb
@@ -21,6 +21,20 @@ class TestFakeGithub < Jp::Test
     end
   end
 
+  def test_serves_array_body_of_several_items
+    seed = Random.new_seed
+    random = Random.new(seed)
+    numbers = [random.rand(1_000_000), random.rand(1_000_000)]
+    Jp::FakeGithub.new(
+      'GET /repos/foo/foo/releases' => [{ id: numbers.first, name: '' }, { id: numbers.last, name: 'Ω' }]
+    ).run do
+      assert_equal(
+        numbers, Octokit::Client.new.releases('foo/foo').map { |release| release[:id] },
+        "the array body of two releases did not reach the client in the order declared, seed #{seed}"
+      )
+    end
+  end
+
   def test_serves_empty_array_body
     Jp::FakeGithub.new(
       'GET /repos/foo/foo/releases' => []


### PR DESCRIPTION
`Jp::FakeGithub#reply` decided what a route declaration meant by its class, and every `Array` was read as the pair `[status, body]`. A route whose body is itself a JSON array was therefore torn apart: the first element became the status and the rest became the body, so the server wrote `HTTP/1.1 {id: 2, ...} Error` on the wire and Faraday refused it as a malformed status line. Since releases, issues, commits, comments and workflow runs all answer with an array, this met almost anyone declaring a real GitHub endpoint, and it surfaced as a connection error rather than as a route the server cannot express.

The route now says its own shape. An `Array` is read as a status pair only when its first element is an `Integer`, and any other array is served as the body. That mirrors the `Integer` branch above it, which already reads a bare status code the same way, and every route declared in the tests today keeps working exactly as before.

`test/test_fake_github.rb` covers the server itself for the first time: an array body of one and of several releases, an empty array, a status paired with an array body, and a plain hash body.

Closes #2032
