### PR TITLE
#2054: give who-is-alive a mark of its own

### DIFF
--- a/judges/who-is-alive/who-is-alive.rb
+++ b/judges/who-is-alive/who-is-alive.rb
@@ -7,6 +7,7 @@ require 'elapsed'
 require 'fbe/consider'
 require 'fbe/fb'
 require 'fbe/octo'
+require 'fbe/overwrite'
 require 'logger'
 require 'octokit'
 require_relative '../../lib/nick_of'
@@ -17,7 +18,11 @@ seen = []
 Fbe.consider(
   "(and
     (eq what 'who-has-name')
-    (lt when (minus (to_time '#{Jp.today.utc.iso8601}') '2 days'))
+    (or
+      (and
+        (absent alive_when)
+        (lt when (minus (to_time '#{Jp.today.utc.iso8601}') '2 days')))
+      (lt alive_when (minus (to_time '#{Jp.today.utc.iso8601}') '2 days')))
     (absent stale)
     (absent tombstone)
     (absent done)
@@ -45,6 +50,7 @@ Fbe.consider(
     end
   unless nick.nil?
     $loog.debug("GitHub user @#{nick} (##{f.who}) is alive")
+    Fbe.overwrite(f, 'alive_when', Time.now)
     next
   end
   elapsed($loog, level: Logger::INFO) do

--- a/test/judges/test-who-is-alive.rb
+++ b/test/judges/test-who-is-alive.rb
@@ -91,6 +91,32 @@ class TestWhoIsAlive < Jp::Test
     end
   end
 
+  def test_marks_a_live_user_so_the_next_cycle_leaves_it_alone
+    fb = Factbase.new
+    fb.with(
+      _id: 1, what: 'who-has-name', where: 'github', who: 10, name: 'user0',
+      when: Time.parse('2025-06-23 20:00:00 UTC')
+    )
+    now = Time.parse('2025-06-25 22:00:00 UTC')
+    Time.stub(:now, now) do
+      Jp::FakeGithub.new(
+        'GET /rate_limit' => { rate: { remaining: 222 } },
+        'GET /user/10' => { login: 'user0', id: 10, type: 'User' }
+      ).run do
+        load_it('who-is-alive', fb)
+      end
+    end
+    fact = fb.query('(eq who 10)').each.first
+    refute_nil(fact['alive_when'], 'the user was checked but nothing recorded that')
+    assert_operator(fact['alive_when'].first, :>, now - 60, 'the mark is older than the check')
+    Time.stub(:now, now + (60 * 60)) do
+      Jp::FakeGithub.new('GET /rate_limit' => { rate: { remaining: 222 } }).run do
+        load_it('who-is-alive', fb)
+      end
+    end
+    assert_equal(1, fb.all.size, 'the same user was looked up again an hour later')
+  end
+
   def test_keeps_fact_on_forbidden_user_lookup
     fb = Factbase.new
     fb.with(


### PR DESCRIPTION
Fixes #2054

`who-is-alive` selected `who-has-name` facts whose `when` was more than two days old and, when the user turned out to be alive, moved on without writing anything. The fact stayed past the two-day line forever, so every known user was looked up on every cycle: one `GET /user/{id}` per user per run, out of the core quota every judge shares.

Writing `when` back would not work here, because `who-has-name` owns that field for its own five-day pass (#2053) and the two periods would overwrite each other. So a live user is now marked with `alive_when`, and the query reads that field.

A fact that has never been checked has no `alive_when`, and for those the query still falls back to `when`, so nothing that was due today becomes due tomorrow instead. Once a fact is checked, its own mark takes over.

The test checks a live user, asserts the mark landed, and loads the judge again an hour later with no `GET /user/10` route at all: the run has to leave the user alone, or the fake server answers 404 and the fact is deleted as dead. On master the first assertion already fails, because nothing is recorded.
