### PR TITLE
#2058: require the cycle count to be positive

### DIFF
--- a/entry.sh
+++ b/entry.sh
@@ -246,7 +246,7 @@ echo "The update will run for up to ${lifetime} seconds"
 
 cycles=${INPUT_CYCLES}
 if [ -n "${cycles}" ]; then
-    if ! [[ "${cycles}" =~ ^[0-9]+$ ]]; then
+    if ! [[ "${cycles}" =~ ^[1-9][0-9]*$ ]]; then
         echo "INPUT_CYCLES must be a positive integer, got: ${cycles}" >&2
         exit 1
     fi

--- a/test/test_entry_cycles.rb
+++ b/test/test_entry_cycles.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+# SPDX-License-Identifier: MIT
+
+require 'open3'
+require_relative 'test__helper'
+
+class TestEntryCycles < Jp::Test
+  def test_rejects_a_cycle_count_that_is_not_positive
+    %w[0 00 007 -1 abc].each do |v|
+      code, err = run_block('INPUT_CYCLES' => v)
+      refute_equal(0, code, "INPUT_CYCLES=#{v.inspect} was accepted")
+      assert_includes(err, 'INPUT_CYCLES must be a positive integer')
+    end
+  end
+
+  def test_accepts_a_positive_cycle_count
+    %w[1 2 30].each do |v|
+      code, = run_block('INPUT_CYCLES' => v)
+      assert_equal(0, code, "INPUT_CYCLES=#{v.inspect} was refused")
+    end
+  end
+
+  def test_falls_back_to_the_default_when_the_input_is_absent
+    code, = run_block('INPUT_CYCLES' => '')
+    assert_equal(0, code)
+  end
+
+  private
+
+  # Runs the block of entry.sh that reads the cycles input, taken from the
+  # file itself, so the guard under test is the shipped one.
+  def run_block(env)
+    body = File.read(File.join(File.expand_path('..', __dir__), 'entry.sh'))
+    block = body[/^cycles=\$\{INPUT_CYCLES\}\n(?:.*\n)*?^fi\n/]
+    refute_nil(block, 'No cycles block found in entry.sh')
+    _, err, status = Open3.capture3(env, 'bash', '-c', "set -e -o pipefail\n#{block}")
+    [status.exitstatus, err]
+  end
+end

--- a/test/test_entry_cycles.rb
+++ b/test/test_entry_cycles.rb
@@ -29,8 +29,6 @@ class TestEntryCycles < Jp::Test
 
   private
 
-  # Runs the block of entry.sh that reads the cycles input, taken from the
-  # file itself, so the guard under test is the shipped one.
   def run_block(env)
     body = File.read(File.join(File.expand_path('..', __dir__), 'entry.sh'))
     block = body[/^cycles=\$\{INPUT_CYCLES\}\n(?:.*\n)*?^fi\n/]


### PR DESCRIPTION
Fixes #2058

The `cycles` input is documented as a positive integer, but the guard matched `^[0-9]+$`, so `0` (and `00`) passed and reached `judges update` as `--max-cycles 0`. The update loop enters cycle 1 before it compares against the maximum, so asking for zero cycles still ran one full cycle, with the GitHub reads and writes that come with it.

The pattern is now `^[1-9][0-9]*$`, which keeps every valid count and turns `0`, `00`, `007` and `-1` into the validation error that `abc` already produced. The empty case still falls back to 2.

The test takes the block out of `entry.sh` and runs it under `bash`, so it exercises the shipped guard. It fails on master with "INPUT_CYCLES=\"0\" was accepted".
