### PR TITLE
#2184: log through injected loog in archived check

### DIFF
--- a/lib/patches/unmask_repos.rb
+++ b/lib/patches/unmask_repos.rb
@@ -43,10 +43,10 @@ module Fbe
       repos.reject! do |repo|
         octo.repository(repo)[:archived]
       rescue Octokit::NotFound, Octokit::Deprecated => e
-        $loog.info("Repository #{repo} not found: #{e.message}")
+        loog.info("Repository #{repo} not found: #{e.message}")
         false
       rescue Octokit::Forbidden => e
-        $loog.warn(
+        loog.warn(
           "[#{$judge}] Access forbidden to #{repo} " \
           "(transient, will retry next cycle): #{e.class}: #{e.message}"
         )


### PR DESCRIPTION
Fixes #2184.

The archived-check rescues logged through the global \\\ while the rest of \Fbe.unmask_repos\ uses the injected \loog:\ param (default \\\). A caller passing its own logger silently lost the 404/403 probe output. Switched both lines to \loog\; \\\ in the message stays.