### PR TITLE
#2063: skip an event whose repository cannot be resolved

### DIFF
--- a/judges/github-events/github-events.rb
+++ b/judges/github-events/github-events.rb
@@ -161,7 +161,7 @@ Fbe.iterate do
       rname = Fbe.octo.repo_name_by_id(fact.repository)
     rescue Octokit::NotFound, Octokit::Deprecated => e
       $loog.info("Repository ##{fact.repository} not found by ID: #{e.message}")
-      return
+      skip(json)
     rescue Octokit::Forbidden => e
       $loog.warn(
         "[#{$judge}] Access forbidden to repo name for ##{fact.repository} " \

--- a/test/judges/test-github-events.rb
+++ b/test/judges/test-github-events.rb
@@ -1309,6 +1309,36 @@ class TestGithubEvents < Jp::Test
     assert(fb.one?(what: 'iterate', repository: 42, events_were_scanned: 55_555))
   end
 
+  def test_skips_event_whose_repository_cannot_be_resolved
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github(
+      'https://api.github.com/repos/foo/foo',
+      body: { id: 42, name: 'foo', full_name: 'foo/foo', default_branch: 'master' }
+    )
+    stub_github(
+      'https://api.github.com/repositories/42',
+      body: { id: 42, name: 'foo', full_name: 'foo/foo', default_branch: 'master' }
+    )
+    stub_github('https://api.github.com/repositories/99', status: 404, body: { message: 'Not Found' })
+    stub_github(
+      'https://api.github.com/repositories/42/events?per_page=100',
+      body: [
+        {
+          id: '77777', type: 'ReleaseEvent', actor: { id: 8_086_956, login: 'rultor' },
+          repo: { id: 99, name: 'foo/gone', url: 'https://api.github.com/repos/foo/gone' },
+          payload: { action: 'published', release: { id: 178_369, tag_name: '9.9.9' } },
+          created_at: Time.parse('2025-06-27T00:52:08Z')
+        }
+      ]
+    )
+    fb = Factbase.new
+    load_it('github-events', fb)
+    assert_equal(1, fb.all.size)
+    assert(fb.one?(what: 'iterate', repository: 42, events_were_scanned: 77_777))
+    assert_equal(0, fb.query('(eq event_id 77777)').each.to_a.size)
+  end
+
   def test_pull_request_event_with_comments
     fb = Factbase.new
     load_it('github-events', fb, Judges::Options.new({ 'repositories' => 'zerocracy/baza', 'testing' => true }))


### PR DESCRIPTION
Closes #2063.

`Fbe.if_absent` has already inserted the event by the time `fill` reaches the repository lookup, so a `NotFound` from `repo_name_by_id` returned without raising and left the fact half-written: `event_id`, `where`, `when`, `event_type` and `repository`, but none of the `what` or issue/release fields. The scanner then advanced past it, and on every later run the event id was treated as already present, so the record could never be enriched even when the 404 had been transient.

`skip` is what this file already does with an event it does not want to record: it raises `Factbase::Rollback`, the transaction discards the fact, and the event is logged as ignored. `fill` already routes every unhandled event type through it. The repository lookup now goes the same way.

That is the second of the two resolutions the issue offers — the event is explicitly skipped rather than stored as a partial fact — and it needs no change to the cursor bookkeeping, which is computed from every scanned event rather than from the ones that were recorded.

### Verification

The test puts an event that names a repository which does not resolve into the feed of one that does, so the scan itself succeeds and only the event's own lookup 404s. I checked the test actually catches the defect rather than passing either way:

- with this change: `test_skips_event_whose_repository_cannot_be_resolved PASS`, suite `407 tests, 942 assertions, 0 failures, 0 errors`
- with `skip(json)` reverted to the bare `return` and the test kept: `FAIL — Expected: 1, Actual: 2`, the second fact being exactly the half-written one

It asserts the `iterate` bookkeeping fact is still written and that nothing carrying `event_id 77777` survives, so a later change cannot start recording the partial fact again quietly.

`bundle exec rake` is green on a fork before opening this.