### PR TITLE
#2191: drop dead nil fallback in unmask_repos

### DIFF
--- a/lib/patches/unmask_repos.rb
+++ b/lib/patches/unmask_repos.rb
@@ -18,7 +18,7 @@ module Fbe
       )
       repos = []
       octo = Fbe.octo(loog:, global:, options:)
-      masks = (options.repositories || '').split(',')
+      masks = options.repositories.split(',')
       masks.reject { |m| m.start_with?('-') }.each do |mask|
         unless mask.include?('*')
           repos << mask


### PR DESCRIPTION
Fixes #2191.

Lines 14-15 already guarantee \options.repositories\ is a non-empty string, so \|| ''\ can never fire. Simplify to \options.repositories.split(',').