### PR TITLE
fix(#2110): stop scanning repositories when github quota is exhausted

### DIFF
--- a/judges/erase-repository/erase-repository.rb
+++ b/judges/erase-repository/erase-repository.rb
@@ -10,8 +10,10 @@ require 'logger'
 require 'octokit'
 
 good = {}
+quota = true
 
 Fbe.fb.query('(and (eq where "github") (exists repository) (absent stale))').each do |f|
+  break unless quota
   next if Fbe.octo.off_quota?
   r = f.repository
   next unless good[r].nil?
@@ -19,6 +21,12 @@ Fbe.fb.query('(and (eq where "github") (exists repository) (absent stale))').eac
     json = Fbe.octo.repository(r)
     good[r] = true
     throw(:"GitHub repository ##{r} is found: #{json[:full_name]}")
+  rescue Octokit::TooManyRequests => e
+    quota = false
+    $loog.warn(
+      "[#{$judge}] GitHub quota is exhausted at repository ##{r}, " \
+      "no more repositories will be checked in this cycle: #{e.class}: #{e.message}"
+    )
   rescue Octokit::NotFound, Octokit::Deprecated => e
     good[r] = false
     throw(:"GitHub repository ##{r} is not found: #{e.message}")

--- a/test/judges/test-erase-repository.rb
+++ b/test/judges/test-erase-repository.rb
@@ -114,4 +114,56 @@ class TestEraseRepository < Jp::Test
     load_it('erase-repository', fb)
     assert_requested(:get, 'https://api.github.com/repositories/403999', times: 1)
   end
+
+  def test_dont_check_more_repositories_after_rate_limit
+    ENV['RACK_ENV'] = 'test'
+    WebMock.disable_net_connect!
+    stub_request(:get, 'https://api.github.com/rate_limit').to_return(
+      { body: '{"rate":{"remaining":222}}', headers: { 'X-RateLimit-Remaining' => '222' } }
+    )
+    stub_github(
+      'https://api.github.com/repositories/403222',
+      body: { message: 'API rate limit exceeded for user ID 42' }, status: 403
+    )
+    stub_github('https://api.github.com/repositories/1236', body: { id: 1236, name: 'żółw', full_name: 'foo/żółw' })
+    fb = Factbase.new
+    fb.insert.then do |f|
+      f._id = 1
+      f.where = 'github'
+      f.repository = 403_222
+    end
+    fb.insert.then do |f|
+      f._id = 2
+      f.where = 'github'
+      f.repository = 1236
+    end
+    load_it('erase-repository', fb)
+    assert_not_requested(:get, 'https://api.github.com/repositories/1236')
+  end
+
+  def test_erase_repository_that_was_missing_before_rate_limit
+    ENV['RACK_ENV'] = 'test'
+    WebMock.disable_net_connect!
+    stub_request(:get, 'https://api.github.com/rate_limit').to_return(
+      { body: '{"rate":{"remaining":222}}', headers: { 'X-RateLimit-Remaining' => '222' } }
+    )
+    stub_github('https://api.github.com/repositories/404125', body: '', status: 404)
+    stub_github(
+      'https://api.github.com/repositories/403223',
+      body: { message: 'API rate limit exceeded for user ID 42' }, status: 403
+    )
+    fb = Factbase.new
+    fb.insert.then do |f|
+      f._id = 1
+      f.where = 'github'
+      f.repository = 404_125
+    end
+    fb.insert.then do |f|
+      f._id = 2
+      f.where = 'github'
+      f.repository = 403_223
+    end
+    load_it('erase-repository', fb)
+    assert_equal(1, fb.query('(exists stale)').each.to_a.size)
+  end
 end


### PR DESCRIPTION
`Octokit::TooManyRequests` is a subclass of `Octokit::Forbidden`, so a 403 that means the quota is gone used to land in the same arm as a 403 that means the token cannot see the repository. The log then blamed access rights, the repository was recorded as verified for the rest of the cycle, and the judge went back to the query and kept spending whatever allowance was left on calls that could not succeed.

The rate limit now has its own arm, placed ahead of the `Forbidden` one, saying which repository was being read when GitHub cut us off. It records nothing about that repository, since nobody actually checked it, and it stops the scan. Repositories already found missing before that point are still marked stale, so the work done earlier in the cycle is not thrown away.

Two tests cover it: one proves no further repository is read after the rate limit, the other proves a repository found missing before it still gets its facts marked stale.

Closes #2110
