### PR TITLE
#2064: name the summary file the workflow actually produces

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,8 @@ The plugin gives them awards for good things
   they do (like fixing bugs) and also punishes them (by deducting points)
   for bad things (like stale pull requests).
 
-The plugin also generates a summary `foo.html` file, which
+The plugin also generates a summary `foo-vitals.html` file
+  in the `output` directory of `pages-action` (`pages` by default), which
   is automatically deployed to the `gh-pages` branch.
 You can configure your GitHub repository to render the branch
   as a static website via [GitHub Pages].


### PR DESCRIPTION
Fixes #2064

The installation guide promised a summary at `foo.html`. `pages-action` builds that path as `${INPUT_OUTPUT}/${name}-vitals.html` (`entry.sh:207`), so the workflow shown right above the sentence writes `pages/foo-vitals.html`, and the deployed page is `foo-vitals.html`. Anyone following the README landed on a missing page.

The sentence now names the real file and says where it is written, since `output` defaults to `pages` and that is the folder the deploy step in the same snippet publishes. The live example the paragraph links to, `zerocracy-vitals.html`, already follows this shape.
