### PR TITLE
#2190: remove noisy tombstone-count log line

### DIFF
--- a/judges/find-missing-issues/find-missing-issues.rb
+++ b/judges/find-missing-issues/find-missing-issues.rb
@@ -85,7 +85,6 @@ Fbe.consider('(and (eq where "github") (exists repository) (unique repository))'
         end
       end
       f.details = "The missing #{type} #{Fbe.issue(f)} has been opened by #{Fbe.who(f)}."
-      $loog.info("The #{type} #{Fbe.issue(f)} is not tombstoned among #{ts.issues('github', r.repository).count}")
       $loog.info("Missing #{type} #{Fbe.issue(f)} was found opened #{f.when.ago} ago")
     end
     added << i


### PR DESCRIPTION
Fixes #2190.

Drops the per-fact $loog.info(... not tombstoned among ...count) line: it names no unit for the operator and costs a full Tombstone#issues query per recovered fact inside the txn. .details + was found opened ... ago logging stays.