### PR TITLE
#2050: do not measure review time backwards from the merge

### DIFF
--- a/judges/quality-of-service/some_review_time.rb
+++ b/judges/quality-of-service/some_review_time.rb
@@ -35,9 +35,7 @@ def some_review_time(fact)
       if first
         seconds = Integer(pr[:pull_request][:merged_at] - first[:submitted_at])
         if seconds.negative?
-          $loog.info(
-            "The pull ##{pr[:number]} in #{repo} was first reviewed after it was merged, "             'its review time is not measurable'
-          )
+          $loog.info("The pull ##{pr[:number]} in #{repo} was reviewed after it was merged")
         else
           times << seconds
         end

--- a/judges/quality-of-service/some_review_time.rb
+++ b/judges/quality-of-service/some_review_time.rb
@@ -32,7 +32,16 @@ def some_review_time(fact)
           next
         end
       first = all.select { |r| r[:submitted_at] }.min_by { |r| r[:submitted_at] }
-      times << Integer(pr[:pull_request][:merged_at] - first[:submitted_at]) if first
+      if first
+        seconds = Integer(pr[:pull_request][:merged_at] - first[:submitted_at])
+        if seconds.negative?
+          $loog.info(
+            "The pull ##{pr[:number]} in #{repo} was first reviewed after it was merged, "             'its review time is not measurable'
+          )
+        else
+          times << seconds
+        end
+      end
       sizes << csize
       users = all.map { |r| r.dig(:user, :id) }
       users.uniq!

--- a/test/judges/test-some-review-time.rb
+++ b/test/judges/test-some-review-time.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+# SPDX-License-Identifier: MIT
+
+require 'factbase'
+require 'judges/options'
+require 'loog'
+require_relative '../fake_github'
+require_relative '../test__helper'
+
+require_relative '../../judges/quality-of-service/some_review_time'
+
+class TestSomeReviewTime < Jp::Test
+  def test_measures_the_gap_from_the_first_review_to_the_merge
+    assert_equal([7200], review_times(Time.parse('2025-01-10 10:00:00 UTC')))
+  end
+
+  def test_ignores_a_review_submitted_after_the_merge
+    assert_empty(review_times(Time.parse('2025-01-10 14:00:00 UTC')))
+    assert_empty(review_times(Time.parse('2025-01-11 12:00:00 UTC')))
+  end
+
+  private
+
+  def review_times(submitted)
+    fact = Factbase.new.insert
+    fact.since = Time.parse('2025-01-01 00:00:00 UTC')
+    fact.when = Time.parse('2025-02-01 00:00:00 UTC')
+    $global = {}
+    $loog = Loog::NULL
+    $options = Judges::Options.new({ 'repositories' => 'foo/foo' })
+    found = {
+      items: [{ id: 1, number: 10, pull_request: { merged_at: Time.parse('2025-01-10 12:00:00 UTC') } }]
+    }
+    Jp::FakeGithub.new(
+      'GET /rate_limit' => { resources: { search: { remaining: 30, limit: 30 } }, rate: { remaining: 1000 } },
+      'GET /repos/foo/foo' => { id: 42, full_name: 'foo/foo' },
+      'GET /repos/foo/foo/pulls/10/reviews?per_page=100' =>
+        [200, [{ id: 7, user: { id: 1 }, submitted_at: submitted.utc.iso8601 }]],
+      'GET /repos/foo/foo/pulls/10/comments?per_page=100' => [200, []]
+    ).run { Jp.stub(:qosearch, found) { some_review_time(fact)[:some_review_time] } }
+  end
+end

--- a/test/judges/test-some-review-time.rb
+++ b/test/judges/test-some-review-time.rb
@@ -30,9 +30,7 @@ class TestSomeReviewTime < Jp::Test
     $global = {}
     $loog = Loog::NULL
     $options = Judges::Options.new({ 'repositories' => 'foo/foo' })
-    found = {
-      items: [{ id: 1, number: 10, pull_request: { merged_at: Time.parse('2025-01-10 12:00:00 UTC') } }]
-    }
+    found = { items: [{ id: 1, number: 10, pull_request: { merged_at: Time.parse('2025-01-10 12:00:00 UTC') } }] }
     Jp::FakeGithub.new(
       'GET /rate_limit' => { resources: { search: { remaining: 30, limit: 30 } }, rate: { remaining: 1000 } },
       'GET /repos/foo/foo' => { id: 42, full_name: 'foo/foo' },


### PR DESCRIPTION
Fixes #2050

`some_review_time` subtracted the earliest review from the merge without asking which came first. A pull merged before anyone reviewed it produced a negative number, and that number went into the metric next to the real ones, dragging the average down by however long the late review took.

A review submitted after the merge does not measure the time a review took, so the pull no longer contributes a review time, and the log says why. It still contributes to `some_review_size`, `some_reviewers_per_pull` and `some_reviews_per_pull`, which are counts and stay correct either way.

The test drives `some_review_time` through `Jp::FakeGithub` with the merge fixed at 12:00 and only the review time moved. On master the two late cases come back as `[-7200]` and `[-86400]`.
