### PR TITLE
Write the lost issue through the enclosing transaction

### DIFF
--- a/judges/find-all-issues/find-all-issues.rb
+++ b/judges/find-all-issues/find-all-issues.rb
@@ -101,7 +101,7 @@ require_relative '../../lib/qos_search'
                   Fbe.octo.pull_request(repo, f.issue).dig(:head, :ref)
                 rescue Octokit::NotFound, Octokit::Deprecated => e
                   $loog.info("The pull ##{f.issue} doesn't exist in #{repo}: #{e.message}")
-                  Jp.issue_was_lost(f.where, f.repository, f.issue)
+                  Jp.issue_was_lost(f.where, f.repository, f.issue, fb: fbt)
                   next
                 rescue Octokit::Forbidden => e
                   $loog.warn(

--- a/judges/find-earliest-issue/find-earliest-issue.rb
+++ b/judges/find-earliest-issue/find-earliest-issue.rb
@@ -66,7 +66,7 @@ Fbe.iterate do
             Fbe.octo.pull_request(repo, f.issue).dig(:head, :ref)
           rescue Octokit::NotFound, Octokit::Deprecated => e
             $loog.info("The pull ##{f.issue} doesn't exist in #{repo}: #{e.message}")
-            Jp.issue_was_lost(f.where, f.repository, f.issue)
+            Jp.issue_was_lost(f.where, f.repository, f.issue, fb: fbt)
             next i
           rescue Octokit::Forbidden => e
             $loog.warn(

--- a/judges/find-latest-issue/find-latest-issue.rb
+++ b/judges/find-latest-issue/find-latest-issue.rb
@@ -66,7 +66,7 @@ Fbe.iterate do
             Fbe.octo.pull_request(repo, f.issue).dig(:head, :ref)
           rescue Octokit::NotFound, Octokit::Deprecated => e
             $loog.info("The pull ##{f.issue} doesn't exist in #{repo}: #{e.message}")
-            Jp.issue_was_lost(f.where, f.repository, f.issue)
+            Jp.issue_was_lost(f.where, f.repository, f.issue, fb: fbt)
             next i
           rescue Octokit::Forbidden => e
             $loog.warn(

--- a/judges/find-missing-issues/find-missing-issues.rb
+++ b/judges/find-missing-issues/find-missing-issues.rb
@@ -82,7 +82,7 @@ Fbe.consider('(and (eq where "github") (exists repository) (unique repository))'
             Fbe.octo.pull_request(repo, f.issue).dig(:head, :ref)
           rescue Octokit::NotFound, Octokit::Deprecated => e
             $loog.info("The pull ##{f.issue} doesn't exist in #{repo}: #{e.message}")
-            Jp.issue_was_lost(f.where, f.repository, f.issue)
+            Jp.issue_was_lost(f.where, f.repository, f.issue, fb: fbt)
             next
           rescue Octokit::Forbidden => e
             $loog.warn(

--- a/lib/issue_was_lost.rb
+++ b/lib/issue_was_lost.rb
@@ -4,12 +4,14 @@
 # SPDX-License-Identifier: MIT
 
 require 'fbe/fb'
+require 'fbe/if_absent'
 require 'fbe/tombstone'
 require_relative 'jp'
 
-def Jp.issue_was_lost(where, repository, issue)
+# @todo #2074:30min Bury through the given "fb", once zerocracy/fbe#843 lets Fbe.overwrite run in a txn.
+def Jp.issue_was_lost(where, repository, issue, fb: Fbe.fb)
   stale =
-    Fbe.fb.query(
+    fb.query(
       "(and
       (eq where '#{where}')
       (eq repository #{repository})
@@ -22,20 +24,18 @@ def Jp.issue_was_lost(where, repository, issue)
     $loog.info("The issue #{issue} was marked as lost, #{stale} facts marked as stale")
     return
   end
-  Fbe.fb.txn do |fbt|
-    f =
-      Fbe.if_absent(fb: fbt) do |n|
-        n.issue = issue
-        n.what = 'issue-was-lost'
-        n.repository = repository
-        n.where = where
-      end
-    if f.nil?
-      $loog.warn("The issue ##{issue} was already lost")
-      next
+  f =
+    Fbe.if_absent(fb:) do |n|
+      n.where = where
+      n.repository = repository
+      n.issue = issue
+      n.what = 'issue-was-lost'
     end
-    f.stale = 'issue'
-    f.when = Time.now
-    $loog.info("The issue #{issue} was marked as lost")
+  if f.nil?
+    $loog.warn("The issue ##{issue} was already lost")
+    return
   end
+  f.stale = 'issue'
+  f.when = Time.now
+  $loog.info("The issue #{issue} was marked as lost")
 end

--- a/test/lib/test_issue_was_lost.rb
+++ b/test/lib/test_issue_was_lost.rb
@@ -88,4 +88,43 @@ class TestIssueWasLost < Minitest::Test
       assert(Fbe::Tombstone.new(fb: fb).has?('github', 7, 11), 'tombstone must contain the issue after the call')
     end
   end
+
+  def test_dont_keep_the_lost_fact_when_the_transaction_rolls_back
+    seed = Random.new_seed
+    issue = Random.new(seed).rand(1..100_000)
+    fb = Factbase.new
+    Fbe.stub(:fb, fb) do
+      $loog = Loog::NULL
+      fb.txn do |fbt|
+        Jp.issue_was_lost('github', 42, issue, fb: fbt)
+        throw(:rollback)
+      end
+      assert_empty(
+        fb.query("(and (eq what 'issue-was-lost') (eq issue #{issue}))").each.to_a,
+        "the issue-was-lost fact survived a rolled back transaction, seed #{seed}"
+      )
+    end
+  end
+
+  def test_dont_keep_the_stale_flag_when_the_transaction_rolls_back
+    seed = Random.new_seed
+    issue = Random.new(seed).rand(1..100_000)
+    fb = Factbase.new
+    f = fb.insert
+    f.where = 'github'
+    f.repository = 42
+    f.issue = issue
+    f.what = 'pull-was-opened'
+    Fbe.stub(:fb, fb) do
+      $loog = Loog::NULL
+      fb.txn do |fbt|
+        Jp.issue_was_lost('github', 42, issue, fb: fbt)
+        throw(:rollback)
+      end
+      assert_nil(
+        fb.query("(eq issue #{issue})").each.first['stale'],
+        "the stale flag survived a rolled back transaction, seed #{seed}"
+      )
+    end
+  end
 end


### PR DESCRIPTION
`Jp.issue_was_lost` opened its own `Fbe.fb.txn`. Four judges reach it from inside an already open transaction, and because `Fbe.fb` is the outer chain rather than the factbase a transaction yields, that inner transaction committed on its own. When the enclosing block then failed, the outer transaction rolled back but the `issue-was-lost` fact stayed behind, leaving the issue marked lost with no `issue-was-opened` fact to explain it.

The function now takes an `fb:` keyword defaulting to `Fbe.fb`, uses it for the stale query and for `Fbe.if_absent`, and no longer opens a transaction of its own. `find-all-issues`, `find-earliest-issue`, `find-latest-issue` and `find-missing-issues` pass their `fbt`, so everything they write rolls back together.

Dropping the transaction meant the fresh fact was built outside one, and `Factbase::Rules` checks after every property, so `(when (exists issue) (exists repository))` rejected the half-built fact. Setting `where`, then `repository`, then `issue` keeps it valid at every step, which is what the transaction was hiding.

The tombstone still goes through the global factbase. Routing it through the given `fb` needs `Fbe.overwrite` to stop opening a transaction of its own, which is zerocracy/fbe#843, so that half is left as a puzzle.

Closes #2074