### PR TITLE
#2183: drop dead refute_equal in marker test

### DIFF
--- a/test/judges/test-find-all-issues.rb
+++ b/test/judges/test-find-all-issues.rb
@@ -266,7 +266,6 @@ class TestFindAllIssues < Jp::Test
     end
     load_it('find-all-issues', fb)
     assert_equal(3, fb.size)
-    refute_equal(0, fb.query('(eq what "iterate")').each.to_a.first.min_issue_was_found)
     assert_equal(45, fb.query('(eq what "iterate")').each.to_a.first.min_issue_was_found)
   end
 


### PR DESCRIPTION
Fixes #2183.

\efute_equal(0, ...min_issue_was_found)\ cannot fail on its own: any value other than 45 fails the \ssert_equal(45, ...)\ below it, and 45 is not 0. Dropped the dead line, kept the one real assertion.