### PR TITLE
#2155: cd to absolute test dir in entries runner

### DIFF
--- a/makes/entries.sh
+++ b/makes/entries.sh
@@ -16,7 +16,7 @@ run_test() {
         exit 1
     fi
     mkdir -p "${base}/target/${sh}"
-    if /bin/bash -c "cd \"target/${sh}\" && exec \"${fqn}\" \"${base}\" > \"${base}/target/entries-logs/${sh}.txt\" 2>&1"; then
+    if /bin/bash -c "cd \"${base}/target/${sh}\" && exec \"${fqn}\" \"${base}\" > \"${base}/target/entries-logs/${sh}.txt\" 2>&1"; then
         echo "👍🏻 ${sh} passed"
         return 0
     else


### PR DESCRIPTION
Fixes #2155. run_test made the dir as absolute base/target/sh but cd-ed into relative target/sh, so the two agree only when the caller runs from the repo root (and a stray target dir elsewhere silently runs tests in the wrong place). cd to the same absolute dir mkdir just created; identical behavior from the root, correct from anywhere else.