### PR TITLE
fix(#2096): ignore an empty github_token option in favor of the github-token input

### DIFF
--- a/entries/ignores-an-empty-github-token-option.sh
+++ b/entries/ignores-an-empty-github-token-option.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+# SPDX-License-Identifier: MIT
+
+set -e -o pipefail
+
+SELF=$1
+
+source "${SELF}/makes/setup-test-env.sh"
+source "${SELF}/makes/test-common.sh"
+setup_test_env "${SELF}" name
+
+run_entry_script "${SELF}" success \
+  "GITHUB_WORKSPACE=$(pwd)" \
+  "INPUT_FACTBASE=${name}.fb" \
+  "INPUT_CYCLES=1" \
+  "INPUT_REPOSITORIES=yegor256/factbase" \
+  "INPUT_OPTIONS=github_token=" \
+  "INPUT_VERBOSE=false" \
+  "INPUT_TOKEN=something" \
+  "INPUT_DRY-RUN=true" \
+  "INPUT_GITHUB-TOKEN=THETOKEN"
+
+factbase_exists "${name}"
+log_contains \
+  "The 'github-token' plugin parameter is set" \
+  "This indicates an empty 'github_token' option suppresses the 'github-token' plugin parameter"

--- a/entries/prefers-a-github-token-option.sh
+++ b/entries/prefers-a-github-token-option.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+# SPDX-License-Identifier: MIT
+
+set -e -o pipefail
+
+SELF=$1
+
+source "${SELF}/makes/setup-test-env.sh"
+source "${SELF}/makes/test-common.sh"
+setup_test_env "${SELF}" name
+
+run_entry_script "${SELF}" success \
+  "GITHUB_WORKSPACE=$(pwd)" \
+  "INPUT_FACTBASE=${name}.fb" \
+  "INPUT_CYCLES=1" \
+  "INPUT_REPOSITORIES=yegor256/factbase" \
+  "INPUT_OPTIONS=github_token=OPTIONTOKEN" \
+  "INPUT_VERBOSE=false" \
+  "INPUT_TOKEN=something" \
+  "INPUT_DRY-RUN=true" \
+  "INPUT_GITHUB-TOKEN=THETOKEN"
+
+factbase_exists "${name}"
+log_contains \
+  "The 'github_token' option is set, using it" \
+  "This indicates a non-empty 'github_token' option is overridden by the 'github-token' plugin parameter"

--- a/entry.sh
+++ b/entry.sh
@@ -116,6 +116,10 @@ while IFS= read -r o; do
         VITALS_URL="${v}"
         continue
     fi
+    if [[ "${k}" == github_token && -z "${v}" ]]; then
+        echo "The 'github_token' option is empty, ignoring it"
+        continue
+    fi
     options+=("--option=${k}=${v}");
 done <<< "${INPUT_OPTIONS}"
 if [ -z "${INPUT_REPOSITORIES}" ]; then


### PR DESCRIPTION
When `options` carried `github_token=` with nothing after the equals sign, `entry.sh` still treated the token as provided. It skipped the fallback to the `github-token` action input and ran the judges with an empty token, so every API call failed even though a valid token was right there.

The options loop now drops a `github_token` entry whose value is empty and says so in the log, so the empty option counts as absent and the action input takes over. A non-empty `github_token` option still wins over the input, as before.

Two entry tests pin both sides of that precedence: one feeds an empty option next to a valid input and expects the input to be used, the other feeds a non-empty option and expects it to be kept.

Closes #2096