### PR TITLE
fix(#2084): advance boundary issue marker past tombstoned issues

### DIFF
--- a/judges/find-earliest-issue/find-earliest-issue.rb
+++ b/judges/find-earliest-issue/find-earliest-issue.rb
@@ -34,7 +34,7 @@ Fbe.iterate do
     json =
       begin
         Fbe.octo.with_disable_auto_paginate do |octo|
-          octo.list_issues(repo, state: :all, sort: :created, direction: :asc, page: 1, per_page: 1).first
+          octo.list_issues(repo, state: :all, sort: :created, direction: :asc, page: 1 - latest, per_page: 1).first
         end
       rescue Octokit::NotFound, Octokit::Deprecated => e
         $loog.info("Issues list not available for #{repo}: #{e.message}")
@@ -48,7 +48,7 @@ Fbe.iterate do
       end
     next latest if json.nil?
     i = json[:number]
-    next latest if Fbe::Tombstone.new.has?('github', repository, i)
+    next latest - 1 if Fbe::Tombstone.new.has?('github', repository, i)
     Fbe.fb.txn do |fbt|
       f =
         Fbe.if_absent(fb: fbt) do |ff|

--- a/judges/find-latest-issue/find-latest-issue.rb
+++ b/judges/find-latest-issue/find-latest-issue.rb
@@ -34,7 +34,7 @@ Fbe.iterate do
     json =
       begin
         Fbe.octo.with_disable_auto_paginate do |octo|
-          octo.list_issues(repo, state: :all, sort: :created, direction: :desc, page: 1, per_page: 1).first
+          octo.list_issues(repo, state: :all, sort: :created, direction: :desc, page: 1 - latest, per_page: 1).first
         end
       rescue Octokit::NotFound, Octokit::Deprecated => e
         $loog.info("Issues list not available for #{repo}: #{e.message}")
@@ -48,7 +48,7 @@ Fbe.iterate do
       end
     next latest if json.nil?
     i = json[:number]
-    next latest if Fbe::Tombstone.new.has?('github', repository, i)
+    next latest - 1 if Fbe::Tombstone.new.has?('github', repository, i)
     Fbe.fb.txn do |fbt|
       f =
         Fbe.if_absent(fb: fbt) do |ff|

--- a/test/judges/test-find-earliest-issue.rb
+++ b/test/judges/test-find-earliest-issue.rb
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: MIT
 
 require 'factbase'
+require 'fbe/tombstone'
 require_relative '../test__helper'
 
 class TestFindEarliestIssue < Jp::Test
@@ -254,6 +255,32 @@ class TestFindEarliestIssue < Jp::Test
     assert_empty(
       fb.query("(eq what 'issue-was-opened')").each.to_a,
       'A vanished repository must produce no facts and must not abort the judge'
+    )
+  end
+
+  def test_records_next_issue_when_earliest_is_tombstoned
+    WebMock.disable_net_connect!
+    rate_limit_up
+    seed = Random.new_seed
+    number = Random.new(seed).rand(1..9999)
+    stub_github('https://api.github.com/repos/foo/foo', body: { id: 42, name: 'foo', full_name: 'foo/foo' })
+    stub_github('https://api.github.com/repositories/42', body: { id: 42, name: 'foo', full_name: 'foo/foo' })
+    stub_github(
+      'https://api.github.com/repos/foo/foo/issues?direction=asc&page=1&per_page=1&sort=created&state=all',
+      body: [{ id: 123, number:, user: { id: 44, login: 'user' }, created_at: '2025-09-27 05:03:16 UTC' }]
+    )
+    stub_github(
+      'https://api.github.com/repos/foo/foo/issues?direction=asc&page=2&per_page=1&sort=created&state=all',
+      body: [{ id: 124, number: number + 1, user: { id: 44, login: 'user' }, created_at: '2025-09-28 05:03:16 UTC' }]
+    )
+    stub_github('https://api.github.com/user/44', body: { id: 44, login: 'user' })
+    fb = Factbase.new
+    Fbe::Tombstone.new(fb:).bury!('github', 42, number)
+    load_it('find-earliest-issue', fb)
+    load_it('find-earliest-issue', fb)
+    assert(
+      fb.one?(what: 'issue-was-opened', issue: number + 1, repository: 42, where: 'github'),
+      "issue next to tombstoned ##{number} is not recorded, seed: #{seed}"
     )
   end
 end

--- a/test/judges/test-find-latest-issue.rb
+++ b/test/judges/test-find-latest-issue.rb
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: MIT
 
 require 'factbase'
+require 'fbe/tombstone'
 require_relative '../test__helper'
 
 class TestFindLatestIssue < Jp::Test
@@ -271,6 +272,32 @@ class TestFindLatestIssue < Jp::Test
     assert_empty(
       fb.query("(eq what 'issue-was-opened')").each.to_a,
       'A vanished repository must produce no facts and must not abort the judge'
+    )
+  end
+
+  def test_records_previous_issue_when_latest_is_tombstoned
+    WebMock.disable_net_connect!
+    rate_limit_up
+    seed = Random.new_seed
+    number = Random.new(seed).rand(2..9999)
+    stub_github('https://api.github.com/repos/foo/foo', body: { id: 42, name: 'foo', full_name: 'foo/foo' })
+    stub_github('https://api.github.com/repositories/42', body: { id: 42, name: 'foo', full_name: 'foo/foo' })
+    stub_github(
+      'https://api.github.com/repos/foo/foo/issues?direction=desc&page=1&per_page=1&sort=created&state=all',
+      body: [{ id: 123, number:, user: { id: 44, login: 'user' }, created_at: '2025-09-28 05:03:16 UTC' }]
+    )
+    stub_github(
+      'https://api.github.com/repos/foo/foo/issues?direction=desc&page=2&per_page=1&sort=created&state=all',
+      body: [{ id: 124, number: number - 1, user: { id: 44, login: 'user' }, created_at: '2025-09-27 05:03:16 UTC' }]
+    )
+    stub_github('https://api.github.com/user/44', body: { id: 44, login: 'user' })
+    fb = Factbase.new
+    Fbe::Tombstone.new(fb:).bury!('github', 42, number)
+    load_it('find-latest-issue', fb)
+    load_it('find-latest-issue', fb)
+    assert(
+      fb.one?(what: 'issue-was-opened', issue: number - 1, repository: 42, where: 'github'),
+      "issue previous to tombstoned ##{number} is not recorded, seed: #{seed}"
     )
   end
 end


### PR DESCRIPTION
Both find-earliest-issue and find-latest-issue fetched the single boundary issue from GitHub and, when that issue was tombstoned, returned the iterator marker unchanged. The marker therefore stayed at zero forever, and every run asked GitHub for the same issue again without ever recording a boundary fact.

Now a non-positive marker counts how many tombstoned candidates were skipped. The judge requests page `1 - latest` with one issue per page, and when the returned issue is tombstoned it moves the marker to `latest - 1`, so the next run examines the next candidate. A positive marker still means the boundary was recorded, so existing behavior for regular repositories does not change.

Each judge gets a test where the first returned issue is tombstoned: after two runs the next candidate is recorded as the boundary.

Closes #2084
