### PR TITLE
Move is-human-or-robot test onto the fake GitHub server

### DIFF
--- a/test/fake_github.rb
+++ b/test/fake_github.rb
@@ -9,9 +9,9 @@ require 'socket'
 require_relative '../lib/jp'
 
 # rubocop:disable Elegant/NoComments
-# @todo #2028:60min Move the rest of the tests onto this server.
-#  Twenty seven files under `test/` still build their GitHub with
-#  `stub_request` and `stub_github`, one thousand one hundred and seventy nine
+# @todo #2041:60min Move the rest of the tests onto this server.
+#  Twenty six files under `test/` still build their GitHub with
+#  `stub_request` and `stub_github`, one thousand two hundred and thirty six
 #  stubs in all, the heaviest being `test/judges/test-quality-of-service.rb`
 #  with two hundred and fifty three. Each of them should declare its routes
 #  through `Jp::FakeGithub` instead, one file at a time, so that a reviewer

--- a/test/judges/test-is-human-or-robot.rb
+++ b/test/judges/test-is-human-or-robot.rb
@@ -4,39 +4,32 @@
 # SPDX-License-Identifier: MIT
 
 require 'factbase'
-require 'octokit'
+require_relative '../fake_github'
 require_relative '../test__helper'
 
 class TestIsHumanOrRobot < Jp::Test
   using SmartFactbase
 
   def test_handles_missing_github_user_gracefully
-    WebMock.disable_net_connect!
     id = 444
-    stub_github("https://api.github.com/user/#{id}", body: {}, status: 404)
-    stub_github(
-      'https://api.github.com/rate_limit',
-      body: {
-        rate: { limit: 60, remaining: 59, reset: 1_728_464_472, used: 1, resource: 'core' }
-      }
-    )
     fb = Factbase.new
     fact = fb.insert
     fact.who = id
     fact.where = 'github'
-    load_it('is-human-or-robot', fb)
+    Jp::FakeGithub.new(
+      'GET /rate_limit' => {
+        rate: { limit: 60, remaining: 59, reset: 1_728_464_472, used: 1, resource: 'core' }
+      },
+      "GET /user/#{id}" => [404, {}]
+    ).run do
+      load_it('is-human-or-robot', fb)
+    end
     facts = fb.query("(eq who #{id})").each.to_a
     assert_equal(id, facts.first.who)
     assert_raises(ArgumentError) { facts.first.is_human }
   end
 
   def test_identify_user_as_bot_or_human
-    WebMock.disable_net_connect!
-    rate_limit_up
-    stub_github('https://api.github.com/user/15', body: { login: 'rultor', id: 15, type: 'User' })
-    stub_github('https://api.github.com/user/16', body: { login: '0pdd', id: 16, type: 'User' })
-    stub_github('https://api.github.com/user/17', body: { login: 'other_bot', id: 17, type: 'Bot' })
-    stub_github('https://api.github.com/user/18', body: { login: 'user4', id: 18, type: 'User' })
     fb = Factbase.new
     fb.with(where: 'github', what: 'issue-was-opened', who: 10, name: 'user0', stale: 'who')
       .with(where: 'github', name: 'user1')
@@ -47,7 +40,15 @@ class TestIsHumanOrRobot < Jp::Test
       .with(where: 'github', what: 'issue-was-opened', who: 16, name: '0pdd')
       .with(where: 'github', what: 'issue-was-opened', who: 17, name: 'other_bot')
       .with(where: 'github', what: 'issue-was-opened', who: 18, name: 'user4')
-    load_it('is-human-or-robot', fb, Judges::Options.new({ 'bots' => '0pdd,rultor' }))
+    Jp::FakeGithub.new(
+      'GET /rate_limit' => { resources: { search: { remaining: 30, limit: 30 } }, rate: { remaining: 1000 } },
+      'GET /user/15' => { login: 'rultor', id: 15, type: 'User' },
+      'GET /user/16' => { login: '0pdd', id: 16, type: 'User' },
+      'GET /user/17' => { login: 'other_bot', id: 17, type: 'Bot' },
+      'GET /user/18' => { login: 'user4', id: 18, type: 'User' }
+    ).run do
+      load_it('is-human-or-robot', fb, Judges::Options.new({ 'bots' => '0pdd,rultor' }))
+    end
     assert_equal(9, fb.all.size)
     assert_equal(2, fb.picks(is_human: 1).size)
     assert_equal(4, fb.picks(is_human: 0).size)
@@ -61,16 +62,14 @@ class TestIsHumanOrRobot < Jp::Test
   end
 
   def test_forbidden_user_lookup_leaves_fact_retriable
-    WebMock.disable_net_connect!
-    rate_limit_up
-    stub_github(
-      'https://api.github.com/user/29139614',
-      status: 403,
-      body: { message: 'Resource not accessible by integration' }
-    )
     fb = Factbase.new
     fb.with(_id: 1, what: 'pull-was-merged', repository: 42, issue: 44, who: 29_139_614, where: 'github')
-    load_it('is-human-or-robot', fb)
+    Jp::FakeGithub.new(
+      'GET /rate_limit' => { resources: { search: { remaining: 30, limit: 30 } }, rate: { remaining: 1000 } },
+      'GET /user/29139614' => [403, { message: 'Resource not accessible by integration' }]
+    ).run do
+      load_it('is-human-or-robot', fb)
+    end
     fact = fb.query('(eq who 29139614)').each.first
     refute_nil(fact)
     assert_raises(ArgumentError, 'fact should not be marked stale on transient 403') { fact.stale }
@@ -80,20 +79,18 @@ class TestIsHumanOrRobot < Jp::Test
   end
 
   def test_forbidden_user_does_not_abort_others
-    WebMock.disable_net_connect!
-    rate_limit_up
-    stub_github('https://api.github.com/user/100', body: { login: 'alice', id: 100, type: 'User' })
-    stub_github(
-      'https://api.github.com/user/200',
-      status: 403,
-      body: { message: 'Resource not accessible by integration' }
-    )
-    stub_github('https://api.github.com/user/300', body: { login: 'bob', id: 300, type: 'User' })
     fb = Factbase.new
     fb.with(_id: 1, what: 'pull-was-merged', who: 100, where: 'github')
       .with(_id: 2, what: 'pull-was-merged', who: 200, where: 'github')
       .with(_id: 3, what: 'pull-was-merged', who: 300, where: 'github')
-    load_it('is-human-or-robot', fb)
+    Jp::FakeGithub.new(
+      'GET /rate_limit' => { resources: { search: { remaining: 30, limit: 30 } }, rate: { remaining: 1000 } },
+      'GET /user/100' => { login: 'alice', id: 100, type: 'User' },
+      'GET /user/200' => [403, { message: 'Resource not accessible by integration' }],
+      'GET /user/300' => { login: 'bob', id: 300, type: 'User' }
+    ).run do
+      load_it('is-human-or-robot', fb)
+    end
     classified = fb.query('(exists is_human)').each.to_a
     staled = fb.query("(eq stale 'who')").each.to_a
     assert_equal(2, classified.size, 'both good users (100, 300) should be classified')


### PR DESCRIPTION
The `is-human-or-robot` test now declares its GitHub routes through `Jp::FakeGithub` and talks to a real socket on localhost, instead of building four separate WebMock stub sets with `stub_github` and `rate_limit_up`. Each of the four tests carries its own route table: the rate limit, the four user lookups, the two 403 replies and the 404 for the vanished user.

The puzzle in `test/fake_github.rb` moves forward with it. Twenty six files are left on `stub_request`, and the count of stubs in the note was stale, so it now reads the real one: one thousand two hundred and thirty six.

`require 'octokit'` went out of the test file, since nothing there names the constant any more once the stubbing is gone.

Closes #2041
