### PR TITLE
#2209: ignore empty bots option so fallback applies

### DIFF
--- a/entry.sh
+++ b/entry.sh
@@ -116,6 +116,9 @@ while IFS= read -r o; do
         VITALS_URL="${v}"
         continue
     fi
+    if [[ "${k}" == bots ]] && [ -z "${v}" ]; then
+        continue
+    fi
     options+=("--option=${k}=${v}");
 done <<< "${INPUT_OPTIONS}"
 if [ -z "${INPUT_REPOSITORIES}" ]; then


### PR DESCRIPTION
Fixes #2209.

An empty \ots=\ line in \options\ matched the \--option=bots=*\ prefix, so \ots_found\ went true, the \INPUT_BOTS\ fallback was skipped, and an empty option reached the judges (every bot counted as human, silently). Drop the empty \ots\ value where the array is built, so the fallback applies and no duplicate option is left behind. Scoped to \ots\ only; \github_token\ (#2096) and \sqlite_cache_min_age\ (#2098) keep their own issues.

Verified with Git Bash against the verbatim parsing loop: \ots=\ + \INPUT_BOTS=rultor,renovate[bot]\ gave \[--option=bots=]\ before and \[--option=bots=rultor,renovate[bot]]\ after; explicit \ots=foo\ still wins; absent \INPUT_BOTS\ leaves no bots option.