### PR TITLE
#2182: assert no duplicate fact on second call

### DIFF
--- a/test/lib/test_issue_was_lost.rb
+++ b/test/lib/test_issue_was_lost.rb
@@ -59,6 +59,10 @@ class TestIssueWasLost < Minitest::Test
       $loog = Loog::NULL
       Jp.issue_was_lost('github', 42, 123)
       Jp.issue_was_lost('github', 42, 123)
+      lost = fb.query(
+        "(and (eq what 'issue-was-lost') (eq where 'github') (eq repository 42) (eq issue 123))"
+      ).each.to_a
+      assert_equal(1, lost.size, 'second call for the same issue must be a no-op, no duplicate fact')
     end
   end
 


### PR DESCRIPTION
Fixes #2182.

\	est_graceful_on_second_call_for_same_issue\ called \Jp.issue_was_lost\ twice and asserted nothing, so a broken uniqueness check (duplicate \issue-was-lost\ fact piling up every run) would stay green. Assert exactly one fact afterwards, in the shape \	est_inserts_fresh_fact_when_none_exists\ uses.