### PR TITLE
#2187: remove dead uniq! call in find-missing-issues

### DIFF
--- a/judges/find-missing-issues/find-missing-issues.rb
+++ b/judges/find-missing-issues/find-missing-issues.rb
@@ -22,7 +22,6 @@ Fbe.consider('(and (eq where "github") (exists repository) (unique repository))'
   issues = Fbe.fb.query(
     "(and (eq repository #{r.repository}) (exists issue) (eq where 'github') (unique issue))"
   ).each.map(&:issue)
-  issues.uniq!
   issues.sort!
   next if issues.empty?
   must = (issues.min..issues.max).to_a


### PR DESCRIPTION
Fixes #2187.Fbe.fb.query already carries (unique issue), so issues.uniq! is a no-op. Removed the line, kept issues.sort! for the min..max range below.

Windows'ta undle install openssl native gem yüzünden patladığı için lokal test koşamadı (uby -c Syntax OK). CI'da ake testlerinin koşması bekleniyor.