### PR TITLE
#2098: treat an empty sqlite_cache_min_age option as absent

### DIFF
--- a/entry.sh
+++ b/entry.sh
@@ -192,12 +192,17 @@ if [ "${bots_found}" == "false" ]; then
 fi
 
 cache_min_age=false
+declare -a kept=()
 for opt in "${options[@]}"; do
+    if [[ "${opt}" == "--option=sqlite_cache_min_age=" ]]; then
+        continue
+    fi
     if [[ "${opt}" == "--option=sqlite_cache_min_age="* ]]; then
         cache_min_age=true
-        break
     fi
+    kept+=("${opt}")
 done
+options=("${kept[@]}")
 if [ "${cache_min_age}" == "false" ]; then
     options+=("--option=sqlite_cache_min_age=3600");
 fi

--- a/test/test_entry_cache.rb
+++ b/test/test_entry_cache.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+# SPDX-License-Identifier: MIT
+
+require 'open3'
+require_relative 'test__helper'
+
+class TestEntryCache < Jp::Test
+  def test_replaces_an_empty_min_age_with_the_default
+    assert_equal(
+      ['--option=foo=привет', '--option=sqlite_cache_min_age=3600'],
+      run_block(['--option=sqlite_cache_min_age=', '--option=foo=привет']),
+      'empty sqlite_cache_min_age is not replaced by the default'
+    )
+  end
+
+  def test_keeps_a_configured_min_age
+    seed = Random.new_seed
+    age = "--option=sqlite_cache_min_age=#{Random.new(seed).rand(1..99_999)}"
+    assert_equal([age], run_block([age]), "configured sqlite_cache_min_age is not kept, seed #{seed}")
+  end
+
+  def test_adds_the_default_when_min_age_is_absent
+    assert_equal(
+      ['--option=bar=', '--option=sqlite_cache_min_age=3600'],
+      run_block(['--option=bar=']),
+      'absent sqlite_cache_min_age does not receive the default'
+    )
+  end
+
+  private
+
+  def run_block(options)
+    body = File.read(File.join(File.expand_path('..', __dir__), 'entry.sh'))
+    block = body[/^cache_min_age=false\n(?:.*\n)*?^fi\n/]
+    refute_nil(block, 'No cache_min_age block found in entry.sh')
+    out, = Open3.capture3(
+      'bash', '-c',
+      "set -e -o pipefail\noptions=(\"$@\")\n#{block}printf '%s\\n' \"${options[@]}\"",
+      'bash', *options
+    )
+    out.lines(chomp: true)
+  end
+end


### PR DESCRIPTION
entry.sh treated any `--option=sqlite_cache_min_age=` entry as configured, including one with an empty value, so it skipped the 3600-second default. With SQLite caching on, Fbe::Octo then called `Integer('')` and the action aborted before processing the factbase.

The block that looks for the option now drops an entry whose value is empty and keeps every other option in its original order. An empty value is therefore treated as absent and receives the default, while a configured value stays untouched.

A new test extracts that block from entry.sh, as the cycles and minutes tests already do, and checks the empty, configured and absent cases.

Closes #2098