### PR TITLE
fix(#2203): create the missing factbase directory before resolving its path

### DIFF
--- a/entries/creates-a-missing-absolute-factbase-directory.sh
+++ b/entries/creates-a-missing-absolute-factbase-directory.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+# SPDX-License-Identifier: MIT
+
+set -e -o pipefail
+
+SELF=$1
+
+source "${SELF}/makes/setup-test-env.sh"
+source "${SELF}/makes/test-common.sh"
+setup_test_env "${SELF}" name
+
+run_entry_script "${SELF}" success \
+  "GITHUB_WORKSPACE=$(pwd)" \
+  "GITHUB_REPOSITORY=zerocracy/judges-action" \
+  "GITHUB_REPOSITORY_OWNER=zerocracy" \
+  "GITHUB_SERVER_URL=https://github.com" \
+  "INPUT_DRY-RUN=true" \
+  "INPUT_GITHUB-TOKEN=test-token" \
+  "INPUT_FACTBASE=$(pwd)/${name}/${name}.fb" \
+  "INPUT_CYCLES=1" \
+  "INPUT_TOKEN=something"
+
+file_exists "$(pwd)/${name}/${name}.fb" \
+  "The factbase was not created inside a missing directory given by an absolute path"

--- a/entries/creates-a-missing-factbase-directory.sh
+++ b/entries/creates-a-missing-factbase-directory.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Zerocracy
+# SPDX-License-Identifier: MIT
+
+set -e -o pipefail
+
+SELF=$1
+
+source "${SELF}/makes/setup-test-env.sh"
+source "${SELF}/makes/test-common.sh"
+setup_test_env "${SELF}" name
+
+run_entry_script "${SELF}" success \
+  "GITHUB_WORKSPACE=$(pwd)" \
+  "GITHUB_REPOSITORY=zerocracy/judges-action" \
+  "GITHUB_REPOSITORY_OWNER=zerocracy" \
+  "GITHUB_SERVER_URL=https://github.com" \
+  "INPUT_DRY-RUN=true" \
+  "INPUT_GITHUB-TOKEN=test-token" \
+  "INPUT_FACTBASE=${name}/deep/${name}.fb" \
+  "INPUT_CYCLES=1" \
+  "INPUT_TOKEN=something"
+
+file_exists "${name}/deep/${name}.fb" \
+  "The factbase was not created inside a directory missing from the workspace"

--- a/entry.sh
+++ b/entry.sh
@@ -72,7 +72,9 @@ fi
 
 name="$(basename "${INPUT_FACTBASE}")"
 name="${name%.*}"
-fb=$(realpath "$( [[ ${INPUT_FACTBASE} = /* ]] && echo "${INPUT_FACTBASE}" || echo "${GITHUB_WORKSPACE}/${INPUT_FACTBASE}" )")
+fb="$( [[ ${INPUT_FACTBASE} = /* ]] && echo "${INPUT_FACTBASE}" || echo "${GITHUB_WORKSPACE}/${INPUT_FACTBASE}" )"
+mkdir -p "$(dirname "${fb}")"
+fb=$(realpath "${fb}")
 if [[ ! "${name}" =~ ^[a-z][a-z0-9-]{1,23}$ ]]; then
     echo "The base name (\"${name}\") of the factbase file doesn't match the expected pattern."
     echo "The file name is: \"${INPUT_FACTBASE}\""


### PR DESCRIPTION
The factbase path in `entry.sh` went through plain `realpath`, which in GNU coreutils tolerates a missing file but not a missing directory above it. A workflow with `factbase: data/new-product.fb` and no `data/` in the checkout therefore stopped right at path resolution, before `judges pull` or `judges update` could run.

Now `entry.sh` creates the parent directory with `mkdir -p` before canonicalizing the path, so judges can create the factbase there on the first run, exactly as it already does for a factbase at the root of the workspace.

Two new `entries/` scenarios cover this: one with a relative path two directories deep and one with an absolute path, both pointing into directories that do not exist yet.

Closes #2203
