### PR TITLE
Preserve the furthest cover window when finding gaps

### DIFF
--- a/lib/cover_qo.rb
+++ b/lib/cover_qo.rb
@@ -35,7 +35,7 @@ def Jp.cover_qo(days, judge: $judge, loog: $loog, today: nil)
   gaps = []
   facts.each do |f|
     gaps << { since: prev.when, when: f.since } if f.since > prev.when
-    prev = f
+    prev = f if f.when > prev.when
   end
   large = gaps.reject { |g| g[:when] - g[:since] < slice }
   large.reject { |g| facts.find { |f| g[:since] < f.when && g[:when] > f.since } }.each do |g|

--- a/test/lib/test_cover_qo.rb
+++ b/test/lib/test_cover_qo.rb
@@ -300,6 +300,32 @@ class TestCoverQo < Minitest::Test
     end
   end
 
+  def test_fills_gap_after_fact_nested_in_previous_window
+    fb = Factbase.new
+    now = Time.parse('2025-03-01 12:00:00 UTC')
+    outer = fb.insert
+    outer.what = 'test-judge'
+    outer.since = Time.parse('2025-01-01 12:00:00 UTC')
+    outer.when = Time.parse('2025-02-01 12:00:00 UTC')
+    nested = fb.insert
+    nested.what = 'test-judge'
+    nested.since = Time.parse('2025-01-10 12:00:00 UTC')
+    nested.when = Time.parse('2025-01-12 12:00:00 UTC')
+    later = fb.insert
+    later.what = 'test-judge'
+    later.since = Time.parse('2025-02-20 12:00:00 UTC')
+    later.when = Time.parse('2025-03-01 12:00:00 UTC')
+    Fbe.stub(:fb, fb) do
+      Jp.cover_qo(10, judge: 'test-judge', loog: Loog::NULL, today: now)
+      facts = fb.query("(eq what 'test-judge')").each.to_a
+      gap = facts.find do |fact|
+        fact.since == Time.parse('2025-02-01 12:00:00 UTC')
+      end
+      refute_nil(gap, 'gap after nested window is filled')
+      assert_equal(Time.parse('2025-02-20 12:00:00 UTC'), gap.when)
+    end
+  end
+
   def test_adds_fresh_fact_past_slice_boundary
     fb = Factbase.new
     now = Time.parse('2025-01-20 12:00:00 UTC')

--- a/test/lib/test_cover_qo.rb
+++ b/test/lib/test_cover_qo.rb
@@ -16,7 +16,7 @@ class TestCoverQo < Minitest::Test
       now = Time.now
       Time.stub(:now, now) do
         Jp.cover_qo(10, judge: 'test-judge', loog: Loog::NULL)
-        end
+      end
       facts = fb.query("(eq what 'test-judge')").each.to_a
       assert_equal(1, facts.size, 'exactly one fact inserted when none exist')
       assert_equal('test-judge', facts.first.what)
@@ -320,8 +320,8 @@ class TestCoverQo < Minitest::Test
       facts = fb.query("(eq what 'test-judge')").each.to_a
       gap =
         facts.find do |fact|
-        fact.since == Time.parse('2025-02-01 12:00:00 UTC')
-      end
+          fact.since == Time.parse('2025-02-01 12:00:00 UTC')
+        end
       refute_nil(gap, 'gap after nested window is filled')
       assert_equal(Time.parse('2025-02-20 12:00:00 UTC'), gap.when)
     end

--- a/test/lib/test_cover_qo.rb
+++ b/test/lib/test_cover_qo.rb
@@ -16,7 +16,7 @@ class TestCoverQo < Minitest::Test
       now = Time.now
       Time.stub(:now, now) do
         Jp.cover_qo(10, judge: 'test-judge', loog: Loog::NULL)
-      end
+        end
       facts = fb.query("(eq what 'test-judge')").each.to_a
       assert_equal(1, facts.size, 'exactly one fact inserted when none exist')
       assert_equal('test-judge', facts.first.what)

--- a/test/lib/test_cover_qo.rb
+++ b/test/lib/test_cover_qo.rb
@@ -318,7 +318,8 @@ class TestCoverQo < Minitest::Test
     Fbe.stub(:fb, fb) do
       Jp.cover_qo(10, judge: 'test-judge', loog: Loog::NULL, today: now)
       facts = fb.query("(eq what 'test-judge')").each.to_a
-      gap = facts.find do |fact|
+      gap =
+        facts.find do |fact|
         fact.since == Time.parse('2025-02-01 12:00:00 UTC')
       end
       refute_nil(gap, 'gap after nested window is filled')


### PR DESCRIPTION
## What changed

`Jp.cover_qo` now advances its previous window only when the next fact ends farther in the future. A nested window therefore cannot move the scan point backwards. A regression test covers a real gap after a nested window.

## Why

The previous implementation replaced the furthest window with every fact in `since` order. When a nested fact was followed by a later window, the resulting gap was measured from the nested fact's end and then rejected as overlapping, leaving the real gap uncovered.

Closes #2049.
