### PR TITLE
Publish the run report to the GitHub step summary

### DIFF
--- a/.github/workflows/zerocracy.yml
+++ b/.github/workflows/zerocracy.yml
@@ -55,12 +55,6 @@ jobs:
           | Timestamp | $(date -u) |
           | Status | ${{ job.status }} |
           EOF
-          if [ -f summary.md ]; then
-            cat summary.md >> "$GITHUB_STEP_SUMMARY"
-          else
-            echo "" >> "$GITHUB_STEP_SUMMARY"
-            echo "_Detailed summary not available (no data from action container)._" >> "$GITHUB_STEP_SUMMARY"
-          fi
       - name: Flag on failure
         if: failure() && github.repository_owner == 'zerocracy'
         run: |

--- a/entries/publishes-the-step-summary.sh
+++ b/entries/publishes-the-step-summary.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+# SPDX-License-Identifier: MIT
+
+set -e -o pipefail
+
+SELF=$1
+
+source "${SELF}/makes/setup-test-env.sh"
+source "${SELF}/makes/test-common.sh"
+setup_test_env "${SELF}" name
+
+note="earlier step wrote ${name} ünïcödé"
+echo "${note}" > step.md
+
+run_entry_script "${SELF}" success \
+  "GITHUB_WORKSPACE=$(pwd)" \
+  "GITHUB_STEP_SUMMARY=$(pwd)/step.md" \
+  "INPUT_FACTBASE=${name}.fb" \
+  "INPUT_CYCLES=1" \
+  "INPUT_REPOSITORIES=yegor256/factbase" \
+  "INPUT_VERBOSE=false" \
+  "INPUT_TOKEN=something" \
+  "INPUT_DRY-RUN=true" \
+  "INPUT_GITHUB-TOKEN=THETOKEN"
+
+grep -qF '## zerocracy run' step.md || die "The run report is not published to the step summary at $(pwd)/step.md"
+grep -qF "${note}" step.md || die "The step summary at $(pwd)/step.md lost what an earlier step wrote into it"
+test ! -e summary.md || die "The run report is left as a stray file at $(pwd)/summary.md"

--- a/entry.sh
+++ b/entry.sh
@@ -318,9 +318,10 @@ else
         "${name}" "${fb}"
 fi
 
+churn_val=$(cat churn.txt 2>/dev/null || echo '0i/0d/0a')
+fb_size=$(ruby -e "require 'factbase'; f=Factbase.new; f.import(File.binread(ARGV[0])); puts f.size" "$fb" 2>/dev/null || echo '0')
+
 if [ -n "${GITHUB_RUN_ID}" ] && [ -n "$(printenv "INPUT_GITHUB-TOKEN")" ]; then
-    churn_val=$(cat churn.txt 2>/dev/null || echo '0i/0d/0a')
-    fb_size=$(ruby -e "require 'factbase'; f=Factbase.new; f.import(File.binread(ARGV[0])); puts f.size" "$fb" 2>/dev/null || echo '0')
     title="judges-action ${action_version} did ${churn_val} to ${fb_size} facts"
     echo "Updating workflow run title to: ${title}"
     curl -s -X PATCH \
@@ -329,6 +330,9 @@ if [ -n "${GITHUB_RUN_ID}" ] && [ -n "$(printenv "INPUT_GITHUB-TOKEN")" ]; then
         "https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
         -d "$(jq -n --arg t "${title}" '{"display_title": $t}')" > /dev/null || \
         echo "Failed to update workflow run title (non-critical)"
+fi
+
+if [ -n "${GITHUB_STEP_SUMMARY}" ]; then
     {
         echo "## zerocracy run"
         echo ""
@@ -340,5 +344,5 @@ if [ -n "${GITHUB_RUN_ID}" ] && [ -n "$(printenv "INPUT_GITHUB-TOKEN")" ]; then
         echo "| Duration | $(($(date +%s) - start))s |"
         echo "| Owner | ${owner} |"
         echo "| Vitals | [View](${VITALS_URL}) |"
-    } > "${GITHUB_WORKSPACE}/summary.md" 2>/dev/null || true
+    } >> "${GITHUB_STEP_SUMMARY}" || echo "Failed to write the run report to ${GITHUB_STEP_SUMMARY} (non-critical)"
 fi


### PR DESCRIPTION
entry.sh built a small metrics table at the end of each run and dropped it into the workspace as summary.md, and only when the run title was also being updated. Nobody using the action ever saw it, apart from our own zerocracy workflow, which picked the file up by hand.

The table now gets appended to $GITHUB_STEP_SUMMARY in a separate block of its own, so it shows up on the run page for every repository that uses the action. Anything an earlier step already wrote there is kept. Since the file is gone, the zerocracy workflow no longer tries to read it.

A new entry, publishes-the-step-summary.sh, runs the script with a step summary that already has some text in it. It checks that the report ends up there, that the earlier text is still there, and that no summary.md is left in the workspace.

One thing to know: zerocracy.yml is pinned to 0.17.23, so its job summary will be missing the metrics until the pin gets bumped to a release that includes this change.

Closes #2086
