### PR TITLE
#2210: treat valueless option lines as true flags

### DIFF
--- a/entry.sh
+++ b/entry.sh
@@ -110,8 +110,13 @@ while IFS= read -r o; do
     if [ "${s}" = "" ]; then
         continue
     fi
-    k=$(echo "${s} "| cut -f1 -d '=')
-    v=$(echo "${s}" | cut -f2- -d '=')
+    if [[ "${s}" == *=* ]]; then
+        k="${s%%=*}"
+        v="${s#*=}"
+    else
+        k="${s}"
+        v="true"
+    fi
     if [[ "${k}" == vitals_url ]]; then
         VITALS_URL="${v}"
         continue


### PR DESCRIPTION
Fixes #2210. A line without equals in options (a boolean flag) was split with cut, producing --option=verbose =verbose (VERBOSE as verbose string) instead of the documented VERBOSE as true. Split with parameter expansion and default valueless lines to true. k=v lines (incl. values containing equals) behave exactly as before. Verified with Git Bash against the verbatim loop: verbose gives --option=verbose=true; foo42=bar, x88=hello world, k=a=b unchanged.