### PR TITLE
#2202: create sqlite-cache parent dir before realpath

### DIFF
--- a/entry.sh
+++ b/entry.sh
@@ -212,7 +212,9 @@ fi
 
 sqlite=$(printenv "INPUT_SQLITE-CACHE" || true)
 if [ -n "${sqlite}" ]; then
-    sqlite=$(realpath "$( [[ ${sqlite} = /* ]] && echo "${sqlite}" || echo "${GITHUB_WORKSPACE}/${sqlite}" )")
+    sqlite_path="$( [[ ${sqlite} = /* ]] && echo "${sqlite}" || echo "${GITHUB_WORKSPACE}/${sqlite}" )"
+    mkdir -p "$(dirname "${sqlite_path}")"
+    sqlite=$(realpath "${sqlite_path}")
     options+=("--option=sqlite_cache=${sqlite}");
     echo "Using SQLite for HTTP caching: ${sqlite}"
     if [ "$(printenv "INPUT_DRY-RUN" || echo 'false')" != 'true' ]; then


### PR DESCRIPTION
Fixes #2202.

Same as #2203 but for \sqlite-cache\: GNU \ealpath\ needs parent dirs to exist, so \sqlite-cache: .cache/http.sqlite\ with no \.cache/\ aborted the action under \set -e\. \mkdir -p\ the parent dir before the \ealpath\ call.