### PR TITLE
Insert the lost-issue fact inside a transaction

### DIFF
--- a/lib/issue_was_lost.rb
+++ b/lib/issue_was_lost.rb
@@ -22,18 +22,20 @@ def Jp.issue_was_lost(where, repository, issue)
     $loog.info("The issue #{issue} was marked as lost, #{stale} facts marked as stale")
     return
   end
-  f =
-    Fbe.if_absent do |n|
-      n.issue = issue
-      n.what = 'issue-was-lost'
-      n.repository = repository
-      n.where = where
+  Fbe.fb.txn do |fbt|
+    f =
+      Fbe.if_absent(fb: fbt) do |n|
+        n.issue = issue
+        n.what = 'issue-was-lost'
+        n.repository = repository
+        n.where = where
+      end
+    if f.nil?
+      $loog.warn("The issue ##{issue} was already lost")
+      next
     end
-  unless f
-    $loog.warn("The issue ##{issue} was already lost")
-    return
+    f.stale = 'issue'
+    f.when = Time.now
+    $loog.info("The issue #{issue} was marked as lost")
   end
-  f.stale = 'issue'
-  f.when = Time.now
-  $loog.info("The issue #{issue} was marked as lost")
 end

--- a/test/judges/test-find-all-issues.rb
+++ b/test/judges/test-find-all-issues.rb
@@ -118,6 +118,37 @@ class TestFindAllIssues < Jp::Test
     refute_empty(fb.query("(eq what 'issue-was-opened')").each.to_a)
   end
 
+  def test_find_all_issues_with_lost_min
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github(
+      'https://api.github.com/repos/foo/foo',
+      body: { id: 695, name: 'foo', full_name: 'foo/foo', created_at: Time.parse('2024-07-11 20:35:25 UTC') }
+    )
+    stub_github(
+      'https://api.github.com/repositories/695',
+      body: { id: 695, name: 'foo', full_name: 'foo/foo', created_at: Time.parse('2024-07-11 20:35:25 UTC') }
+    )
+    stub_github(
+      'https://api.github.com/repos/foo/foo/issues/87',
+      status: 404,
+      body: { message: 'Not Found', documentation_url: 'https://docs.github.com', status: '404' }
+    )
+    fb = Factbase.new
+    fb.insert.then do |f|
+      f.issue = 87
+      f.repository = 695
+      f.stale = 'issue'
+      f.what = 'issue-was-opened'
+      f.where = 'github'
+    end
+    load_it('find-all-issues', fb)
+    refute_empty(
+      fb.query("(and (eq what 'issue-was-lost') (eq issue 87))").each.to_a,
+      'the lost issue cannot be recorded when the factbase enforces its rules'
+    )
+  end
+
   def test_find_all_issues
     WebMock.disable_net_connect!
     rate_limit_up


### PR DESCRIPTION
Wraps the `Fbe.if_absent` call in `Jp.issue_was_lost` in an `Fbe.fb.txn`, and adds `test_find_all_issues_with_lost_min`, which reproduces the failure.

`Fbe.if_absent` sets the properties of a new fact one at a time, and `Factbase::Rules` checks the fact after each one unless a transaction is open. This block sets `issue` before `repository`, so the fact was checked while it held nothing but `issue`, which the `(when (exists issue) (exists repository))` rule forbids. `Fbe::Iterate` turned that into an `Fbe::Error` and `find-all-issues` died on it twice in one production run, once per cycle, leaving the repository half scanned. This was the only one of the sixteen `Fbe.if_absent` call sites here that ran outside a transaction, so the fix just brings it in line with the rest.

The existing 404 test never caught it because its prior fact is fresh, so the method returns at the `stale.positive?` guard and never reaches the insert. The non-atomic insert in the gem itself is reported separately as zerocracy/fbe#797, and once that lands this wrapper stops being load-bearing, though it stays correct either way.

Closes #2047