### PR TITLE
#2189: fix mismatched user id in find-all-issues stub

### DIFF
--- a/test/judges/test-find-all-issues.rb
+++ b/test/judges/test-find-all-issues.rb
@@ -164,7 +164,7 @@ class TestFindAllIssues < Jp::Test
     )
     stub_github(
       'https://api.github.com/user/526302',
-      body: { login: 'yegor257', id: 526_301, type: 'User', site_admin: false }
+      body: { login: 'yegor257', id: 526_302, type: 'User', site_admin: false }
     )
     fb = Factbase.new
     fb.insert.then do |f|


### PR DESCRIPTION
Fixes #2189.

user/526302 stub returned id: 526_301, contradicting its URL and the search fixture (526302 = yegor257). One-digit fix to 526_302.