### PR TITLE
#2185: cover pull branch in find-one-pull yml

### DIFF
--- a/judges/find-missing-issues/find-one-pull.yml
+++ b/judges/find-missing-issues/find-one-pull.yml
@@ -9,13 +9,13 @@ input:
     where: github
     when: 2024-10-10T15:00:00Z
     repository: 700
-    issue: 141
+    issue: 143
   -
     what: pull-was-opened
     where: github
     when: 2024-10-11T15:00:00Z
     repository: 700
-    issue: 143
+    issue: 145
 expected:
   - /fb[count(f)=3]
-  - /fb/f[what='issue-was-opened' and repository='700' and issue='142']
+  - /fb/f[what='pull-was-opened' and repository='700' and issue='144' and branch='master']


### PR DESCRIPTION
Fixes #2185.

\ind-one-pull.yml\ seeded 141/143 so the fake returned 142 with no \pull_request\ key and the \	ype == 'pull'\ block was never reached — a duplicate of \ind-one.yml\. Seed 143/145 instead so 144 (which the fake returns with a \pull_request\ key and \head.ref\ of \master\) exercises the pull path; expect \pull-was-opened\ + \ranch='master'\.