### PR TITLE
fix(#2083): name the found issue latest in find-latest-issue details

### DIFF
--- a/judges/find-latest-issue/find-latest-issue.rb
+++ b/judges/find-latest-issue/find-latest-issue.rb
@@ -81,7 +81,7 @@ Fbe.iterate do
           f.stale = 'branch'
         end
       end
-      f.details = "The issue #{Fbe.issue(f)} is the first we found, opened by #{Fbe.who(f)}."
+      f.details = "The issue #{Fbe.issue(f)} is the latest we found, opened by #{Fbe.who(f)}."
       $loog.info("The issue #{Fbe.issue(f)} was opened by #{Fbe.who(f)} #{f.when.ago} ago")
     end
     json[:number]

--- a/test/judges/test-find-latest-issue.rb
+++ b/test/judges/test-find-latest-issue.rb
@@ -34,7 +34,7 @@ class TestFindLatestIssue < Jp::Test
       fb.one?(
         what: 'issue-was-opened', issue: 547, repository: 42, where: 'github',
         who: 44, when: Time.parse('2025-09-14 20:03:16 UTC'),
-        details: 'The issue foo/foo#547 is the first we found, opened by @user.'
+        details: 'The issue foo/foo#547 is the latest we found, opened by @user.'
       )
     )
     assert(fb.one?(what: 'iterate', latest_issue_was_found: 547, repository: 42, where: 'github'))
@@ -74,10 +74,36 @@ class TestFindLatestIssue < Jp::Test
       fb.one?(
         what: 'pull-was-opened', issue: 548, repository: 42, where: 'github',
         who: 44, branch: '547', when: Time.parse('2025-09-14 20:03:16 UTC'),
-        details: 'The issue foo/foo#548 is the first we found, opened by @user.'
+        details: 'The issue foo/foo#548 is the latest we found, opened by @user.'
       )
     )
     assert(fb.one?(what: 'iterate', latest_issue_was_found: 548, repository: 42, where: 'github'))
+  end
+
+  def test_names_found_issue_latest_in_details
+    WebMock.disable_net_connect!
+    rate_limit_up
+    seed = Random.new_seed
+    number = Random.new(seed).rand(1..99_999)
+    stub_github('https://api.github.com/repos/foo/foo', body: { id: 42, name: 'foo', full_name: 'foo/foo' })
+    stub_github('https://api.github.com/repositories/42', body: { id: 42, name: 'foo', full_name: 'foo/foo' })
+    stub_github(
+      'https://api.github.com/repos/foo/foo/issues?direction=desc&page=1&per_page=1&sort=created&state=all',
+      body: [
+        {
+          id: 123, number:, title: 'Последняя задача 最新', user: { id: 44, login: 'user' },
+          created_at: '2025-09-14 20:03:16 UTC'
+        }
+      ]
+    )
+    stub_github('https://api.github.com/user/44', body: { id: 44, login: 'user' })
+    fb = Factbase.new
+    load_it('find-latest-issue', fb)
+    assert_equal(
+      "The issue foo/foo##{number} is the latest we found, opened by @user.",
+      fb.query("(eq what 'issue-was-opened')").each.first.details,
+      "details of the issue ##{number} do not name it the latest one, seed is #{seed}"
+    )
   end
 
   def test_not_found_latest_issue


### PR DESCRIPTION
The find-latest-issue judge picks the newest issue of a repository, yet the details it records claimed the issue "is the first we found", which is the wording of the earliest judge and tells a reader the opposite of what happened.

The judge now records that the issue "is the latest we found". The two existing assertions on the details text follow the new wording, and a new test feeds a randomly numbered issue, derived from a seed printed on failure, and checks that its details name it the latest one.

Closes #2083