### PR TITLE
#2203: create factbase parent dir before realpath

### DIFF
--- a/entry.sh
+++ b/entry.sh
@@ -72,7 +72,9 @@ fi
 
 name="$(basename "${INPUT_FACTBASE}")"
 name="${name%.*}"
-fb=$(realpath "$( [[ ${INPUT_FACTBASE} = /* ]] && echo "${INPUT_FACTBASE}" || echo "${GITHUB_WORKSPACE}/${INPUT_FACTBASE}" )")
+fb_path="$( [[ ${INPUT_FACTBASE} = /* ]] && echo "${INPUT_FACTBASE}" || echo "${GITHUB_WORKSPACE}/${INPUT_FACTBASE}" )"
+mkdir -p "$(dirname "${fb_path}")"
+fb=$(realpath "${fb_path}")
 if [[ ! "${name}" =~ ^[a-z][a-z0-9-]{1,23}$ ]]; then
     echo "The base name (\"${name}\") of the factbase file doesn't match the expected pattern."
     echo "The file name is: \"${INPUT_FACTBASE}\""


### PR DESCRIPTION
Fixes #2203.

GNU \ealpath\ requires every directory above the last path component to exist, so \actbase: data/foo.fb\ with no \data/\ in the checkout aborted the action under \set -e\ before \pull/update\. \mkdir -p\ the parent dir before the \ealpath\ call.