### PR TITLE
#2037: log the count where it is not zero

### DIFF
--- a/lib/issue_was_lost.rb
+++ b/lib/issue_was_lost.rb
@@ -18,7 +18,10 @@ def Jp.issue_was_lost(where, repository, issue)
       (absent tombstone))"
     ).each { |f| f.stale = 'issue' }
   Fbe::Tombstone.new.bury!(where, repository, issue)
-  return if stale.positive?
+  if stale.positive?
+    $loog.info("The issue #{issue} was marked as lost, #{stale} facts marked as stale")
+    return
+  end
   f =
     Fbe.if_absent do |n|
       n.issue = issue
@@ -32,5 +35,5 @@ def Jp.issue_was_lost(where, repository, issue)
   end
   f.stale = 'issue'
   f.when = Time.now
-  $loog.info("The issue #{issue} was marked as lost, #{stale} facts marked as stale")
+  $loog.info("The issue #{issue} was marked as lost")
 end

--- a/test/lib/test_issue_was_lost.rb
+++ b/test/lib/test_issue_was_lost.rb
@@ -39,6 +39,20 @@ class TestIssueWasLost < Minitest::Test
     end
   end
 
+  def test_logs_how_many_facts_were_marked_stale
+    fb = Factbase.new
+    f = fb.insert
+    f.where = 'github'
+    f.repository = 42
+    f.issue = 7
+    f.what = 'pull-was-opened'
+    Fbe.stub(:fb, fb) do
+      $loog = Loog::Buffer.new
+      Jp.issue_was_lost('github', 42, 7)
+      assert_includes($loog.to_s, '1 facts marked as stale', $loog.to_s)
+    end
+  end
+
   def test_graceful_on_second_call_for_same_issue
     fb = Factbase.new
     Fbe.stub(:fb, fb) do


### PR DESCRIPTION
`return if stale.positive?` meant the line below it was reachable only when `stale` was
zero, so the log always said "0 facts marked as stale".

The count now goes into the branch that has it, and the message that stays does not
mention it.

Closes #2037
