### PR TITLE
#2207: record evaluated-but-empty metrics

### DIFF
--- a/lib/incremate.rb
+++ b/lib/incremate.rb
@@ -19,8 +19,8 @@ def Jp.incremate(
   evaluated = 0
   Dir[File.join(dir, "#{prefix}_*.rb")].each do |rb|
     n = File.basename(rb).gsub(/\.rb$/, '')
-    if fact[n]
-      $loog.debug("#{n} is here: #{fact[n].first}")
+    if fact[n] || fact["#{n}_empty"]
+      $loog.debug("#{n} is here: #{fact[n]&.first}")
       next
     end
     break if Fbe.over?(epoch:, kickoff:)
@@ -45,7 +45,12 @@ def Jp.incremate(
         Array(v).each { fact.__send__("#{k}=", _1) }
       end
       if h.key?(n.to_sym) && !(avoid_duplicate && fact.all_properties.include?(n))
-        Array(h[n.to_sym]).each { fact.__send__("#{n}=", _1) }
+        values = Array(h[n.to_sym])
+        if values.empty?
+          fact.__send__("#{n}_empty=", 1)
+        else
+          values.each { fact.__send__("#{n}=", _1) }
+        end
       end
       throw(:"Collected #{n}: [#{h.map { |k, v| "#{k}: #{v}" }.join(', ')}]")
     end

--- a/test/lib/test_incremate.rb
+++ b/test/lib/test_incremate.rb
@@ -106,6 +106,37 @@ class TestIncremate < Minitest::Test
     $options = nil
   end
 
+  def test_incremate_skips_metric_with_empty_result
+    WebMock.disable_net_connect!
+    stub_request(:get, 'https://api.github.com/rate_limit').to_return(
+      body: { rate: { remaining: 1000, limit: 1000 } }.to_json,
+      headers: { 'X-RateLimit-Remaining' => '999' }
+    )
+    $global = {}
+    $local = {}
+    $loog = Loog::VERBOSE
+    $options = Judges::Options.new({ 'lifetime' => 100, 'timeout' => 100 })
+    Dir.mktmpdir do |dir|
+      File.write(File.expand_path('some_empty.rb', dir), <<~RUBY)
+        def some_empty(_f)
+          $calls += 1
+          { some_empty: [] }
+        end
+      RUBY
+      time = Time.now - 60
+      fb = Factbase.new
+      f = fb.insert
+      $calls = 0
+      3.times { Jp.incremate(f, dir, 'some', epoch: time, kickoff: time) }
+      assert_equal(1, $calls, 'a metric with an empty result must be evaluated once, then skipped')
+      $calls = nil
+    end
+    $global = nil
+    $local = nil
+    $loog = nil
+    $options = nil
+  end
+
   def test_incremate_pauses_between_evaluations
     WebMock.disable_net_connect!
     stub_request(:get, 'https://api.github.com/rate_limit').to_return(


### PR DESCRIPTION
Fixes #2207. A metric returning an empty list wrote nothing, so the already-evaluated guard never fired and the metric (often a GitHub search API call) re-ran every cycle. Now an empty result records an n_empty marker the guard understands, distinguishing computed-empty from not-computed. Added test_incremate_skips_metric_with_empty_result, which fails on the old code (3 evaluations) and passes on the new (1).