### PR TITLE
#2206: match bots option case-insensitively

### DIFF
--- a/judges/is-human-or-robot/is-human-or-robot.rb
+++ b/judges/is-human-or-robot/is-human-or-robot.rb
@@ -37,7 +37,7 @@ Fbe.consider(
   type = json[:type]
   location = "#{f.what} at #{Fbe.issue(f) if f['issue']}"
   @bots ||= Jp.bots
-  if type == 'Bot' || @bots.include?(json[:login])
+  if type == 'Bot' || @bots.include?(json[:login].to_s.downcase)
     f.is_human = 0
     $loog.info("GitHub user ##{f.who} (@#{json[:login]}) is actually a bot, in #{location}")
   else

--- a/lib/humans.rb
+++ b/lib/humans.rb
@@ -10,7 +10,7 @@ def Jp.bots
   list = $options.bots
   return [] if list.nil? || list.empty?
   list.split(',').filter_map do |n|
-    n = n.strip
+    n = n.strip.downcase
     n unless n.empty?
   end
 end
@@ -18,6 +18,6 @@ end
 def Jp.human_comments(comments)
   bots = Jp.bots
   comments.reject do |c|
-    c.dig(:user, :type) == 'Bot' || bots.include?(c.dig(:user, :login))
+    c.dig(:user, :type) == 'Bot' || bots.include?(c.dig(:user, :login).to_s.downcase)
   end
 end

--- a/test/judges/test-is-human-or-robot.rb
+++ b/test/judges/test-is-human-or-robot.rb
@@ -60,6 +60,16 @@ class TestIsHumanOrRobot < Jp::Test
     assert(fb.one?(where: 'github', who: 18, name: 'user4', is_human: 1))
   end
 
+  def test_matches_bots_case_insensitively
+    WebMock.disable_net_connect!
+    rate_limit_up
+    stub_github('https://api.github.com/user/19', body: { login: 'rultor', id: 19, type: 'User' })
+    fb = Factbase.new
+    fb.with(where: 'github', what: 'issue-was-opened', who: 19, name: 'rultor')
+    load_it('is-human-or-robot', fb, Judges::Options.new({ 'bots' => 'Rultor' }))
+    assert(fb.one?(where: 'github', who: 19, name: 'rultor', is_human: 0))
+  end
+
   def test_forbidden_user_lookup_leaves_fact_retriable
     WebMock.disable_net_connect!
     rate_limit_up


### PR DESCRIPTION
Fixes #2206. GitHub logins are case-insensitive identities, but bots list matching was exact, so bots=Rultor never matched the rultor from the API and the bot counted as human in review rewards and the awards table. Normalize once in Jp.bots (strip.downcase) and compare downcased at both call sites (human_comments, is-human-or-robot). Added test_matches_bots_case_insensitively, which fails on the old code.