### PR TITLE
#2097: bury the issue before marking its facts stale

### DIFF
--- a/lib/issue_was_lost.rb
+++ b/lib/issue_was_lost.rb
@@ -8,6 +8,7 @@ require 'fbe/tombstone'
 require_relative 'jp'
 
 def Jp.issue_was_lost(where, repository, issue)
+  Fbe::Tombstone.new.bury!(where, repository, issue)
   stale =
     Fbe.fb.query(
       "(and
@@ -17,7 +18,6 @@ def Jp.issue_was_lost(where, repository, issue)
       (absent stale)
       (absent tombstone))"
     ).each { |f| f.stale = 'issue' }
-  Fbe::Tombstone.new.bury!(where, repository, issue)
   if stale.positive?
     $loog.info("The issue #{issue} was marked as lost, #{stale} facts marked as stale")
     return

--- a/test/lib/test_issue_was_lost.rb
+++ b/test/lib/test_issue_was_lost.rb
@@ -88,4 +88,87 @@ class TestIssueWasLost < Minitest::Test
       assert(Fbe::Tombstone.new(fb: fb).has?('github', 7, 11), 'tombstone must contain the issue after the call')
     end
   end
+
+  def test_buries_issue_on_retry_after_tombstone_failure
+    seed = Random.new_seed
+    random = Random.new(seed)
+    repo = random.rand(1..99_999)
+    issue = random.rand(1..99_999)
+    fb = Factbase.new
+    f = fb.insert
+    f.where = 'github'
+    f.repository = repo
+    f.issue = issue
+    f.what = 'issue-was-opened'
+    broken = Object.new
+    broken.define_singleton_method(:bury!) { |*| raise(Fbe::Error, 'tombstone is down') }
+    Fbe.stub(:fb, fb) do
+      $loog = Loog::NULL
+      Fbe::Tombstone.stub(:new, broken) do
+        Jp.issue_was_lost('github', repo, issue)
+      rescue Fbe::Error
+        nil
+      end
+      Jp.issue_was_lost('github', repo, issue)
+      assert(
+        Fbe::Tombstone.new(fb: fb).has?('github', repo, issue),
+        "issue #{issue} in repo #{repo} is not buried after a retry, seed #{seed}"
+      )
+    end
+  end
+
+  def test_dont_insert_lost_fact_on_retry_after_tombstone_failure
+    seed = Random.new_seed
+    random = Random.new(seed)
+    repo = random.rand(1..99_999)
+    issue = random.rand(1..99_999)
+    fb = Factbase.new
+    f = fb.insert
+    f.where = 'github'
+    f.repository = repo
+    f.issue = issue
+    f.what = 'issue-was-opened'
+    broken = Object.new
+    broken.define_singleton_method(:bury!) { |*| raise(Fbe::Error, 'tombstone is down') }
+    Fbe.stub(:fb, fb) do
+      $loog = Loog::NULL
+      Fbe::Tombstone.stub(:new, broken) do
+        Jp.issue_was_lost('github', repo, issue)
+      rescue Fbe::Error
+        nil
+      end
+      Jp.issue_was_lost('github', repo, issue)
+      assert_empty(
+        fb.query("(eq what 'issue-was-lost')").each.to_a,
+        "retry for issue #{issue} in repo #{repo} inserted a lost fact despite a prior fact, seed #{seed}"
+      )
+    end
+  end
+
+  def test_dont_mark_facts_stale_when_tombstone_fails
+    seed = Random.new_seed
+    random = Random.new(seed)
+    repo = random.rand(1..99_999)
+    issue = random.rand(1..99_999)
+    fb = Factbase.new
+    f = fb.insert
+    f.where = 'github'
+    f.repository = repo
+    f.issue = issue
+    f.what = 'issue-was-opened'
+    broken = Object.new
+    broken.define_singleton_method(:bury!) { |*| raise(Fbe::Error, 'tombstone is down') }
+    Fbe.stub(:fb, fb) do
+      $loog = Loog::NULL
+      Fbe::Tombstone.stub(:new, broken) do
+        Jp.issue_was_lost('github', repo, issue)
+      rescue Fbe::Error
+        nil
+      end
+      assert_empty(
+        fb.query('(exists stale)').each.to_a,
+        "facts of issue #{issue} in repo #{repo} are stale without a tombstone, seed #{seed}"
+      )
+    end
+  end
 end


### PR DESCRIPTION
Jp.issue_was_lost used to mark every matching fact stale before calling Fbe::Tombstone#bury!. When bury! raised, those stale marks stayed in the factbase while no tombstone existed.

The tombstone is now written first, so a failure in bury! leaves the facts untouched and the next run repeats the whole transition. This also stops a retry from inserting a spurious issue-was-lost fact next to the facts that were already marked stale.

Three failure-path tests cover it: facts stay fresh when bury! raises, the issue is buried on the retry, and the retry inserts no extra lost fact.

Closes #2097