### PR TITLE
#2162: spare forbidden and unreached users from staling

### DIFF
--- a/judges/eliminate-ghosts/eliminate-ghosts.rb
+++ b/judges/eliminate-ghosts/eliminate-ghosts.rb
@@ -13,10 +13,14 @@ require_relative '../../lib/nick_of'
 good = Set.new
 bad = Set.new
 forbidden = Set.new
+finished = true
 
 Fbe.fb.query('(and (absent stale) (eq where "github") (exists who))').each do |f|
   next if good.include?(f.who) || bad.include?(f.who) || forbidden.include?(f.who)
-  next if Fbe.octo.off_quota?
+  if Fbe.octo.off_quota?
+    finished = false
+    next
+  end
   elapsed($loog, level: Logger::INFO) do
     nick =
       begin
@@ -52,10 +56,12 @@ Fbe.fb.txn do |fbt|
       f.stale = 'who'
     end
   end
-  fbt.query('(and (eq where "github") (exists who) (eq stale "who") (unique who))').each do |f|
-    next if good.include?(f.who)
-    fbt.query("(and (eq who #{f.who}) (not (eq stale 'who')) (eq where 'github'))").each do |ff|
-      ff.stale = 'who'
+  if finished
+    fbt.query('(and (eq where "github") (exists who) (eq stale "who") (unique who))').each do |f|
+      next if good.include?(f.who) || forbidden.include?(f.who)
+      fbt.query("(and (eq who #{f.who}) (not (eq stale 'who')) (eq where 'github'))").each do |ff|
+        ff.stale = 'who'
+      end
     end
   end
 end

--- a/test/judges/test-eliminate-ghosts.rb
+++ b/test/judges/test-eliminate-ghosts.rb
@@ -172,6 +172,39 @@ class TestEliminateGhosts < Jp::Test
     )
   end
 
+  def test_keeps_sibling_facts_of_forbidden_user
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github(
+      'https://api.github.com/user/29139615',
+      status: 403,
+      body: { message: 'Resource not accessible by integration' }
+    )
+    fb = Factbase.new
+    fb.insert.then do |f|
+      f._id = 1
+      f.what = 'issue-was-opened'
+      f.repository = 42
+      f.issue = 44
+      f.who = 29_139_615
+      f.where = 'github'
+      f.stale = 'who'
+    end
+    fb.insert.then do |f|
+      f._id = 2
+      f.what = 'issue-was-closed'
+      f.repository = 42
+      f.issue = 44
+      f.who = 29_139_615
+      f.where = 'github'
+    end
+    load_it('eliminate-ghosts', fb)
+    assert_equal(
+      1, fb.picks(where: 'github', who: 29_139_615, stale: 'who').count,
+      'a transient 403 must not retire the other facts of the user'
+    )
+  end
+
   def test_looks_up_forbidden_user_once_per_run
     WebMock.disable_net_connect!
     rate_limit_up


### PR DESCRIPTION
Fixes #2162. The propagation block staled every remaining fact of any user not in good, including transient-403 users in forbidden and users never reached after off_quota. Now forbidden users are skipped in propagation, and propagation is skipped entirely when the scan did not finish (confirmed-bad users are still staled via the bad loop). Both changes only ever reduce staling. Added test_keeps_sibling_facts_of_forbidden_user, which fails on the old code and passes on the new.