### PR TITLE
fix(#2085): re-query latest issue on every cycle instead of stopping after first marker

### DIFF
--- a/judges/find-latest-issue/advance-marker.yml
+++ b/judges/find-latest-issue/advance-marker.yml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+# SPDX-License-Identifier: MIT
+---
+options:
+  testing: true
+  repositories: foo/bazz
+input:
+  -
+    _id: 1
+    what: iterate
+    where: github
+    repository: 810
+    latest_issue_was_found: 100
+expected:
+  - /fb[count(f)=2]
+  - /fb/f[what='pull-was-opened' and repository='810' and issue='144' and where='github']
+  - /fb/f[what='iterate' and repository='810' and latest_issue_was_found='144' and where='github']

--- a/judges/find-latest-issue/find-latest-issue.rb
+++ b/judges/find-latest-issue/find-latest-issue.rb
@@ -17,7 +17,6 @@ Fbe.iterate do
   as 'latest_issue_was_found'
   by '(plus 0 $before)'
   over do |repository, latest|
-    next latest if latest.positive?
     repo =
       begin
         Fbe.octo.repo_name_by_id(repository)

--- a/test/judges/test-find-latest-issue.rb
+++ b/test/judges/test-find-latest-issue.rb
@@ -133,6 +133,16 @@ class TestFindLatestIssue < Jp::Test
     WebMock.disable_net_connect!
     rate_limit_up
     stub_github('https://api.github.com/repos/foo/foo', body: { id: 42, name: 'foo', full_name: 'foo/foo' })
+    stub_github('https://api.github.com/repositories/42', body: { id: 42, name: 'foo', full_name: 'foo/foo' })
+    stub_github(
+      'https://api.github.com/repos/foo/foo/issues?direction=desc&page=1&per_page=1&sort=created&state=all',
+      body: [
+        {
+          id: 123, number: 547, title: 'Some title', user: { id: 44, login: 'user' },
+          created_at: '2025-09-14 20:03:16 UTC'
+        }
+      ]
+    )
     fb = Factbase.new
     fb.with(
       _id: 1, what: 'issue-was-opened', issue: 547, repository: 42, where: 'github',
@@ -144,6 +154,63 @@ class TestFindLatestIssue < Jp::Test
     load_it('find-latest-issue', fb)
     assert_equal(2, fb.all.size)
     assert(fb.one?(what: 'iterate', latest_issue_was_found: 547, repository: 42, where: 'github'))
+  end
+
+  def test_advances_marker_to_newer_issue
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repos/foo/foo', body: { id: 42, name: 'foo', full_name: 'foo/foo' })
+    stub_github('https://api.github.com/repositories/42', body: { id: 42, name: 'foo', full_name: 'foo/foo' })
+    stub_github(
+      'https://api.github.com/repos/foo/foo/issues?direction=desc&page=1&per_page=1&sort=created&state=all',
+      body: [
+        {
+          id: 124, number: 560, title: 'Новая задача', user: { id: 44, login: 'user' },
+          created_at: '2025-10-02 08:11:40 UTC'
+        }
+      ]
+    )
+    stub_github('https://api.github.com/user/44', body: { id: 44, login: 'user' })
+    fb = Factbase.new
+    fb.with(
+      _id: 1, what: 'issue-was-opened', issue: 547, repository: 42, where: 'github',
+      who: 44, when: Time.parse('2025-09-14 20:03:16 UTC'),
+      details: 'The issue foo/foo#547 has been opened by @user.'
+    ).with(
+      _id: 2, what: 'iterate', where: 'github', repository: 42, latest_issue_was_found: 547
+    )
+    load_it('find-latest-issue', fb)
+    assert(
+      fb.one?(what: 'iterate', latest_issue_was_found: 560, repository: 42, where: 'github'),
+      'marker is not advanced to the newer issue foo/foo#560'
+    )
+  end
+
+  def test_records_newer_issue_after_marker
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/repos/foo/foo', body: { id: 42, name: 'foo', full_name: 'foo/foo' })
+    stub_github('https://api.github.com/repositories/42', body: { id: 42, name: 'foo', full_name: 'foo/foo' })
+    stub_github(
+      'https://api.github.com/repos/foo/foo/issues?direction=desc&page=1&per_page=1&sort=created&state=all',
+      body: [
+        {
+          id: 124, number: 560, title: '', user: { id: 44, login: 'user' },
+          created_at: '2025-10-02 08:11:40 UTC'
+        }
+      ]
+    )
+    stub_github('https://api.github.com/user/44', body: { id: 44, login: 'user' })
+    fb = Factbase.new
+    fb.with(_id: 1, what: 'iterate', where: 'github', repository: 42, latest_issue_was_found: 547)
+    load_it('find-latest-issue', fb)
+    assert(
+      fb.one?(
+        what: 'issue-was-opened', issue: 560, repository: 42, where: 'github',
+        who: 44, when: Time.parse('2025-10-02 08:11:40 UTC')
+      ),
+      'newer issue foo/foo#560 is not recorded while marker is 547'
+    )
   end
 
   def test_rescues_not_found_on_pull_request_lookup


### PR DESCRIPTION
The find-latest-issue judge returned early whenever its iterator marker was positive. Since the marker is saved after the first successful lookup, every later run skipped GitHub entirely, so newer issues were never noticed and the marker never moved.

The early return is now gone from find-latest-issue, so the judge asks GitHub for the newest issue on each cycle, records it when it is new, and advances the marker. When the newest issue is already known, Fbe.if_absent skips it as before. find-earliest-issue keeps its one-time behavior, because the earliest issue never changes.

Two unit tests cover a stored marker with a newer issue on GitHub, the existing already-found test now stubs the issues list, and a new advance-marker.yml fixture starts from an existing marker and expects it to move to the newer issue.

Closes #2085
