### PR TITLE
#2045: count only the comments that people made

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -52,6 +52,7 @@ Elegant/GoodMethodName:
     - issue_was_lost
     - nick_of
     - comments_info
+    - human_comments
     - count_appreciated_comments
     - fetch_workflows
     - count_suggestions

--- a/judges/code-was-reviewed/code-was-reviewed.rb
+++ b/judges/code-was-reviewed/code-was-reviewed.rb
@@ -9,6 +9,7 @@ require 'fbe/issue'
 require 'fbe/octo'
 require 'fbe/who'
 require 'octokit'
+require_relative '../../lib/humans'
 require_relative '../../lib/issue_was_lost'
 
 Fbe.consider(
@@ -116,7 +117,7 @@ Fbe.consider(
       n.author = pr.dig(:user, :id)
       count ||=
         begin
-          Fbe.octo.issue_comments(repo, f.issue).count
+          Jp.human_comments(Fbe.octo.issue_comments(repo, f.issue)).count
         rescue Octokit::NotFound, Octokit::Deprecated => e
           $loog.info("Issue comments not found for #{repo}##{f.issue}: #{e.message}")
           0

--- a/judges/is-human-or-robot/is-human-or-robot.rb
+++ b/judges/is-human-or-robot/is-human-or-robot.rb
@@ -6,6 +6,7 @@
 require 'fbe/consider'
 require 'fbe/issue'
 require 'fbe/octo'
+require_relative '../../lib/humans'
 
 @bots = nil
 
@@ -35,14 +36,7 @@ Fbe.consider(
     end
   type = json[:type]
   location = "#{f.what} at #{Fbe.issue(f) if f['issue']}"
-  @bots ||=
-    if $options.respond_to?(:bots) && !$options.bots.nil? && !$options.bots.empty?
-      names = $options.bots.split(',').map(&:strip)
-      names.reject!(&:empty?)
-      names
-    else
-      []
-    end
+  @bots ||= Jp.bots
   if type == 'Bot' || @bots.include?(json[:login])
     f.is_human = 0
     $loog.info("GitHub user ##{f.who} (@#{json[:login]}) is actually a bot, in #{location}")

--- a/lib/humans.rb
+++ b/lib/humans.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+# SPDX-License-Identifier: MIT
+
+require_relative 'jp'
+
+def Jp.bots
+  return [] unless $options.respond_to?(:bots)
+  list = $options.bots
+  return [] if list.nil? || list.empty?
+  list.split(',').filter_map do |n|
+    n = n.strip
+    n unless n.empty?
+  end
+end
+
+def Jp.human_comments(comments)
+  bots = Jp.bots
+  comments.reject do |c|
+    c.dig(:user, :type) == 'Bot' || bots.include?(c.dig(:user, :login))
+  end
+end

--- a/lib/pull_request.rb
+++ b/lib/pull_request.rb
@@ -5,6 +5,7 @@
 
 require 'fbe/github_graph'
 require 'fbe/octo'
+require_relative 'humans'
 require_relative 'jp'
 
 def Jp.comments_info(pr, repo: nil)
@@ -36,10 +37,12 @@ def Jp.comments_info(pr, repo: nil)
       )
       []
     end
+  ccomments = Jp.human_comments(ccomments)
+  icomments = Jp.human_comments(icomments)
   org, rname = repo.split('/')
   uid = pr.dig(:user, :id)
   {
-    comments: (pr[:comments] || 0) + (pr[:review_comments] || 0),
+    comments: ccomments.count + icomments.count,
     comments_to_code: ccomments.count,
     comments_by_author: ccomments.count { |c| c.dig(:user, :id) == uid } +
       icomments.count { |c| c.dig(:user, :id) == uid },

--- a/test/judges/test-code-was-reviewed.rb
+++ b/test/judges/test-code-was-reviewed.rb
@@ -99,10 +99,7 @@ class TestCodeWasReviewed < Jp::Test
     stub_github('https://api.github.com/user/422', body: { id: 422, login: 'user2' })
     fb = Factbase.new
     fb.with(_id: 1, what: 'pull-was-closed', repository: 42, issue: 50, where: 'github')
-    load_it(
-      'code-was-reviewed', fb,
-      Judges::Options.new({ 'repositories' => 'foo/foo', 'bots' => 'rultor' })
-    )
+    load_it('code-was-reviewed', fb, Judges::Options.new({ 'repositories' => 'foo/foo', 'bots' => 'rultor' }))
     assert(fb.one?(what: 'code-was-reviewed', issue: 50, who: 422, comments: 1))
   end
 

--- a/test/judges/test-code-was-reviewed.rb
+++ b/test/judges/test-code-was-reviewed.rb
@@ -69,6 +69,43 @@ class TestCodeWasReviewed < Jp::Test
     )
   end
 
+  def test_counts_only_the_comments_that_people_made
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repositories/42', body: { id: 42, full_name: 'foo/foo' })
+    stub_github(
+      'https://api.github.com/repos/foo/foo/pulls/50',
+      body: {
+        id: 60, number: 50, user: { id: 421, login: 'user' },
+        created_at: Time.parse('2025-09-01 15:35:30 UTC'), additions: 12, deletions: 5
+      }
+    )
+    stub_github(
+      'https://api.github.com/repos/foo/foo/pulls/50/reviews?per_page=100',
+      body: [
+        { id: 49_211, user: { id: 422, login: 'user2' }, submitted_at: Time.parse('2025-09-02 10:39:20 UTC') }
+      ]
+    )
+    stub_github(
+      'https://api.github.com/repos/foo/foo/issues/50/comments?per_page=100',
+      body: [
+        { id: 48_219, user: { id: 421, login: 'user', type: 'User' } },
+        { id: 48_220, user: { id: 900, login: 'github-actions', type: 'Bot' } },
+        { id: 48_221, user: { id: 901, login: 'rultor', type: 'User' } }
+      ]
+    )
+    stub_github('https://api.github.com/repos/foo/foo/pulls/50/reviews/49211/comments?per_page=100', body: [])
+    stub_github('https://api.github.com/user/421', body: { id: 421, login: 'user1' })
+    stub_github('https://api.github.com/user/422', body: { id: 422, login: 'user2' })
+    fb = Factbase.new
+    fb.with(_id: 1, what: 'pull-was-closed', repository: 42, issue: 50, where: 'github')
+    load_it(
+      'code-was-reviewed', fb,
+      Judges::Options.new({ 'repositories' => 'foo/foo', 'bots' => 'rultor' })
+    )
+    assert(fb.one?(what: 'code-was-reviewed', issue: 50, who: 422, comments: 1))
+  end
+
   def test_fetches_issue_comments_once_for_multiple_reviews
     WebMock.disable_net_connect!
     rate_limit_up

--- a/test/judges/test-pull-was-merged.rb
+++ b/test/judges/test-pull-was-merged.rb
@@ -52,7 +52,7 @@ class TestPullWasMerged < Jp::Test
       assert(
         fb.one?(
           what: 'pull-was-closed', where: 'github', who: 422, repository: 42, issue: 44, hoc: 17,
-          comments: 0, comments_appreciated: 0, comments_by_author: 0, comments_by_reviewers: 1,
+          comments: 1, comments_appreciated: 0, comments_by_author: 0, comments_by_reviewers: 1,
           comments_resolved: 0, comments_to_code: 0, succeeded_builds: 0, branch: '40',
           details: 'Apparently, foo/foo#44 has been "pull-was-closed".'
         )
@@ -106,7 +106,7 @@ class TestPullWasMerged < Jp::Test
       assert(
         fb.one?(
           what: 'pull-was-closed', where: 'github', who: 422, repository: 42, issue: 44, hoc: 17,
-          comments: 0, comments_appreciated: 0, comments_by_author: 0, comments_by_reviewers: 1,
+          comments: 1, comments_appreciated: 0, comments_by_author: 0, comments_by_reviewers: 1,
           comments_resolved: 0, comments_to_code: 1, succeeded_builds: 0, branch: '40',
           details: 'Apparently, foo/foo#44 has been "pull-was-closed".'
         )

--- a/test/lib/test_pull_request.rb
+++ b/test/lib/test_pull_request.rb
@@ -309,6 +309,65 @@ class TestPullRequest < Jp::Test
     assert_equal(0, count)
   end
 
+  def test_counts_only_the_comments_that_people_made
+    WebMock.disable_net_connect!
+    rate_limit_up
+    $options = Judges::Options.new({ 'bots' => 'rultor' })
+    $global = {}
+    $loog = Loog::NULL
+    stub_github(
+      'https://api.github.com/repos/foo/foo/pulls/7/comments?per_page=100',
+      body: [
+        { id: 20, user: { id: 5, login: 'jeff', type: 'User' } },
+        { id: 21, user: { id: 9, login: 'github-actions', type: 'Bot' } }
+      ]
+    )
+    stub_github(
+      'https://api.github.com/repos/foo/foo/issues/7/comments?per_page=100',
+      body: [
+        { id: 22, user: { id: 6, login: 'walter', type: 'User' } },
+        { id: 23, user: { id: 7, login: '0crat', type: 'Bot' } },
+        { id: 24, user: { id: 8, login: 'rultor', type: 'User' } }
+      ]
+    )
+    [20, 22, 24].each { |i| stub_github("https://api.github.com/repos/foo/foo/issues/comments/#{i}/reactions", body: []) }
+    stub_github('https://api.github.com/repos/foo/foo/pulls/comments/20/reactions', body: [])
+    Fbe.stub(:github_graph, Fbe::Graph::Fake.new) do
+      pr = {
+        number: 7, comments: 3, review_comments: 2,
+        user: { id: 5 }, base: { repo: { full_name: 'foo/foo' } }
+      }
+      info = Jp.comments_info(pr)
+      assert_equal(2, info[:comments], 'bots and the named bot must not be counted')
+      assert_equal(1, info[:comments_to_code])
+      assert_equal(1, info[:comments_by_author])
+      assert_equal(1, info[:comments_by_reviewers])
+    end
+  end
+
+  def test_counts_every_comment_when_no_bot_wrote_one
+    WebMock.disable_net_connect!
+    rate_limit_up
+    $options = Judges::Options.new({})
+    $global = {}
+    $loog = Loog::NULL
+    stub_github(
+      'https://api.github.com/repos/foo/foo/pulls/8/comments?per_page=100',
+      body: [{ id: 30, user: { id: 5, login: 'jeff', type: 'User' } }]
+    )
+    stub_github(
+      'https://api.github.com/repos/foo/foo/issues/8/comments?per_page=100',
+      body: [{ id: 31, user: { id: 6, login: 'walter', type: 'User' } }]
+    )
+    stub_github('https://api.github.com/repos/foo/foo/issues/comments/31/reactions', body: [])
+    stub_github('https://api.github.com/repos/foo/foo/pulls/comments/30/reactions', body: [])
+    Fbe.stub(:github_graph, Fbe::Graph::Fake.new) do
+      pr = { number: 8, user: { id: 5 }, base: { repo: { full_name: 'foo/foo' } } }
+      info = Jp.comments_info(pr)
+      assert_equal(2, info[:comments])
+    end
+  end
+
   def test_skips_pr_comments_on_not_found
     WebMock.disable_net_connect!
     rate_limit_up

--- a/test/lib/test_pull_request.rb
+++ b/test/lib/test_pull_request.rb
@@ -333,10 +333,7 @@ class TestPullRequest < Jp::Test
     [20, 22, 24].each { |i| stub_github("https://api.github.com/repos/foo/foo/issues/comments/#{i}/reactions", body: []) }
     stub_github('https://api.github.com/repos/foo/foo/pulls/comments/20/reactions', body: [])
     Fbe.stub(:github_graph, Fbe::Graph::Fake.new) do
-      pr = {
-        number: 7, comments: 3, review_comments: 2,
-        user: { id: 5 }, base: { repo: { full_name: 'foo/foo' } }
-      }
+      pr = { number: 7, comments: 3, review_comments: 2, user: { id: 5 }, base: { repo: { full_name: 'foo/foo' } } }
       info = Jp.comments_info(pr)
       assert_equal(2, info[:comments], 'bots and the named bot must not be counted')
       assert_equal(1, info[:comments_to_code])


### PR DESCRIPTION
Fixes #2045.

The comment counts that decide an award were raw GitHub totals, and GitHub counts bots. On a typical pull in a repository this action runs on, half to two thirds of the count is `0crat`, `rultor`, `github-actions` and `renovate`.

That number drives two bylaws in opposite directions. `code-contribution-was-rewarded` deducts for every comment above the threshold, so an author whose pull drew three real review comments is recorded at five once the bots have spoken and starts paying for a conversation that did not happen. `code-review-was-rewarded` rewards comments, so the same bot posts make a thin review look thorough and can lift a reviewer over the twelve-comment line.

`Jp.human_comments` drops a comment whose author GitHub marks as a `Bot` or whose login is in the `bots` option, which is the test `is-human-or-robot` already applies to the author of a fact. That judge now reads its list through `Jp.bots` instead of parsing the option itself, so an installation that names its own bots gets them excluded everywhere rather than in one place.

`comments_info` filters both fetched lists once, at the top, and builds the total from them rather than from `pr[:comments] + pr[:review_comments]`. So `comments_to_code`, `comments_by_author`, `comments_by_reviewers` and `comments_appreciated` all count people too — a bot is not a reviewer in any of those either. `code-was-reviewed.rb` filters its own `issue_comments` call the same way.

Three tests: two on `comments_info`, one covering both a `Bot` author and a login named in `bots`, one making sure a pull with no bots on it counts everything; and one on `code-was-reviewed`, asserting the fact records 1 comment where three were posted. All fail on master.
