### PR TITLE
fix(#2109): wrap the stale marking of dead repositories in a transaction

### DIFF
--- a/judges/erase-repository/erase-repository.rb
+++ b/judges/erase-repository/erase-repository.rb
@@ -5,6 +5,7 @@
 
 require 'elapsed'
 require 'fbe/consider'
+require 'fbe/fb'
 require 'fbe/octo'
 require 'logger'
 require 'octokit'
@@ -31,10 +32,12 @@ Fbe.fb.query('(and (eq where "github") (exists repository) (absent stale))').eac
   end
 end
 
-good.each do |repo, ok|
-  next if ok
-  Fbe.fb.query("(and (eq where 'github') (eq repository #{repo}) (absent stale))").each do |f|
-    f.stale = 'repository'
+Fbe.fb.txn do |fbt|
+  good.each do |repo, ok|
+    next if ok
+    fbt.query("(and (eq where 'github') (eq repository #{repo}) (absent stale))").each do |f|
+      f.stale = 'repository'
+    end
   end
 end
 

--- a/test/judges/test-erase-repository.rb
+++ b/test/judges/test-erase-repository.rb
@@ -7,6 +7,8 @@ require 'factbase'
 require_relative '../test__helper'
 
 class TestEraseRepository < Jp::Test
+  using SmartFactbase
+
   def test_erase_not_found_repository
     WebMock.disable_net_connect!
     stub_request(:get, 'https://api.github.com/rate_limit').to_return(
@@ -113,5 +115,51 @@ class TestEraseRepository < Jp::Test
     end
     load_it('erase-repository', fb)
     assert_requested(:get, 'https://api.github.com/repositories/403999', times: 1)
+  end
+
+  def test_writes_the_stale_flags_in_one_transaction
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repositories/404125', body: '', status: 404)
+    fb = Factbase.new
+    fb.with(_id: 1, where: 'github', repository: 404_125, what: 'something-a')
+      .with(_id: 2, where: 'github', repository: 404_125, what: 'something-b')
+    loog = Loog::Buffer.new
+    load_it('erase-repository', fb, loog:)
+    assert_includes(
+      loog.to_s, 'Txn #',
+      'The stale flags of a dead repository cannot be written one by one, outside a transaction'
+    )
+  end
+
+  def test_marks_every_fact_of_every_dead_repository
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repositories/404201', body: '', status: 404)
+    stub_github('https://api.github.com/repositories/404202', body: '', status: 404)
+    fb = Factbase.new
+    fb.with(_id: 1, where: 'github', repository: 404_201, what: 'something-a')
+      .with(_id: 2, where: 'github', repository: 404_201, what: 'something-b')
+      .with(_id: 3, where: 'github', repository: 404_202, what: 'something-c')
+    load_it('erase-repository', fb)
+    assert_equal(
+      3, fb.picks(stale: 'repository').count,
+      'A transaction over dead repositories cannot leave some of their facts unmarked'
+    )
+  end
+
+  def test_dont_touch_a_repository_that_is_alive
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repositories/404301', body: '', status: 404)
+    stub_github('https://api.github.com/repositories/700301', body: { id: 700_301, full_name: 'foo/bar' })
+    fb = Factbase.new
+    fb.with(_id: 1, where: 'github', repository: 404_301, what: 'something-a')
+      .with(_id: 2, where: 'github', repository: 700_301, what: 'something-b')
+    load_it('erase-repository', fb)
+    assert(
+      fb.none?(repository: 700_301, stale: 'repository'),
+      'A repository answering GitHub in this very run cannot have its facts retired'
+    )
   end
 end


### PR DESCRIPTION
The second loop of `erase-repository` wrote `stale = 'repository'` straight onto the
factbase, one fact at a time. An error raised halfway through the dead repositories
committed the marks made so far and abandoned the rest, so the next run started from
a factbase that was neither the state before nor the state after.

The loop now runs inside `Fbe.fb.txn` and queries through the transaction handle, the
same way `eliminate-ghosts` and `who-is-alive` already mark stale users. Either every
fact of every missing repository gets its flag, or none of them does.

Three tests come with it: one that fails unless the marking happens in a transaction,
one that checks all facts of several dead repositories are marked together, and one
that keeps a repository answering GitHub in the same run untouched.

Closes #2109
