### PR TITLE
Count only human review comments

### DIFF
--- a/judges/add-review-comments/add-review-comments.rb
+++ b/judges/add-review-comments/add-review-comments.rb
@@ -6,6 +6,7 @@
 require 'fbe/consider'
 require 'fbe/octo'
 require 'octokit'
+require_relative '../../lib/humans'
 require_relative '../../lib/issue_was_lost'
 
 Fbe.consider(
@@ -75,7 +76,7 @@ Fbe.consider(
       )
       next
     end
-  c = json[:review_comments]
+  c = Jp.human_comments(Fbe.octo.pull_request_comments(repo, f.issue)).count
   f.review_comments = c
   $loog.info("Found #{c} review comments in #{repo}##{f.issue} (what: #{f.what})")
 end

--- a/judges/add-review-comments/add-review-comments.rb
+++ b/judges/add-review-comments/add-review-comments.rb
@@ -48,9 +48,8 @@ Fbe.consider(
       )
       next
     end
-  json =
-    begin
-      Fbe.octo.pull_request(repo, f.issue)
+  begin
+    Fbe.octo.pull_request(repo, f.issue)
     rescue Octokit::NotFound, Octokit::Deprecated => e
       $loog.info("Failed to find issue ##{f.issue} in #{repo}: #{e.message}")
       Jp.issue_was_lost(f.where, f.repository, f.issue)
@@ -75,7 +74,7 @@ Fbe.consider(
         "(will retry next cycle): #{e.class}: #{e.message}"
       )
       next
-    end
+  end
   c = Jp.human_comments(Fbe.octo.pull_request_comments(repo, f.issue)).count
   f.review_comments = c
   $loog.info("Found #{c} review comments in #{repo}##{f.issue} (what: #{f.what})")

--- a/judges/github-events/github-events.rb
+++ b/judges/github-events/github-events.rb
@@ -310,10 +310,10 @@ Fbe.iterate do
         skip(json) unless json.dig(:payload, :review, :state) == 'approved'
         fact.what = 'pull-was-reviewed'
         fact.hoc = (pull[:additions] || 0) + (pull[:deletions] || 0)
-        issue_comments = Jp.human_comments(Fbe.octo.issue_comments(rname, fact.issue))
-        review_comments = Jp.human_comments(Fbe.octo.pull_request_comments(rname, fact.issue))
-        fact.comments = issue_comments.count + review_comments.count
-        fact.review_comments = review_comments.count
+        ic = Jp.human_comments(Fbe.octo.issue_comments(rname, fact.issue))
+        rc = Jp.human_comments(Fbe.octo.pull_request_comments(rname, fact.issue))
+        fact.comments = ic.count + rc.count
+        fact.review_comments = rc.count
         fact.commits = pull[:commits]
         fact.files = pull[:changed_files]
         fact.details =

--- a/judges/github-events/github-events.rb
+++ b/judges/github-events/github-events.rb
@@ -310,8 +310,10 @@ Fbe.iterate do
         skip(json) unless json.dig(:payload, :review, :state) == 'approved'
         fact.what = 'pull-was-reviewed'
         fact.hoc = (pull[:additions] || 0) + (pull[:deletions] || 0)
-        fact.comments = pull[:comments] + pull[:review_comments]
-        fact.review_comments = pull[:review_comments]
+        issue_comments = Jp.human_comments(Fbe.octo.issue_comments(rname, fact.issue))
+        review_comments = Jp.human_comments(Fbe.octo.pull_request_comments(rname, fact.issue))
+        fact.comments = issue_comments.count + review_comments.count
+        fact.review_comments = review_comments.count
         fact.commits = pull[:commits]
         fact.files = pull[:changed_files]
         fact.details =

--- a/test/judges/test-add-review-comments.rb
+++ b/test/judges/test-add-review-comments.rb
@@ -44,6 +44,28 @@ class TestAddReviewComments < Jp::Test
     assert_equal(1, facts.first.review_comments)
   end
 
+  def test_ignores_bot_review_comments
+    WebMock.disable_net_connect!
+    pl = { id: 96, comments: 2 }
+    repo = 42
+    stub(repo, pl)
+    stub_github(
+      'https://api.github.com/repos/foo/foo/pulls/96/comments?per_page=100',
+      body: [
+        { user: { type: 'Bot', login: 'review-bot' } },
+        { user: { type: 'User', login: 'reviewer' } }
+      ]
+    )
+    fb = Factbase.new
+    fact = fb.insert
+    fact.what = 'pull-was-reviewed'
+    fact.issue = pl[:id]
+    fact.repository = repo
+    fact.where = 'github'
+    load_it('add-review-comments', fb)
+    assert_equal(1, fb.query("(eq issue #{pl[:id]})").each.first.review_comments)
+  end
+
   def test_adds_review_comments_to_bare_facts
     WebMock.disable_net_connect!
     pulls = [{ id: 93, comments: 2 }, { id: 94, comments: 1 }, { id: 95, comments: 4 }]
@@ -228,6 +250,10 @@ class TestAddReviewComments < Jp::Test
           commits: 2,
           changed_files: 3
         }
+      )
+      stub_github(
+        "https://api.github.com/repos/foo/foo/pulls/#{pl[:id]}/comments?per_page=100",
+        body: Array.new(pl[:comments]) { { user: { type: 'User', login: 'reviewer' } } }
       )
     end
     stub_github(

--- a/test/judges/test-github-events.rb
+++ b/test/judges/test-github-events.rb
@@ -14,6 +14,18 @@ require_relative '../test__helper'
 class TestGithubEvents < Jp::Test
   using SmartFactbase
 
+  def setup
+    super
+    stub_github(
+      'https://api.github.com/repos/foo/foo/issues/93/comments?per_page=100',
+      body: [{ user: { type: 'User', login: 'commenter' } }]
+    )
+    stub_github(
+      'https://api.github.com/repos/foo/foo/pulls/93/comments?per_page=100',
+      body: Array.new(2) { { user: { type: 'User', login: 'reviewer' } } }
+    )
+  end
+
   def test_create_tag_event
     WebMock.disable_net_connect!
     rate_limit_up


### PR DESCRIPTION
## What changed

Review facts created by `github-events` and completed by `add-review-comments` now count actual pull-request and issue comments after filtering bot authors through the existing `Jp.human_comments` helper. The raw REST totals, which include automation, are no longer copied into reward inputs.

The test suite includes endpoint fixtures for the comment collections and a regression covering a bot plus a human review comment.

## Why

GitHub's pull totals include bot comments, which can inflate review rewards and change the twelve-comment threshold without additional human review.

Closes #2052.
