### PR TITLE
#2154: stop enabling xtrace for test callers

### DIFF
--- a/makes/setup-test-env.sh
+++ b/makes/setup-test-env.sh
@@ -6,7 +6,7 @@
 # Usage (preferred): setup_test_env "$1" dest
 # Backward-compat: still echoes the name to stdout
 setup_test_env() {
-  set -ex -o pipefail
+  set -e -o pipefail
 
   local SELF=$1
   local dest=$2


### PR DESCRIPTION
Fixes #2154. set inside a sourced function is process-global, so setup_test_env flipped -x on for every entries script and never restored it: doubled logs, and the trace echoed run_entry_script argument lists carrying INPUT_TOKEN and INPUT_GITHUB-TOKEN values. Keep -e and pipefail for the function body, drop -x. No entries assertion depends on trace lines (masks-tokens checks only entry.sh output shapes, which are unaffected).