### PR TITLE
#2053: move the refresh line forward when the name is re-read

### DIFF
--- a/judges/who-has-name/who-has-name.rb
+++ b/judges/who-has-name/who-has-name.rb
@@ -92,7 +92,7 @@ Fbe.consider(
     next
   end
   alive << f.who
-  Fbe.overwrite(f, 'name', nick)
+  Fbe.overwrite(f, { 'name' => nick, 'when' => Time.now })
 end
 
 alive.uniq!

--- a/test/judges/test-who-has-name.rb
+++ b/test/judges/test-who-has-name.rb
@@ -87,6 +87,27 @@ class TestWhoHasName < Jp::Test
     end
   end
 
+  def test_moves_the_refresh_line_forward_after_a_lookup
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/user/12', body: { login: 'user22', id: 12, type: 'User' })
+    fb = Factbase.new
+    fb.with(
+      _id: 3, what: 'who-has-name', where: 'github', who: 12, name: 'user2',
+      when: Time.parse('2025-06-18 20:00:00 UTC')
+    )
+    now = Time.parse('2025-06-23 22:00:00 UTC')
+    Time.stub(:now, now) do
+      load_it('who-has-name', fb)
+    end
+    fact = fb.query('(eq who 12)').each.first
+    assert_equal('user22', fact['name'].first)
+    assert_operator(
+      fact['when'].first, :>, now - 60,
+      'the fact stayed past the five-day line, so the next cycle looks the same user up again'
+    )
+  end
+
   def test_keeps_fact_active_on_forbidden_user_lookup
     WebMock.disable_net_connect!
     rate_limit_up


### PR DESCRIPTION
Fixes #2053

The second pass of `who-has-name` selects facts whose `when` is more than five days old and re-reads the nickname, but nothing wrote `when` back. `Fbe.overwrite` rebuilds the fact from the properties it already carries, so the old `when` survived and the fact matched `(lt when ...)` again on the very next cycle. The five-day refresh was therefore a lookup of every known user on every cycle: one `GET /user/{id}` per user per run, for data that changes rarely, paid out of the same core quota every other judge shares.

`name` and `when` are now written together in one `Fbe.overwrite` call, so the fact is rebuilt once and lands five days past the line, which is what the `5 days` in the query asks for.

The test loads the judge with one fact dated five days back and checks that `when` moved to the current time. On master it stays at 2025-06-18 and the assertion reports that the next cycle would look the same user up again.

`who-is-alive` reads the same `when` on the same facts with a two-day period of its own; that half is #2054, and it needs a marker of its own rather than this one.
