### PR TITLE
#2060: refuse a timeout or lifetime that is not a positive integer

### DIFF
--- a/entry.sh
+++ b/entry.sh
@@ -234,12 +234,20 @@ timeout=${INPUT_TIMEOUT}
 if [ -z "${timeout}" ]; then
     timeout=10
 fi
+if ! [[ "${timeout}" =~ ^[1-9][0-9]*$ ]]; then
+    echo "INPUT_TIMEOUT must be a positive integer, got: ${timeout}" >&2
+    exit 1
+fi
 timeout=$((timeout * 60))
 echo "Each judge will spend up to ${timeout} seconds"
 
 lifetime=${INPUT_LIFETIME}
 if [ -z "${lifetime}" ]; then
     lifetime=15
+fi
+if ! [[ "${lifetime}" =~ ^[1-9][0-9]*$ ]]; then
+    echo "INPUT_LIFETIME must be a positive integer, got: ${lifetime}" >&2
+    exit 1
 fi
 lifetime=$((lifetime * 60))
 echo "The update will run for up to ${lifetime} seconds"

--- a/test/test_entry_minutes.rb
+++ b/test/test_entry_minutes.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+# SPDX-License-Identifier: MIT
+
+require 'open3'
+require_relative 'test__helper'
+
+class TestEntryMinutes < Jp::Test
+  def test_rejects_a_timeout_that_is_not_a_positive_integer
+    ['abc', '0', '-5', '1.5', ''].each do |v|
+      next if v.empty?
+      code, err = run_block('timeout', 'INPUT_TIMEOUT' => v)
+      refute_equal(0, code, "INPUT_TIMEOUT=#{v.inspect} was accepted")
+      assert_includes(err, 'INPUT_TIMEOUT must be a positive integer')
+    end
+  end
+
+  def test_rejects_a_lifetime_that_is_not_a_positive_integer
+    ['abc', '0', '-5', '1.5'].each do |v|
+      code, err = run_block('lifetime', 'INPUT_LIFETIME' => v)
+      refute_equal(0, code, "INPUT_LIFETIME=#{v.inspect} was accepted")
+      assert_includes(err, 'INPUT_LIFETIME must be a positive integer')
+    end
+  end
+
+  def test_accepts_a_positive_integer_and_turns_it_into_seconds
+    code, = run_block('timeout', 'INPUT_TIMEOUT' => '7')
+    assert_equal(0, code)
+    code, = run_block('lifetime', 'INPUT_LIFETIME' => '7')
+    assert_equal(0, code)
+  end
+
+  def test_falls_back_to_the_default_when_the_input_is_absent
+    code, = run_block('timeout', 'INPUT_TIMEOUT' => '')
+    assert_equal(0, code)
+    code, = run_block('lifetime', 'INPUT_LIFETIME' => '')
+    assert_equal(0, code)
+  end
+
+  private
+
+  # Runs the block of entry.sh that reads one of the two minute inputs,
+  # taken from the file itself, so the guard under test is the shipped one.
+  def run_block(name, env)
+    body = File.read(File.join(File.expand_path('..', __dir__), 'entry.sh'))
+    block = body[/^#{name}=\$\{INPUT_#{name.upcase}\}\n(?:.*\n)*?#{name}=\$\(\(#{name} \* 60\)\)\n/]
+    refute_nil(block, "No #{name} block found in entry.sh")
+    _, err, status = Open3.capture3(env, 'bash', '-c', "set -e -o pipefail\n#{block}")
+    [status.exitstatus, err]
+  end
+end

--- a/test/test_entry_minutes.rb
+++ b/test/test_entry_minutes.rb
@@ -40,8 +40,6 @@ class TestEntryMinutes < Jp::Test
 
   private
 
-  # Runs the block of entry.sh that reads one of the two minute inputs,
-  # taken from the file itself, so the guard under test is the shipped one.
   def run_block(name, env)
     body = File.read(File.join(File.expand_path('..', __dir__), 'entry.sh'))
     block = body[/^#{name}=\$\{INPUT_#{name.upcase}\}\n(?:.*\n)*?#{name}=\$\(\(#{name} \* 60\)\)\n/]


### PR DESCRIPTION
Fixes #2060

`INPUT_TIMEOUT` and `INPUT_LIFETIME` went straight into `$(( ))`, where Bash reads an unrecognized word as zero. `INPUT_TIMEOUT=abc` therefore became `--timeout 0` and the run continued, stopping every judge at once and publishing whatever factbase it had, with nothing in the log to say the input was wrong.

Both are now checked against `^[1-9][0-9]*$` before the arithmetic, refusing `abc`, `0`, `-5` and `1.5` with the same shape of message the `cycles` input already uses. The empty case is untouched: it still falls back to 10 and 15.

The test pulls each block out of `entry.sh` itself and runs it under `bash`, so what it exercises is the shipped guard rather than a copy of it. Both cases fail on master with "INPUT_TIMEOUT=\"abc\" was accepted".
