### PR TITLE
#2100: evaluate the date in the job summary heredoc

### DIFF
--- a/.github/workflows/zerocracy.yml
+++ b/.github/workflows/zerocracy.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Job Summary
         if: always()
         run: |
-          cat > "$GITHUB_STEP_SUMMARY" <<'EOF'
+          cat > "$GITHUB_STEP_SUMMARY" <<EOF
           ## zerocracy run
 
           | Info | |

--- a/test/test_workflow_config.rb
+++ b/test/test_workflow_config.rb
@@ -3,6 +3,8 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
 # SPDX-License-Identifier: MIT
 
+require 'open3'
+require 'tmpdir'
 require 'yaml'
 require_relative 'test__helper'
 
@@ -16,5 +18,20 @@ class TestWorkflowConfig < Jp::Test
     repos = text[/repositories: (\S+)/, 1]
     refute_nil(repos)
     refute_includes(repos.split(','), 'zerocracy/baza')
+  end
+
+  def test_prints_evaluated_timestamp_in_summary
+    steps = YAML.load_file(
+      File.expand_path('../.github/workflows/zerocracy.yml', __dir__)
+    )['jobs']['zerocracy']['steps']
+    script = steps.find { |s| s['name'] == 'Job Summary' }['run'].gsub(/\$\{\{[^}]*\}\}/, 'x')
+    Dir.mktmpdir do |dir|
+      file = File.join(dir, 'step.md')
+      env = { 'GITHUB_STEP_SUMMARY' => file, 'LC_ALL' => 'C' }
+      Open3.capture3(env, 'timeout', '10', 'bash', '-c', script, chdir: dir)
+      assert_match(
+        /^\| Timestamp \| .*\d{2}:\d{2}:\d{2}.* \|$/, File.read(file), 'timestamp row is not the evaluated date'
+      )
+    end
   end
 end


### PR DESCRIPTION
The Job Summary step in `.github/workflows/zerocracy.yml` wrote its heredoc with a quoted `EOF` delimiter, which disables command substitution, so every run published the literal text `$(date -u)` in the Timestamp row instead of the actual time.

The delimiter is now unquoted, so bash evaluates the date when it writes the summary. The other values in the heredoc are GitHub expressions that are substituted before the shell runs and carry no dollar signs or backticks, so nothing else in the summary changes.

A new test in `test/test_workflow_config.rb` takes the Job Summary script from the workflow, replaces the GitHub expressions with placeholders, runs it under bash in a temporary directory, and checks that the Timestamp row holds an evaluated time.

Closes #2100
