### PR TITLE
#2062: let a dry run start without a Zerocracy token

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -9,8 +9,8 @@ runs:
   image: 'docker://yegor256/judges-action:0.0.0'
 inputs:
   token:
-    description: 'Authentication token from www.zerocracy.com'
-    required: true
+    description: 'Authentication token from www.zerocracy.com, not needed when "dry-run" is true'
+    required: false
   options:
     description: 'Command line options for the "judges" tool'
     required: false

--- a/entries/runs-dry-without-token.sh
+++ b/entries/runs-dry-without-token.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+# SPDX-License-Identifier: MIT
+
+set -e -o pipefail
+
+SELF=$1
+
+source "${SELF}/makes/setup-test-env.sh"
+source "${SELF}/makes/test-common.sh"
+setup_test_env "${SELF}" name
+
+bundle exec judges eval "${name}.fb" "f = \$fb.insert; f.what = 'judges-summary'; f.cycles = 7"
+
+run_entry_script "${SELF}" success \
+  "GITHUB_WORKSPACE=$(pwd)" \
+  "INPUT_FACTBASE=${name}.fb" \
+  "INPUT_CYCLES=1" \
+  "INPUT_REPOSITORIES=yegor256/factbase" \
+  "INPUT_VERBOSE=false" \
+  "INPUT_DRY-RUN=true" \
+  "INPUT_GITHUB-TOKEN=THETOKEN"
+
+factbase_exists "${name}"

--- a/entry.sh
+++ b/entry.sh
@@ -81,7 +81,7 @@ if [[ ! "${name}" =~ ^[a-z][a-z0-9-]{1,23}$ ]]; then
     exit 1
 fi
 
-if [ -z "${INPUT_TOKEN}" ]; then
+if [ -z "${INPUT_TOKEN}" ] && [ "$(printenv "INPUT_DRY-RUN" || echo 'false')" != 'true' ]; then
     echo "The 'token' plugin parameter is not set."
     echo "We stop here, since all further operations will fail anyway."
     echo "By the way, if you want to run it in 'dry' mode,"


### PR DESCRIPTION
Fixes #2062

`entry.sh` refused to start without `INPUT_TOKEN` and, in the same breath, told the user that a run without any connection to the server is available as `dry-run: true`. The exit came before anything read that flag, so the advice pointed at a path the check itself made unreachable. `action.yml` said the same by declaring `token` as `required: true`.

The check now applies only when the run is not dry, and `token` becomes optional in the metadata with a description that says when it may be left out. Every use of `INPUT_TOKEN` further down is already inside a non-dry branch: `pull`, `push`, and the SQLite `download` and `upload` all skip themselves in dry mode, so nothing later needs the value.

The `github-token` check is untouched, and `fails-without-github-token.sh` still expects a dry run without it to stop.

The new entry test runs the real `entry.sh` in dry mode with no `INPUT_TOKEN` at all and requires it to finish and leave the factbase in place. On master it exits 1 at the token check.
