### PR TITLE
#2208: require fbe line that has Fbe-Error

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ source 'https://rubygems.org'
 gem 'baza.rb', '~>0.11'
 gem 'decoor', '~>0.1'
 gem 'factbase', '~>0.17'
-gem 'fbe', '~>0.48'
+gem 'fbe', '~>0.49'
 gem 'judges', '~>0.57'
 gem 'minitest', '~>6.0', require: false
 gem 'minitest-mock', '~>5.27', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -290,7 +290,7 @@ DEPENDENCIES
   baza.rb (~> 0.11)
   decoor (~> 0.1)
   factbase (~> 0.17)
-  fbe (~> 0.48)
+  fbe (~> 0.49)
   judges (~> 0.57)
   minitest (~> 6.0)
   minitest-mock (~> 5.27)


### PR DESCRIPTION
Fixes #2208. The Gemfile allowed fbe 0.48.0, which lacks Fbe-Error, so any rescue of it dies with NameError instead of handling the error. Pinned to the 0.49 line (the issue suggested 0.48.7 or 0.49; 0.49 keeps the lockfile at 0.49.1 valid, so frozen Docker builds need no lock churn, and no other gem constrains fbe). CI make will prove the frozen build stays green.