### PR TITLE
#2057: remember successful empty metrics

### DIFF
--- a/lib/incremate.rb
+++ b/lib/incremate.rb
@@ -11,7 +11,6 @@ require 'tago'
 require 'time'
 require_relative 'jp'
 
-# Factbase cannot store an empty property, so keep completion separately.
 Jp::INCREMATE_MARKER = '_incremate'
 
 def Jp.incremate(

--- a/lib/incremate.rb
+++ b/lib/incremate.rb
@@ -11,6 +11,9 @@ require 'tago'
 require 'time'
 require_relative 'jp'
 
+# Factbase cannot store an empty property, so keep completion separately.
+Jp::INCREMATE_MARKER = '_incremate'
+
 def Jp.incremate(
   fact, dir, prefix, avoid_duplicate: true, pause: 0,
   max_per_fact: nil,
@@ -19,8 +22,8 @@ def Jp.incremate(
   evaluated = 0
   Dir[File.join(dir, "#{prefix}_*.rb")].each do |rb|
     n = File.basename(rb).gsub(/\.rb$/, '')
-    if fact[n]
-      $loog.debug("#{n} is here: #{fact[n].first}")
+    if fact[n] || fact[Jp::INCREMATE_MARKER]&.include?(n)
+      $loog.debug("#{n} is here: #{fact[n]&.first || 'empty'}")
       next
     end
     break if Fbe.over?(epoch:, kickoff:)
@@ -46,6 +49,9 @@ def Jp.incremate(
       end
       if h.key?(n.to_sym) && !(avoid_duplicate && fact.all_properties.include?(n))
         Array(h[n.to_sym]).each { fact.__send__("#{n}=", _1) }
+      end
+      if h[n.to_sym].is_a?(Array) && h[n.to_sym].empty?
+        fact.__send__("#{Jp::INCREMATE_MARKER}=", n)
       end
       throw(:"Collected #{n}: [#{h.map { |k, v| "#{k}: #{v}" }.join(', ')}]")
     end

--- a/test/lib/test_incremate.rb
+++ b/test/lib/test_incremate.rb
@@ -142,4 +142,128 @@ class TestIncremate < Minitest::Test
     $loog = nil
     $options = nil
   end
+
+  def test_incremate_remembers_empty_metric_after_factbase_roundtrip
+    configure_incremate
+    Dir.mktmpdir do |dir|
+      File.write(File.expand_path('some_empty.rb', dir), <<~RUBY)
+        def some_empty(_fact)
+          $calls += 1
+          { some_empty: [] }
+        end
+      RUBY
+      $calls = 0
+      time = Time.now - 60
+      fb = Factbase.new
+      fact = fb.insert
+      Jp.incremate(fact, dir, 'some', epoch: time, kickoff: time)
+      assert_equal(1, $calls)
+      assert_nil(fact['some_empty'])
+      assert_equal(['some_empty'], fact[Jp::INCREMATE_MARKER])
+      copy = Factbase.new
+      copy.import(fb.export)
+      resumed = copy.query('(always)').each.to_a.first
+      Jp.incremate(resumed, dir, 'some', epoch: time, kickoff: time)
+      assert_equal(1, $calls, 'a persisted empty result must not be collected again')
+      assert_nil(resumed['some_empty'])
+    end
+  ensure
+    reset_incremate
+  end
+
+  def test_incremate_retries_metric_without_result
+    configure_incremate
+    Dir.mktmpdir do |dir|
+      File.write(File.expand_path('some_empty.rb', dir), <<~RUBY)
+        def some_empty(_fact)
+          $calls += 1
+          $calls == 1 ? {} : { some_empty: [] }
+        end
+      RUBY
+      $calls = 0
+      fact = Factbase.new.insert
+      time = Time.now - 60
+      Jp.incremate(fact, dir, 'some', epoch: time, kickoff: time)
+      assert_equal(1, $calls)
+      assert_nil(fact[Jp::INCREMATE_MARKER])
+      Jp.incremate(fact, dir, 'some', epoch: time, kickoff: time)
+      assert_equal(2, $calls)
+      assert_equal(['some_empty'], fact[Jp::INCREMATE_MARKER])
+      Jp.incremate(fact, dir, 'some', epoch: time, kickoff: time)
+      assert_equal(2, $calls, 'a successful empty result must be remembered')
+    end
+  ensure
+    reset_incremate
+  end
+
+  def test_incremate_marks_only_after_writing_all_values
+    configure_incremate
+    Dir.mktmpdir do |dir|
+      File.write(File.expand_path('some_empty.rb', dir), <<~RUBY)
+        def some_empty(_fact)
+          $calls += 1
+          if $calls == 1
+            { some_empty: [], some_invalid: Object.new }
+          else
+            { some_empty: [] }
+          end
+        end
+      RUBY
+      $calls = 0
+      fact = Factbase.new.insert
+      time = Time.now - 60
+      assert_raises(ArgumentError) do
+        Jp.incremate(fact, dir, 'some', epoch: time, kickoff: time)
+      end
+      assert_nil(fact[Jp::INCREMATE_MARKER])
+      Jp.incremate(fact, dir, 'some', epoch: time, kickoff: time)
+      assert_equal(['some_empty'], fact[Jp::INCREMATE_MARKER])
+      Jp.incremate(fact, dir, 'some', epoch: time, kickoff: time)
+      assert_equal(2, $calls, 'a failed collection must remain retryable')
+    end
+  ensure
+    reset_incremate
+  end
+
+  def test_incremate_keeps_non_empty_metrics_unchanged
+    configure_incremate
+    Dir.mktmpdir do |dir|
+      File.write(File.expand_path('some_non_empty.rb', dir), <<~RUBY)
+        def some_non_empty(_fact)
+          $nonempty += 1
+          { some_non_empty: 42 }
+        end
+      RUBY
+      $nonempty = 0
+      fact = Factbase.new.insert
+      time = Time.now - 60
+      2.times { Jp.incremate(fact, dir, 'some', epoch: time, kickoff: time) }
+      assert_equal(1, $nonempty)
+      assert_equal(42, fact.some_non_empty)
+      assert_nil(fact[Jp::INCREMATE_MARKER])
+    end
+  ensure
+    reset_incremate
+  end
+
+  private
+
+  def configure_incremate
+    WebMock.disable_net_connect!
+    stub_request(:get, 'https://api.github.com/rate_limit').to_return(
+      body: { rate: { remaining: 1000, limit: 1000 } }.to_json,
+      headers: { 'X-RateLimit-Remaining' => '999' }
+    )
+    $global = {}
+    $local = {}
+    $loog = Loog::VERBOSE
+    $options = Judges::Options.new({ 'lifetime' => 100, 'timeout' => 100 })
+  end
+
+  def reset_incremate
+    $global = nil
+    $local = nil
+    $loog = nil
+    $options = nil
+  end
 end


### PR DESCRIPTION
# Fix #2057: remember successful empty metrics

`Jp.incremate` now persists completed metric names in the internal `_incremate`
property when a metric returns an empty array. The marker is written after all
returned values have been accepted, so transient `{}` results and failed
writes remain retryable. Existing non-empty metrics still use their own value
as the completion signal.

Checks on base `85e3ead9f56c7199b50993c3eae2f37a44c606ef`:

- Original reproduction: three consecutive runs of a `{ some_empty: [] }`
  metric made 3 calls and left the fact with no properties.
- Focused `test/lib/test_incremate.rb`: 8 tests, 25 assertions, 0 failures.
- `bundle exec rake test` (Ruby 4.0.5, locked Bundler 2.6.8): 422 tests,
  1,037 assertions, 0 failures, 1 expected skip.
- `bundle exec rake rubocop`: 123 files, 0 offenses.
- `bundle exec rake judges`: 30 judges, 62 tests passed.

The Docker verification attempt stopped in the image build apt layer because the local host ran out of disk space; `entry.sh` integration was not run. The Ruby checks above used synthetic fixtures and did not use live GitHub credentials.

Closes #2057.
