### PR TITLE
#2061: keep the event actor when the release author is gone

### DIFF
--- a/judges/github-events/github-events.rb
+++ b/judges/github-events/github-events.rb
@@ -359,8 +359,9 @@ Fbe.iterate do
       case json[:payload][:action]
       when 'published'
         fact.what = 'release-published'
-        if fact.all_properties.include?('who') && fact.who != json[:payload][:release][:author][:id]
-          Fbe.overwrite(fact, 'who', json[:payload][:release][:author][:id])
+        author = json[:payload][:release].dig(:author, :id)
+        if author && fact.all_properties.include?('who') && fact.who != author
+          Fbe.overwrite(fact, 'who', author)
         end
         contributors(fact, rname).each { |c| fact.contributors = c }
         Jp.fill_fact_by_hash(fact, info(fact, rname))

--- a/test/judges/test-github-events.rb
+++ b/test/judges/test-github-events.rb
@@ -2711,6 +2711,60 @@ class TestGithubEvents < Jp::Test
     assert_equal([526_301], f.first[:contributors])
   end
 
+  def test_release_event_survives_a_deleted_release_author
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_event(
+      {
+        id: '101',
+        type: 'ReleaseEvent',
+        actor: {
+          id: 8_086_956,
+          login: 'rultor',
+          display_login: 'rultor'
+        },
+        repo: {
+          id: 42,
+          name: 'foo/foo',
+          url: 'https://api.github.com/repos/foo/foo'
+        },
+        payload: {
+          action: 'published',
+          release: {
+            id: 999_001,
+            author: nil,
+            tag_name: '1.0.1',
+            name: 'v1.0.1',
+            created_at: Time.parse('2024-11-30T00:51:39Z'),
+            published_at: Time.parse('2024-11-30T00:52:07Z')
+          }
+        },
+        public: true,
+        created_at: Time.parse('2024-11-30T00:52:08Z')
+      }
+    )
+    stub_github(
+      'https://api.github.com/repos/foo/foo/contributors?per_page=100',
+      body: [{ login: 'yegor256', id: 526_301 }]
+    )
+    stub_github('https://api.github.com/repos/foo/foo/commits?per_page=1', body: [{ sha: 'abc123def456' }])
+    stub_github(
+      'https://api.github.com/repos/foo/foo/compare/abc123def456...1.0.1?per_page=100',
+      status: 404,
+      body: {
+        message: 'Not Found',
+        documentation_url: 'https://docs.github.com/rest/commits/commits#compare-two-commits',
+        status: '404'
+      }
+    )
+    stub_github('https://api.github.com/user/8086956', body: { login: 'rultor', id: 8_086_956 })
+    fb = Factbase.new
+    load_it('github-events', fb)
+    f = fb.query('(and (eq repository 42) (eq what "release-published"))').each.to_a
+    assert_equal(1, f.count)
+    assert_equal([8_086_956], f.first[:who])
+  end
+
   def test_release_rescues_forbidden_contributors
     WebMock.disable_net_connect!
     rate_limit_up


### PR DESCRIPTION
Closes #2061.

GitHub returns `release.author: null` once the account that published a release has been deleted. `github-events` dereferenced it twice while deciding whether to overwrite `who`:

```ruby
if fact.all_properties.include?('who') && fact.who != json[:payload][:release][:author][:id]
```

so the whole event scan died with `NoMethodError: undefined method '[]' for nil` and every event queued behind the ghost release went unprocessed.

The overwrite now happens only when the release actually names an author. When it does not, the fact keeps the actor `fact.who` was already set from at line 159 — the identity the event itself reports — so nothing downstream loses a `who` and the `Fbe.who` calls in the same branch still have something to read. That is the second option the issue suggests, and it needs no `stale` marker because the fact is not missing an author at all.

### Verification

The regression test is a published `ReleaseEvent` with `author: nil` and an actor present, as in the issue. I checked it actually catches the defect rather than passing either way:

- with this change: `test_release_event_survives_a_deleted_release_author PASS`, suite green
- with the change reverted and the test kept: `ERROR — Fbe::Error: Failure in repository #42 at #0: undefined method '[]' for nil`

It also asserts the event actor is kept as `who`, so a later change cannot quietly drop the identity instead of preserving it.

`bundle exec rake` is green on a fork before opening this.