### PR TITLE
#2153: tell missing sqlite file apart from unset option

### DIFF
--- a/entry.sh
+++ b/entry.sh
@@ -279,15 +279,17 @@ ${JUDGES} "${gopts[@]}" --hello update \
     "${ALL_JUDGES}" \
     "${fb}"
 
-if [ -e "${sqlite}" ] && [ "$(printenv "INPUT_DRY-RUN" || echo 'false')" != 'true' ]; then
+if [ -z "${sqlite}" ]; then
+    echo "SQLite is not used for HTTP caching because the sqlite-cache option is not set"
+elif [ ! -e "${sqlite}" ]; then
+    echo "SQLite cache file not found, skipping upload: ${sqlite}"
+elif [ "$(printenv "INPUT_DRY-RUN" || echo 'false')" != 'true' ]; then
     ${JUDGES} "${gopts[@]}" upload \
         "--token=${INPUT_TOKEN}" \
         "--owner=${owner}" \
         "${name}" "${sqlite}"
-elif [ -e "${sqlite}" ]; then
-    echo "We are in 'dry' mode; skipping SQLite upload"
 else
-    echo "SQLite is not used for HTTP caching because the sqlite-cache option is not set"
+    echo "We are in 'dry' mode; skipping SQLite upload"
 fi
 
 if [ "${SKIP_VERSION_CHECKING}" != 'true' ]; then


### PR DESCRIPTION
Fixes #2153. The upload block keyed all three branches off file existence, so a set-but-missing cache file printed option is not set (the unset case already has its own message at line 230). Restructured: empty sqlite prints not-set, set-but-missing prints its own skipping-upload message, existing file keeps upload and dry-run branches byte-identical. Verified all four states in Git Bash against the verbatim block.