### PR TITLE
#2055: mark who stale when the author account is gone

### DIFF
--- a/judges/find-all-issues/find-all-issues.rb
+++ b/judges/find-all-issues/find-all-issues.rb
@@ -94,7 +94,12 @@ require_relative '../../lib/qos_search'
             next if f.nil?
             found << f.issue
             f.when = json[:created_at]
-            f.who = json.dig(:user, :id)
+            who = json.dig(:user, :id)
+            if who
+              f.who = who
+            else
+              f.stale = 'who'
+            end
             if type == 'pull'
               ref =
                 begin
@@ -116,8 +121,9 @@ require_relative '../../lib/qos_search'
                 f.stale = 'branch'
               end
             end
-            f.details = "The #{type} #{Fbe.issue(f)} has been earlier opened by #{Fbe.who(f)}."
-            $loog.info("The #{Fbe.issue(f)} was opened by #{Fbe.who(f)} #{f.when.ago} ago")
+            author = who ? Fbe.who(f) : 'an unknown user'
+            f.details = "The #{type} #{Fbe.issue(f)} has been earlier opened by #{author}."
+            $loog.info("The #{Fbe.issue(f)} was opened by #{author} #{f.when.ago} ago")
           end
         end
         issue = first if issue < first

--- a/judges/find-earliest-issue/find-earliest-issue.rb
+++ b/judges/find-earliest-issue/find-earliest-issue.rb
@@ -59,7 +59,12 @@ Fbe.iterate do
         end
       next if f.nil?
       f.when = json[:created_at]
-      f.who = json.dig(:user, :id)
+      who = json.dig(:user, :id)
+      if who
+        f.who = who
+      else
+        f.stale = 'who'
+      end
       if json[:pull_request]
         ref =
           begin
@@ -81,8 +86,9 @@ Fbe.iterate do
           f.stale = 'branch'
         end
       end
-      f.details = "The issue #{Fbe.issue(f)} is the earliest we found, opened by #{Fbe.who(f)}."
-      $loog.info("The issue #{Fbe.issue(f)} was opened by #{Fbe.who(f)} #{f.when.ago} ago")
+      author = who ? Fbe.who(f) : 'an unknown user'
+      f.details = "The issue #{Fbe.issue(f)} is the earliest we found, opened by #{author}."
+      $loog.info("The issue #{Fbe.issue(f)} was opened by #{author} #{f.when.ago} ago")
     end
     json[:number]
   end

--- a/judges/find-latest-issue/find-latest-issue.rb
+++ b/judges/find-latest-issue/find-latest-issue.rb
@@ -59,7 +59,12 @@ Fbe.iterate do
         end
       next if f.nil?
       f.when = json[:created_at]
-      f.who = json.dig(:user, :id)
+      who = json.dig(:user, :id)
+      if who
+        f.who = who
+      else
+        f.stale = 'who'
+      end
       if json[:pull_request]
         ref =
           begin
@@ -81,8 +86,9 @@ Fbe.iterate do
           f.stale = 'branch'
         end
       end
-      f.details = "The issue #{Fbe.issue(f)} is the first we found, opened by #{Fbe.who(f)}."
-      $loog.info("The issue #{Fbe.issue(f)} was opened by #{Fbe.who(f)} #{f.when.ago} ago")
+      author = who ? Fbe.who(f) : 'an unknown user'
+      f.details = "The issue #{Fbe.issue(f)} is the first we found, opened by #{author}."
+      $loog.info("The issue #{Fbe.issue(f)} was opened by #{author} #{f.when.ago} ago")
     end
     json[:number]
   end

--- a/judges/find-missing-issues/find-missing-issues.rb
+++ b/judges/find-missing-issues/find-missing-issues.rb
@@ -75,7 +75,12 @@ Fbe.consider('(and (eq where "github") (exists repository) (unique repository))'
         end
       next if f.nil?
       f.when = json[:created_at]
-      f.who = json.dig(:user, :id)
+      who = json.dig(:user, :id)
+      if who
+        f.who = who
+      else
+        f.stale = 'who'
+      end
       if type == 'pull'
         ref =
           begin
@@ -97,7 +102,8 @@ Fbe.consider('(and (eq where "github") (exists repository) (unique repository))'
           f.stale = 'branch'
         end
       end
-      f.details = "The missing #{type} #{Fbe.issue(f)} has been opened by #{Fbe.who(f)}."
+      author = who ? Fbe.who(f) : 'an unknown user'
+      f.details = "The missing #{type} #{Fbe.issue(f)} has been opened by #{author}."
       $loog.info("The #{type} #{Fbe.issue(f)} is not tombstoned among #{ts.issues('github', r.repository).count}")
       $loog.info("Missing #{type} #{Fbe.issue(f)} was found opened #{f.when.ago} ago")
     end

--- a/judges/issue-was-opened/issue-was-opened.rb
+++ b/judges/issue-was-opened/issue-was-opened.rb
@@ -68,9 +68,15 @@ Fbe.conclude do
       end
     n.what = $judge
     n.when = json[:created_at]
-    n.who = json.dig(:user, :id)
-    n.details = "The issue #{Fbe.issue(n)} has been opened earlier by #{Fbe.who(n)}."
-    $loog.info("The issue #{Fbe.issue(n)} was opened by #{Fbe.who(n)} #{n.when.ago} ago")
+    who = json.dig(:user, :id)
+    if who
+      n.who = who
+    else
+      n.stale = 'who'
+    end
+    author = who ? Fbe.who(n) : 'an unknown user'
+    n.details = "The issue #{Fbe.issue(n)} has been opened earlier by #{author}."
+    $loog.info("The issue #{Fbe.issue(n)} was opened by #{author} #{n.when.ago} ago")
   end
 end
 

--- a/judges/milestone-was-set/milestone-was-set.rb
+++ b/judges/milestone-was-set/milestone-was-set.rb
@@ -68,7 +68,12 @@ Fbe.consider(
       end
       nn.when = m[:created_at]
       nn.deadline = m[:due_on] if m[:due_on]
-      nn.who = m.dig(:creator, :id)
+      who = m.dig(:creator, :id)
+      if who
+        nn.who = who
+      else
+        nn.stale = 'who'
+      end
       nn.details = "The milestone ##{m[:number]} \"#{m[:title]}\" was set."
       $loog.info("Milestone ##{m[:number]} \"#{m[:title]}\" found in #{repo}")
     end

--- a/judges/pull-was-opened/pull-was-opened.rb
+++ b/judges/pull-was-opened/pull-was-opened.rb
@@ -66,7 +66,12 @@ Fbe.conclude do
       end
     n.what = $judge
     n.when = json[:created_at]
-    n.who = json.dig(:user, :id)
+    who = json.dig(:user, :id)
+    if who
+      n.who = who
+    else
+      n.stale = 'who'
+    end
     ref =
       begin
         Fbe.octo.pull_request(repo, f.issue).dig(:head, :ref)
@@ -86,7 +91,8 @@ Fbe.conclude do
     else
       n.stale = 'branch'
     end
-    n.details = "The pull #{Fbe.issue(n)} has been opened earlier by #{Fbe.who(n)}."
+    author = who ? Fbe.who(n) : 'an unknown user'
+    n.details = "The pull #{Fbe.issue(n)} has been opened earlier by #{author}."
     $loog.info("The pull #{Fbe.issue(n)} was opened #{n.when.ago} ago")
   end
 end

--- a/test/judges/test-milestone-was-set.rb
+++ b/test/judges/test-milestone-was-set.rb
@@ -56,6 +56,34 @@ class TestMilestoneWasSet < Jp::Test
     end
   end
 
+  def test_survives_a_milestone_whose_creator_is_gone
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repos/foo/foo', body: { id: 42, full_name: 'foo/foo' })
+    stub_github('https://api.github.com/repositories/42', body: { id: 42, full_name: 'foo/foo' })
+    stub_github(
+      'https://api.github.com/repos/foo/foo/milestones?per_page=100&state=all',
+      body: [
+        {
+          number: 1,
+          title: 'v1.0',
+          description: 'First release',
+          state: 'open',
+          created_at: '2024-01-15T10:00:00Z',
+          due_on: nil,
+          creator: nil
+        }
+      ]
+    )
+    fb = Factbase.new
+    fb.with(_id: 1, what: 'issue-was-opened', repository: 42, issue: 44, where: 'github')
+    load_it('milestone-was-set', fb)
+    assert(fb.one?(what: 'milestone-was-set', milestone: 1))
+    f = fb.query("(eq what 'milestone-was-set')").each.to_a.first
+    assert_equal('who', f.stale)
+    assert_nil(f['who'])
+  end
+
   def test_empty_milestones_list
     WebMock.disable_net_connect!
     rate_limit_up


### PR DESCRIPTION
Closes #2055.

GitHub returns a null author when the account that made an object has been deleted. Seven places assigned that straight into a fact, and Factbase refuses a nil, so `milestone-was-set` died with `ArgumentError: The value of 'who' can't be nil` and every milestone queued behind the ghost one went unrecorded.

All seven now use the shape #1409 settled, which `issue-was-closed` and `label-was-attached` already follow:

```ruby
who = m.dig(:creator, :id)
if who
  nn.who = who
else
  nn.stale = 'who'
end
```

Keeping the fact and marking it `stale = 'who'` leaves `revive-user` a way back in if the account returns.

### One thing the issue does not mention

Six of the seven then pass the same fact to `Fbe.who`, which raises `Fbe::Error` when the property is absent. Guarding only the assignment would have swapped one crash for another, so those messages fall back to `an unknown user`, the way `label-was-attached` already says `an unknown actor`. That also removes a duplicated lookup where one message asked for the same name twice.

`milestone-was-set` is the only one of the seven that never reads the name back.

### Verification

The regression test is the reproduction from the issue — a milestone with `creator: nil`. I checked that it actually catches the defect rather than passing either way:

- with this change: `test_survives_a_milestone_whose_creator_is_gone PASS`, suite `407 tests, 942 assertions, 0 failures, 0 errors`
- with the `milestone-was-set` guard reverted and the test kept: `ERROR — ArgumentError: The value of 'who' can't be nil`, suite `407 tests, 1 errors`

`bundle exec rake` is green on a fork before opening this.