### PR TITLE
Mask tokens passed through the options input

### DIFF
--- a/entries/masks-tokens-in-verbose-mode.sh
+++ b/entries/masks-tokens-in-verbose-mode.sh
@@ -18,6 +18,7 @@ setup_test_env "${SELF}" name
 # Distinctive token values so we can match them by exact string.
 github_token='ghp_test-secret-github-token-aaaaaaaaaaaa'
 zerocracy_token='ZRCY-test-secret-zerocracy-token-bbbbbbbbbbbb'
+options_token='ghp_test-options-token-cccccccccccc'
 
 run_entry_script "${SELF}" success \
   "GITHUB_WORKSPACE=$(pwd)" \
@@ -30,13 +31,18 @@ run_entry_script "${SELF}" success \
   "INPUT_FACTBASE=${name}.fb" \
   "INPUT_CYCLES=1" \
   "INPUT_VERBOSE=true" \
-  "INPUT_TOKEN=${zerocracy_token}"
+  "INPUT_TOKEN=${zerocracy_token}" \
+  "INPUT_OPTIONS=github_token=${options_token}"
 
 log_contains "::add-mask::${github_token}" \
   "::add-mask:: workflow command for INPUT_GITHUB-TOKEN must be emitted before bash tracing"
 log_contains "::add-mask::${zerocracy_token}" \
   "::add-mask:: workflow command for INPUT_TOKEN must be emitted before bash tracing"
+log_contains "::add-mask::${options_token}" \
+  "::add-mask:: workflow command for github_token in INPUT_OPTIONS must be emitted before bash tracing"
 log_not_contains "--option=github_token=${github_token}" \
   "github_token leaked via bash trace without ::add-mask:: prefix"
 log_not_contains "--token=${zerocracy_token}" \
   "zerocracy_token leaked via bash trace without ::add-mask:: prefix"
+log_not_contains "--option=github_token=${options_token}" \
+  "github_token from INPUT_OPTIONS leaked via bash trace without ::add-mask:: prefix"

--- a/entry.sh
+++ b/entry.sh
@@ -44,10 +44,6 @@ if [ -n "${INPUT_TOKEN}" ]; then
     echo "::add-mask::${INPUT_TOKEN}"
 fi
 
-if [ "${INPUT_VERBOSE}" == 'true' ]; then
-    set -x
-fi
-
 if [ -z "$1" ]; then
     SELF=$(dirname "$0")
 else
@@ -200,6 +196,20 @@ for opt in "${options[@]}"; do
 done
 if [ "${cache_min_age}" == "false" ]; then
     options+=("--option=sqlite_cache_min_age=3600");
+fi
+
+# Mask secrets supplied through the generic options input before tracing the
+# command that expands the options array. GitHub cannot mask values that are
+# not present in an environment variable of its own.
+for opt in "${options[@]}"; do
+    case "${opt}" in
+        --option=*token=*|--option=*secret=*|--option=*password=*)
+            echo "::add-mask::${opt#*=*=}"
+            ;;
+    esac
+done
+if [ "${INPUT_VERBOSE}" == 'true' ]; then
+    set -x
 fi
 
 owner="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"


### PR DESCRIPTION
## What changed

Mask token-, secret-, and password-shaped values from the generic `options` input before verbose tracing is enabled. This covers documented `github_token=...` options that do not arrive through `INPUT_GITHUB-TOKEN`.

The verbose-mode integration test now exercises a token passed through `INPUT_OPTIONS` and verifies that the workflow mask command is emitted.

## Why

`set -x` expands the options array when invoking Judges. A token supplied through `options:` was previously not registered with GitHub Actions masking, so it could appear in the trace.

Closes #2067.
